### PR TITLE
Add integration CI: build + run server and 4-player games end-to-end

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,53 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  integration:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Build server
+      run: |
+        bazel build --cxxopt=-std=c++17 --features=external_include_paths --verbose_failures //server:server
+
+    - name: Start server
+      run: |
+        mkdir -p log
+        ./bazel-bin/server/server local.config.env &
+        echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+        echo "Waiting for server on port 40405..."
+        for i in $(seq 1 20); do
+          nc -z 127.0.0.1 40405 2>/dev/null && echo "Server ready (${i}s)" && break
+          sleep 1
+          if [ "$i" = "20" ]; then
+            echo "ERROR: server did not start within 20 seconds"
+            exit 1
+          fi
+        done
+
+    - name: Run integration tests
+      run: |
+        export PYTHONPATH="$(pwd):${PYTHONPATH}"
+        python3 tests/integration_test.py local.config.env
+
+    - name: Stop server
+      if: always()
+      run: |
+        if [ -n "$SERVER_PID" ]; then
+          kill "$SERVER_PID" || true
+        fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,10 +25,14 @@ jobs:
       run: |
         bazel build --cxxopt=-std=c++17 --features=external_include_paths --verbose_failures //server:server
 
+    - name: Create CI config
+      run: |
+        printf "SERVER_PORT=40405\nSERVER_ADDR=localhost\nLOG_DIR=./log\n" > ci.config.env
+
     - name: Start server
       run: |
         mkdir -p log
-        ./bazel-bin/server/server local.config.env &
+        ./bazel-bin/server/server ci.config.env &
         echo "SERVER_PID=$!" >> "$GITHUB_ENV"
         echo "Waiting for server on port 40405..."
         for i in $(seq 1 20); do
@@ -43,7 +47,7 @@ jobs:
     - name: Run integration tests
       run: |
         export PYTHONPATH="$(pwd):${PYTHONPATH}"
-        python3 tests/integration_test.py local.config.env
+        python3 tests/integration_test.py ci.config.env
 
     - name: Stop server
       if: always()

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Integration test: exercises a complete Hearts game end-to-end against a running server.
+Usage: python3 tests/integration_test.py [env_file_path]
+       env_file_path defaults to ./local.config.env
+"""
+
+import sys
+import os
+
+# Must precede all client imports — Env.py reads sys.argv[1] at module load time
+if len(sys.argv) < 2:
+    sys.argv.append("./local.config.env")
+
+from clients.python.api.networking.ManagedConnection import ManagedConnection
+from clients.python.api.networking.SessionHelpers import RunGame, RunMultipleGames
+from clients.python.players.random_player import RandomPlayer
+from clients.python.util.Constants import GameType
+from clients.python.util.Env import SERVER_IP, SERVER_PORT
+
+FOUR_RANDOM = [RandomPlayer, RandomPlayer, RandomPlayer, RandomPlayer]
+TIMEOUT_S = 60
+
+
+def check_game(game, label):
+    assert game.winner is not None, \
+        f"{label}: game ended with no winner"
+    assert len(game.players_to_points) == 4, \
+        f"{label}: expected 4 player scores, got {len(game.players_to_points)}"
+
+    winner_pts = game.players_to_points[game.winner]
+    for player, pts in game.players_to_points.items():
+        assert isinstance(pts, int), \
+            f"{label}: {player} score should be int, got {type(pts)}"
+        assert pts >= 0, \
+            f"{label}: {player} has negative score ({pts})"
+        assert pts >= winner_pts, \
+            f"{label}: {player} ({pts}pts) has fewer points than declared winner {game.winner} ({winner_pts}pts)"
+
+    print(f"  PASS {label}: winner={game.winner}, scores={dict(game.players_to_points)}")
+
+
+def test_single_game():
+    print("Test 1: Single complete game (4 random players)")
+    with ManagedConnection(timeout_s=TIMEOUT_S) as conn:
+        game = RunGame(conn, GameType.ANY, FOUR_RANDOM, timeout_s=TIMEOUT_S)
+    check_game(game, "game")
+
+
+def test_two_concurrent_games():
+    print("Test 2: Two concurrent games (8 sessions on one connection)")
+    with ManagedConnection(timeout_s=TIMEOUT_S) as conn:
+        games = RunMultipleGames(
+            conn, GameType.ANY, FOUR_RANDOM, num_games=2, timeout_s=TIMEOUT_S
+        )
+    assert len(games) == 2, f"Expected 2 game results, got {len(games)}"
+    for i, game in enumerate(games):
+        check_game(game, f"concurrent-game-{i + 1}")
+
+
+if __name__ == "__main__":
+    print("Hearts Engine Integration Tests")
+    print("================================")
+    print(f"Server: {SERVER_IP}:{SERVER_PORT}")
+    print()
+
+    test_single_game()
+    test_two_concurrent_games()
+
+    print("\nAll integration tests PASSED")
+    sys.exit(0)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/integration.yml`: builds the server via Bazel, starts it on `localhost:40405`, waits for it to accept connections, then runs integration tests, then kills the server
- Adds `tests/integration_test.py`: two tests — a single complete game (4 random players) and two concurrent games — both asserting valid winners and scores

## Test plan
- [ ] GTests job (existing) still passes
- [ ] Integration Tests job appears and goes green
- [ ] Both test cases (`test_single_game`, `test_two_concurrent_games`) print PASS in the CI log

🤖 Generated with [Claude Code](https://claude.com/claude-code)