### PR TITLE
Add CLAUDE.md for Claude Code session context

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,53 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  integration:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Build server
+      run: |
+        bazel build --cxxopt=-std=c++17 --features=external_include_paths --verbose_failures //server:server
+
+    - name: Start server
+      run: |
+        mkdir -p log
+        ./bazel-bin/server/server local.config.env &
+        echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+        echo "Waiting for server on port 40405..."
+        for i in $(seq 1 20); do
+          nc -z 127.0.0.1 40405 2>/dev/null && echo "Server ready (${i}s)" && break
+          sleep 1
+          if [ "$i" = "20" ]; then
+            echo "ERROR: server did not start within 20 seconds"
+            exit 1
+          fi
+        done
+
+    - name: Run integration tests
+      run: |
+        export PYTHONPATH="$(pwd):${PYTHONPATH}"
+        python3 tests/integration_test.py local.config.env
+
+    - name: Stop server
+      if: always()
+      run: |
+        if [ -n "$SERVER_PID" ]; then
+          kill "$SERVER_PID" || true
+        fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A Hearts card game engine: a C++ TCP server that runs game logic, and a Python client SDK for writing AI players. The server handles matching, game state, and protocol; clients implement player strategy by subclassing `Player`.
+
+## Commands
+
+**Server (Bazel 9+):**
+```bash
+bazel run //server:server                                           # run server (reads config.env)
+bazel test --cxxopt=-std=c++17 --features=external_include_paths //tests:all  # run all C++ tests
+```
+
+**Python clients:**
+```bash
+export PYTHONPATH=$PYTHONPATH:$(pwd)
+python3 clients/python/players/random_player.py                    # run a player against the live server
+```
+
+**Config:** Copy `config.env` (or `local.config.env`) and set `SERVER_PORT`, `SERVER_ADDR`, `LOG_DIR`.
+
+## Architecture
+
+```
+C++ Server (server/)
+  Broker (boost::asio TCP) → ManagedConnection (protocol) → Matcher/Lobby → LiveGame
+  LiveGame runs: Game → Round → Trick → Player (server-side slot, not AI)
+
+Python Client SDK (clients/python/api/)
+  ManagedConnection (context manager) → Messenger → PlayerGameSession
+  ActiveGame / ActiveRound / ActiveTrick — receive protocol messages, maintain state
+  Player (abstract base) — override hooks to implement strategy
+```
+
+The server and client communicate over JSON messages with `type`, `session_id`, `seq_num`. Full protocol spec is in `clients/README.md`.
+
+## Game Flow
+
+```
+connect → request session (player_tag, game_type, lobby_code)
+  → matched into 4-player LiveGame
+  → 13 rounds:
+      deal → pass 3 cards (except KEEPER rounds) → 13 tricks:
+          4 moves per trick (follow suit if able, highest trick-suit card wins)
+      → score round
+  → end game (lowest score wins; 26 pts = shoot the moon → others +26)
+```
+
+**Points:** Each heart = 1 pt, Queen of Spades = 13 pts.
+
+## Adding a New Player
+
+1. Create `clients/python/players/my_player.py`, subclass `Player`
+2. Set a unique `player_tag` class variable
+3. Implement the two required methods:
+   - `get_cards_to_pass(pass_dir, receiving_player) → List[Card]` — choose 3 cards to pass
+   - `get_move(trick, legal_moves) → Card` — choose a card to play
+4. Override optional hooks for state tracking:
+   - `handle_new_round(round)` — `round.cards_in_hand` is a live reference, stays current
+   - `receive_passed_cards(cards, from_player, to_player)`
+   - `handle_move(player, card)` — observe all 4 players' moves including your own
+   - `handle_finished_trick(trick, winner)`
+5. Add a `__main__` block using `RunMultipleGames` to test win rate vs. `RandomPlayer`
+
+See `clients/python/players/rob_player.py` for a full strategic example and `clients/python/players/claude_player.py` for a danger-scoring approach.
+
+## Key Types
+
+- **Card:** two-char string, rank + suit — e.g. `"QS"`, `"2C"`, `"TH"` (T = 10)
+- **PlayerTagSession:** `(player_tag, session_id)` tuple identifying a player in a specific game
+- **PassDirection:** `LEFT`, `RIGHT`, `ACROSS`, `KEEPER` (no pass)
+- **GameType:** `ANY` (FIFO matching) or lobby-code-based grouping
+
+## Non-Obvious Behaviors
+
+- `round.cards_in_hand` is mutated in place by the framework — don't copy it at round start expecting it to stay static.
+- One `ManagedConnection` can run 64+ concurrent sessions (useful for batch testing with lobby codes).
+- `SessionHelpers` (`MakeSession`, `RunGame`, `RunMultipleGames`) handle threading and synchronization for concurrent sessions.
+- `DebuggerPlayer` wraps any player with a CLI that pauses at each decision — useful for tracing strategy bugs.
+- Matching is currently FIFO with optional lobby codes; no skill-based pairing.

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Integration test: exercises a complete Hearts game end-to-end against a running server.
+Usage: python3 tests/integration_test.py [env_file_path]
+       env_file_path defaults to ./local.config.env
+"""
+
+import sys
+import os
+
+# Must precede all client imports — Env.py reads sys.argv[1] at module load time
+if len(sys.argv) < 2:
+    sys.argv.append("./local.config.env")
+
+from clients.python.api.networking.ManagedConnection import ManagedConnection
+from clients.python.api.networking.SessionHelpers import RunGame, RunMultipleGames
+from clients.python.players.random_player import RandomPlayer
+from clients.python.util.Constants import GameType
+from clients.python.util.Env import SERVER_IP, SERVER_PORT
+
+FOUR_RANDOM = [RandomPlayer, RandomPlayer, RandomPlayer, RandomPlayer]
+TIMEOUT_S = 60
+
+
+def check_game(game, label):
+    assert game.winner is not None, \
+        f"{label}: game ended with no winner"
+    assert len(game.players_to_points) == 4, \
+        f"{label}: expected 4 player scores, got {len(game.players_to_points)}"
+
+    winner_pts = game.players_to_points[game.winner]
+    for player, pts in game.players_to_points.items():
+        assert isinstance(pts, int), \
+            f"{label}: {player} score should be int, got {type(pts)}"
+        assert pts >= 0, \
+            f"{label}: {player} has negative score ({pts})"
+        assert pts >= winner_pts, \
+            f"{label}: {player} ({pts}pts) has fewer points than declared winner {game.winner} ({winner_pts}pts)"
+
+    print(f"  PASS {label}: winner={game.winner}, scores={dict(game.players_to_points)}")
+
+
+def test_single_game():
+    print("Test 1: Single complete game (4 random players)")
+    with ManagedConnection(timeout_s=TIMEOUT_S) as conn:
+        game = RunGame(conn, GameType.ANY, FOUR_RANDOM, timeout_s=TIMEOUT_S)
+    check_game(game, "game")
+
+
+def test_two_concurrent_games():
+    print("Test 2: Two concurrent games (8 sessions on one connection)")
+    with ManagedConnection(timeout_s=TIMEOUT_S) as conn:
+        games = RunMultipleGames(
+            conn, GameType.ANY, FOUR_RANDOM, num_games=2, timeout_s=TIMEOUT_S
+        )
+    assert len(games) == 2, f"Expected 2 game results, got {len(games)}"
+    for i, game in enumerate(games):
+        check_game(game, f"concurrent-game-{i + 1}")
+
+
+if __name__ == "__main__":
+    print("Hearts Engine Integration Tests")
+    print("================================")
+    print(f"Server: {SERVER_IP}:{SERVER_PORT}")
+    print()
+
+    test_single_game()
+    test_two_concurrent_games()
+
+    print("\nAll integration tests PASSED")
+    sys.exit(0)


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` so Claude Code sessions start with full project context without re-scanning the repo
- Covers architecture (C++ server + Python client SDK split), commands (Bazel + Python), game flow, and a step-by-step guide for writing new players

## Test plan

- [ ] Verify `CLAUDE.md` appears in repo root on main