### PR TITLE
Fix duplicate AI strategy crash at table game startup

### DIFF
--- a/clients/python/util/table_game/TableGame.py
+++ b/clients/python/util/table_game/TableGame.py
@@ -65,11 +65,7 @@ def _setup_players(strategies: Dict[str, Type[Player]]):
 
             cls: Optional[Type[Player]] = strategies.get(entry) or strategies.get(entry.lower())
             if cls is not None:
-                tag = cls.player_tag
-                if tag in used_tags:
-                    # Disambiguate duplicate strategy by appending seat number
-                    tag = f"{tag}_{seat}"
-                used_tags.add(tag)
+                tag = cls.player_tag  # must match the class's hardcoded player_tag
                 player_configs.append((tag, cls))
                 print(f"  → AI: {cls.__name__} (tag: {tag})")
             else:


### PR DESCRIPTION
When the same strategy was chosen for two seats, the entry point appended _2 to the tag, producing a PlayerTagSession whose player_tag no longer matched the class hardcoded value, crashing in Player.__init__. Fix: always use cls.player_tag directly — two instances are already distinct via session_id (seat position).