### PR TITLE
Fix hands_after_passing observer ordering and add cards_passed logging

### DIFF
--- a/server/game/game_observer.h
+++ b/server/game/game_observer.h
@@ -13,6 +13,8 @@ public:
 
     virtual void onStartRound(int roundIdx, const std::string& passDir) {}
     virtual void onHandsAfterPass(const std::map<std::string, std::vector<std::string>>& hands) {}
+    // passedByPlayer: playerTagSession → 3 cards they passed (empty map on Keeper rounds)
+    virtual void onCardsPassed(const std::map<std::string, std::vector<std::string>>& passedByPlayer) {}
     virtual void onTrickComplete(const std::vector<std::string>& playerOrder, // play order
                                   const std::vector<std::string>& cards,       // play order
                                   const std::string& winner, int points) {}

--- a/server/game/round.h
+++ b/server/game/round.h
@@ -24,7 +24,7 @@ public:
     {
         dealCards();
         notifyStartRound();
-        passCards();
+        auto passedFrom = passCards();
 
         if (mObserver)
         {
@@ -35,8 +35,10 @@ public:
                 for (int i = 0; i < (int)p->getHand().size(); ++i)
                     h.push_back(p->getHand()[i].getAbbreviation());
             }
-            mObserver->onHandsAfterPass(hands);
             mObserver->onStartRound(mRoundIndex, PassDirectionToString(mPassDirection));
+            mObserver->onHandsAfterPass(hands);
+            if (!passedFrom.empty())
+                mObserver->onCardsPassed(passedFrom);
         }
 
         size_t startingPlayer = getStartingPlayer();
@@ -84,10 +86,12 @@ private:
         }
     }
 
-    void passCards()
+    // Returns map from playerTagSession → cards passed (empty on Keeper rounds).
+    std::map<std::string, std::vector<std::string>> passCards()
     {
+        std::map<std::string, std::vector<std::string>> passedFrom;
         if (mPassDirection == Keeper)
-            return;
+            return passedFrom;
 
         std::vector<CardCollection> passedCards;
         for (const auto& player: mPlayers)
@@ -104,6 +108,16 @@ private:
             mPlayers[passTo]->receiveCards(passedCards[passFrom]);
             mPlayers[passTo]->notifyReceivedCards(passedCards[passFrom], passedCards[passTo]);
         }
+
+        for (int i = 0; i < Constants::NUM_PLAYERS; i++)
+        {
+            std::vector<std::string> cardStrs;
+            for (int j = 0; j < (int)passedCards[i].size(); j++)
+                cardStrs.push_back(passedCards[i][j].getAbbreviation());
+            passedFrom[mPlayers[i]->getTagSession()] = std::move(cardStrs);
+        }
+
+        return passedFrom;
     }
 
     int playerToPassTo(int fromPlayer)

--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -365,6 +365,7 @@ struct TrickRecord {
 struct RoundRecord {
     int roundIdx;
     std::string passDir;
+    std::map<std::string, std::vector<std::string>> cardsPassed;   // playerTagSession → 3 cards passed
     std::map<std::string, std::vector<std::string>> handsAfterPass;
     std::vector<TrickRecord> tricks;
     std::map<std::string, int> roundScores;
@@ -420,6 +421,12 @@ public:
     {
         if (!result.rounds.empty())
             result.rounds.back().handsAfterPass = hands;
+    }
+
+    void onCardsPassed(const std::map<std::string, std::vector<std::string>>& passed) override
+    {
+        if (!result.rounds.empty())
+            result.rounds.back().cardsPassed = passed;
     }
 
     void onTrickComplete(const std::vector<std::string>& playerOrder,
@@ -577,6 +584,8 @@ static json gameResultToDetailJson(const GameResult& gr)
         json rj;
         rj["round_idx"]           = r.roundIdx;
         rj["pass_direction"]      = r.passDir;
+        if (!r.cardsPassed.empty())
+            rj["cards_passed"]    = remapKeys(r.cardsPassed, gr.playerTagToSlotId);
         rj["hands_after_passing"] = remapKeys(r.handsAfterPass, gr.playerTagToSlotId);
 
         json tricks = json::array();

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -52,6 +52,7 @@ export interface TrickRecord {
 export interface RoundRecord {
   round_idx: number
   pass_direction: string
+  cards_passed?: Record<string, string[]>   // player fullId → 3 cards passed (absent on Keeper rounds)
   hands_after_passing: Record<string, string[]>
   tricks: TrickRecord[]
   round_scores: Record<string, number>

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -71,6 +71,38 @@ table.data tbody tr:hover {
   color: #4a5a6a;
 }
 
+.passing-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.passing-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.passing-row__from,
+.passing-row__to {
+  min-width: 90px;
+}
+
+.passing-row__from {
+  text-align: right;
+}
+
+.passing-row__cards {
+  display: flex;
+  gap: 4px;
+}
+
+.passing-row__arrow {
+  color: #888;
+  font-size: 18px;
+}
+
 .row-actions {
   display: flex;
   gap: 8px;

--- a/web/frontend/src/lib/seating.ts
+++ b/web/frontend/src/lib/seating.ts
@@ -1,5 +1,18 @@
 import type { TrickRecord } from '../api/client'
 
+/** Given a player's seat and the pass direction, return the recipient's player id. */
+export function passRecipient(player: string, playerOrder: string[], passDir: string): string {
+  const n = playerOrder.length
+  const idx = playerOrder.indexOf(player)
+  if (idx < 0) return player
+  switch (passDir) {
+    case 'Left':   return playerOrder[(idx + 1) % n]
+    case 'Right':  return playerOrder[(idx - 1 + n) % n]
+    case 'Across': return playerOrder[(idx + 2) % n]
+    default:       return player
+  }
+}
+
 export const NUM_COLS = 7
 export const CENTER = 3
 

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -4,10 +4,11 @@ import { api } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver, displayString } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
-import { columnSeats, NUM_COLS, CENTER } from '../lib/seating'
+import { columnSeats, NUM_COLS, CENTER, passRecipient } from '../lib/seating'
 import { handBeforePlay } from '../lib/reconstruct'
 import { TrickRow } from '../components/TrickRow'
 import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
+import { Card } from '../components/Card'
 
 export function RoundDetail() {
   const { id = '', gameId = '', roundIdx = '0' } = useParams()
@@ -45,6 +46,32 @@ export function RoundDetail() {
       <h1>
         Round {Number(roundIdx) + 1} <span className="muted" style={{ fontSize: 15 }}>· pass {round.pass_direction}</span>
       </h1>
+
+      {round.cards_passed && (
+        <div className="card-surface passing-section">
+          <h3 style={{ margin: '0 0 8px' }}>Cards passed ({round.pass_direction})</h3>
+          <div className="passing-rows">
+            {data.player_order.map((p) => {
+              const cards = round.cards_passed![p] ?? []
+              const recipient = passRecipient(p, data.player_order, round.pass_direction)
+              return (
+                <div key={p} className="passing-row">
+                  <div className="passing-row__from">
+                    <PlayerName d={nameOf(p)} />
+                  </div>
+                  <div className="passing-row__cards">
+                    {cards.map((c) => <Card key={c} code={c} size="sm" />)}
+                  </div>
+                  <div className="passing-row__arrow">→</div>
+                  <div className="passing-row__to">
+                    <PlayerName d={nameOf(recipient)} />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
 
       <div className="row-actions">
         <label className="muted" style={{ fontSize: 13 }}>


### PR DESCRIPTION
## Summary
- **Fixes a data-integrity bug:** `onHandsAfterPass` was called before `onStartRound` in `round.h`, causing each round's post-pass hands to be written into the previous round's record and the last round to always have empty `hands_after_passing`. Fixed by calling `onStartRound` first so the record exists when hands are written.
- **Adds passed-cards logging (Phase 2):** `passCards()` now captures the 3 cards each player passed and returns them as `map<playerTagSession, vector<card>>`. A new `GameObserver::onCardsPassed` hook delivers this to the recording observer, which stores it in `RoundRecord::cardsPassed` and serializes it as `cards_passed` in the game detail JSON (present on all non-Keeper rounds going forward; absent from old result files).
- **Frontend passing visualization:** the Round Detail page now shows a "Cards passed" section above the trick rows when `cards_passed` is present, rendering the 3 small cards each player passed with an arrow to the recipient. Recipient is computed from pass direction + seating order via a new `passRecipient` helper.

## Notes
- Old result files are unaffected and will continue to work; the `cards_passed` field is optional (`?`) in the TypeScript type.
- The existing hand-before-card overlay in `reconstruct.ts` was already updated to derive hands purely from played tricks (not from `hands_after_passing`), so it is unaffected by the data bug and will continue to work on all files.
- No changes to the game protocol, Python SDK, or non-tournament code paths.

## Test plan
- [ ] `bazel build //server:tournament_server` — compiles cleanly.
- [ ] `bazel test //tests:all` — all pass.
- [ ] Run a tournament; verify new game files have `cards_passed` on non-Keeper rounds and that the 3 cards per player match what the players actually passed (cross-check by confirming `hands_after_passing` now equals the union of `hands_before_pass + received - passed`, i.e. `cards_passed` + `hands_after_passing` together reconstruct the deal).
- [ ] Visit a round detail page for a new game; confirm the "Cards passed" section appears with correct cards and recipients.
- [ ] Verify the section is absent on Keeper rounds and on old game files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
