### PR TITLE
Add team/admin login to gate private passed-cards

### DIFF
--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -1,0 +1,144 @@
+"""Lightweight team / admin authentication for the web UI.
+
+Public data (tournament results, scores, post-pass hands) stays open. The only
+private field is each round's ``cards_passed`` (what each player passed, which
+encodes their pre-pass hand and received cards). Visibility:
+  * admin  -> sees every player's passed cards;
+  * a team -> sees only its own players' passed cards, in any game;
+  * anyone -> sees none.
+
+Credentials live in ``tournament_server.env`` (never committed):
+  * ``WEB_ADMIN_PASSWORD`` -> the admin password (admin login uses no team name);
+  * ``TEAMS=name:password,...`` -> per-team passwords (same file the server uses).
+
+Tokens are stdlib-only HMAC-signed blobs (no extra dependency).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from typing import Optional
+
+import results
+
+TOKEN_TTL_SECONDS = 12 * 60 * 60
+
+# Per-process fallback so tokens are unforgeable even when no secret is configured
+# (they simply won't survive a restart, which is fine for this app).
+_PROCESS_SECRET = secrets.token_hex(32)
+
+
+def _server_env() -> dict[str, str]:
+    return results._parse_env_file(results.repo_root() / "tournament_server.env")
+
+
+def _signing_secret() -> bytes:
+    env = _server_env()
+    secret = (
+        os.environ.get("WEB_TOKEN_SECRET")
+        or env.get("WEB_TOKEN_SECRET")
+        or os.environ.get("WEB_ADMIN_PASSWORD")
+        or env.get("WEB_ADMIN_PASSWORD")
+        or _PROCESS_SECRET
+    )
+    return secret.encode()
+
+
+def _admin_password() -> Optional[str]:
+    pw = os.environ.get("WEB_ADMIN_PASSWORD") or _server_env().get("WEB_ADMIN_PASSWORD")
+    return pw or None
+
+
+def _team_passwords() -> dict[str, str]:
+    """name -> password parsed from TEAMS (entries without a password are skipped)."""
+    teams: dict[str, str] = {}
+    for part in _server_env().get("TEAMS", "").split(","):
+        part = part.strip()
+        if not part or ":" not in part:
+            continue
+        name, _, pw = part.partition(":")
+        name, pw = name.strip(), pw.strip()
+        if name and pw:
+            teams[name] = pw
+    return teams
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _b64u_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def make_token(team: Optional[str], is_admin: bool) -> str:
+    payload = {"team": team, "is_admin": is_admin, "exp": int(time.time()) + TOKEN_TTL_SECONDS}
+    body = _b64u(json.dumps(payload, separators=(",", ":")).encode())
+    sig = _b64u(hmac.new(_signing_secret(), body.encode(), hashlib.sha256).digest())
+    return f"{body}.{sig}"
+
+
+def verify_token(token: Optional[str]) -> Optional[dict]:
+    """Return the validated payload, or None if missing/tampered/expired."""
+    if not token or "." not in token:
+        return None
+    body, _, sig = token.partition(".")
+    expected = _b64u(hmac.new(_signing_secret(), body.encode(), hashlib.sha256).digest())
+    if not hmac.compare_digest(sig, expected):
+        return None
+    try:
+        payload = json.loads(_b64u_decode(body))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("exp", 0) < int(time.time()):
+        return None
+    return payload
+
+
+def authenticate(team: Optional[str], password: str) -> Optional[str]:
+    """Validate credentials; return a signed token, or None on failure."""
+    admin_pw = _admin_password()
+    if admin_pw and not team and hmac.compare_digest(password, admin_pw):
+        return make_token(team=None, is_admin=True)
+    if team:
+        expected = _team_passwords().get(team)
+        if expected and hmac.compare_digest(password, expected):
+            return make_token(team=team, is_admin=False)
+    return None
+
+
+def principal_from_header(authorization: Optional[str]) -> Optional[dict]:
+    """Parse a ``Bearer <token>`` header into a validated principal payload."""
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer":
+        return None
+    return verify_token(token.strip())
+
+
+def can_see_passed_cards(principal: Optional[dict], player_id: str) -> bool:
+    """A player's passed cards are visible to admins, and to that player's own team."""
+    if not principal:
+        return False
+    if principal.get("is_admin"):
+        return True
+    team = principal.get("team")
+    return bool(team) and player_id.startswith(f"{team}/")
+
+
+def redact_game(detail: dict, principal: Optional[dict]) -> dict:
+    """Strip ``cards_passed`` entries the principal may not see (in place)."""
+    for rnd in detail.get("rounds", []):
+        passed = rnd.get("cards_passed")
+        if not isinstance(passed, dict):
+            continue
+        rnd["cards_passed"] = {
+            pid: cards for pid, cards in passed.items() if can_see_passed_cards(principal, pid)
+        } or None
+    return detail

--- a/web/backend/auth.py
+++ b/web/backend/auth.py
@@ -122,23 +122,52 @@ def principal_from_header(authorization: Optional[str]) -> Optional[dict]:
     return verify_token(token.strip())
 
 
-def can_see_passed_cards(principal: Optional[dict], player_id: str) -> bool:
-    """A player's passed cards are visible to admins, and to that player's own team."""
-    if not principal:
-        return False
-    if principal.get("is_admin"):
-        return True
-    team = principal.get("team")
-    return bool(team) and player_id.startswith(f"{team}/")
+def _recipient_index(idx: int, n: int, pass_dir: str) -> Optional[int]:
+    """Seat that the player at ``idx`` passes to, or None for Keeper/unknown."""
+    if pass_dir == "Left":
+        return (idx + 1) % n
+    if pass_dir == "Right":
+        return (idx - 1) % n
+    if pass_dir == "Across":
+        return (idx + 2) % n
+    return None
 
 
 def redact_game(detail: dict, principal: Optional[dict]) -> dict:
-    """Strip ``cards_passed`` entries the principal may not see (in place)."""
+    """Strip ``cards_passed`` entries the principal may not see (in place).
+
+    A passing transaction (the passer's 3 cards) is private to both the passer
+    and the recipient — the recipient legitimately knows what they received. So
+    a team sees entries where it owns the passer OR the recipient; an admin sees
+    all; everyone else sees none.
+    """
+    if principal and principal.get("is_admin"):
+        return detail
+
+    team = principal.get("team") if principal else None
+    player_order = detail.get("player_order", []) or []
+    n = len(player_order)
+
     for rnd in detail.get("rounds", []):
         passed = rnd.get("cards_passed")
         if not isinstance(passed, dict):
             continue
-        rnd["cards_passed"] = {
-            pid: cards for pid, cards in passed.items() if can_see_passed_cards(principal, pid)
-        } or None
+        if not team:
+            rnd["cards_passed"] = None
+            continue
+
+        prefix = f"{team}/"
+        pass_dir = rnd.get("pass_direction", "")
+        visible: dict[str, list] = {}
+        for pid, cards in passed.items():
+            # Viewer owns the passer.
+            if pid.startswith(prefix):
+                visible[pid] = cards
+                continue
+            # Viewer owns the recipient -> these are cards the viewer received.
+            if pid in player_order:
+                ri = _recipient_index(player_order.index(pid), n, pass_dir)
+                if ri is not None and player_order[ri].startswith(prefix):
+                    visible[pid] = cards
+        rnd["cards_passed"] = visible or None
     return detail

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+from typing import Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
+import auth
 import results
 
 app = FastAPI(title="Hearts Web UI")
@@ -13,9 +16,23 @@ app = FastAPI(title="Hearts Web UI")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
-    allow_methods=["GET"],
+    allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
+
+
+class LoginRequest(BaseModel):
+    team: Optional[str] = None
+    password: str
+
+
+@app.post("/api/login")
+def login(req: LoginRequest):
+    token = auth.authenticate(req.team, req.password)
+    if token is None:
+        raise HTTPException(status_code=401, detail="invalid credentials")
+    principal = auth.verify_token(token) or {}
+    return {"token": token, "team": principal.get("team"), "is_admin": principal.get("is_admin", False)}
 
 
 @app.get("/api/tournaments")
@@ -32,11 +49,11 @@ def tournament(tournament_id: str):
 
 
 @app.get("/api/tournaments/{tournament_id}/games/{game_id}")
-def game(tournament_id: str, game_id: str):
+def game(tournament_id: str, game_id: str, authorization: Optional[str] = Header(default=None)):
     detail = results.get_game(tournament_id, game_id)
     if detail is None:
         raise HTTPException(status_code=404, detail="game not found")
-    return detail
+    return auth.redact_game(detail, auth.principal_from_header(authorization))
 
 
 @app.get("/api/live")

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet } from 'react-router-dom'
+import { AuthControl } from './components/AuthControl'
 import './App.css'
 
 export function App() {
@@ -12,6 +13,7 @@ export function App() {
           <Link to="/">Tournaments</Link>
           <Link to="/live">Live</Link>
         </nav>
+        <AuthControl />
       </header>
       <main className="app-main">
         <Outlet />

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -1,3 +1,5 @@
+import { authToken } from '../lib/auth'
+
 export interface TournamentListEntry {
   tournament_id: string
   began_at: string | null
@@ -78,9 +80,17 @@ export interface LiveStats {
 }
 
 async function getJSON<T>(url: string): Promise<T> {
-  const res = await fetch(url)
+  const token = authToken()
+  const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {}
+  const res = await fetch(url, { headers })
   if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${url}`)
   return res.json() as Promise<T>
+}
+
+export interface LoginResult {
+  token: string
+  team: string | null
+  is_admin: boolean
 }
 
 export const api = {
@@ -89,4 +99,14 @@ export const api = {
   game: (id: string, gameId: string) =>
     getJSON<GameDetail>(`/api/tournaments/${encodeURIComponent(id)}/games/${encodeURIComponent(gameId)}`),
   live: () => getJSON<LiveStats>('/api/live'),
+  login: async (team: string | null, password: string): Promise<LoginResult> => {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ team: team || null, password }),
+    })
+    if (res.status === 401) throw new Error('Invalid credentials')
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return res.json() as Promise<LoginResult>
+  },
 }

--- a/web/frontend/src/components/AuthControl.css
+++ b/web/frontend/src/components/AuthControl.css
@@ -1,0 +1,71 @@
+.auth-control {
+  position: relative;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.auth-who {
+  color: #cdd7e2;
+  font-size: 13px;
+}
+
+.auth-btn {
+  background: #34465a;
+  color: #fff;
+  border: 1px solid #4a5d72;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.auth-btn:hover {
+  background: #415673;
+}
+
+.auth-btn--primary {
+  background: #2f6f4f;
+  border-color: #3a8a62;
+}
+
+.auth-btn--primary:hover {
+  background: #38855f;
+}
+
+.auth-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 260px;
+  background: #fff;
+  color: #1f2d3d;
+  border: 1px solid #d4dce4;
+  border-radius: 8px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.auth-hint {
+  margin: 0 0 2px;
+  font-size: 12px;
+  color: #5b6b73;
+  line-height: 1.4;
+}
+
+.auth-input {
+  padding: 7px 9px;
+  border: 1px solid #c6ced6;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.auth-error {
+  margin: 0;
+  color: #b3261e;
+  font-size: 12px;
+}

--- a/web/frontend/src/components/AuthControl.tsx
+++ b/web/frontend/src/components/AuthControl.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { api } from '../api/client'
+import { useAuth, setAuth, logout } from '../lib/auth'
+import './AuthControl.css'
+
+export function AuthControl() {
+  const auth = useAuth()
+  const [open, setOpen] = useState(false)
+  const [team, setTeam] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  if (auth.token) {
+    const who = auth.isAdmin ? 'admin' : auth.team
+    return (
+      <div className="auth-control">
+        <span className="auth-who">
+          {auth.isAdmin ? '★ ' : ''}
+          {who}
+        </span>
+        <button className="auth-btn" onClick={() => logout()}>
+          Sign out
+        </button>
+      </div>
+    )
+  }
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await api.login(team.trim() || null, password)
+      setAuth({ token: res.token, team: res.team, isAdmin: res.is_admin })
+      setOpen(false)
+      setTeam('')
+      setPassword('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="auth-control">
+      <button className="auth-btn" onClick={() => setOpen((o) => !o)}>
+        Sign in
+      </button>
+      {open && (
+        <form className="auth-popover" onSubmit={submit}>
+          <p className="auth-hint">
+            Team: enter your team name + password. Admin: leave team blank, enter the admin password.
+          </p>
+          <input
+            className="auth-input"
+            placeholder="Team (blank for admin)"
+            value={team}
+            onChange={(e) => setTeam(e.target.value)}
+            autoComplete="off"
+          />
+          <input
+            className="auth-input"
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+          />
+          {error && <p className="auth-error">{error}</p>}
+          <button className="auth-btn auth-btn--primary" type="submit" disabled={busy || !password}>
+            {busy ? '…' : 'Sign in'}
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/web/frontend/src/components/Card.tsx
+++ b/web/frontend/src/components/Card.tsx
@@ -6,9 +6,10 @@ interface CardProps {
   highlight?: boolean // winning card
   onClick?: () => void
   size?: 'sm' | 'md'
+  title?: string // tooltip override for clickable cards
 }
 
-export function Card({ code, highlight, onClick, size = 'md' }: CardProps) {
+export function Card({ code, highlight, onClick, size = 'md', title }: CardProps) {
   const { rank, suit } = parseCard(code)
   const red = isRedSuit(suit)
   const pts = cardPoints(code)
@@ -23,7 +24,11 @@ export function Card({ code, highlight, onClick, size = 'md' }: CardProps) {
     .join(' ')
 
   return (
-    <div className={className} onClick={onClick} title={onClick ? 'Click to see hand before this play' : undefined}>
+    <div
+      className={className}
+      onClick={onClick}
+      title={title ?? (onClick ? 'Click to see hand before this play' : undefined)}
+    >
       <span className="card__corner card__corner--tl">
         <span className="card__rank">{rankLabel(rank)}</span>
         <span className="card__suit">{SUIT_SYMBOL[suit]}</span>

--- a/web/frontend/src/components/HandOverlay.tsx
+++ b/web/frontend/src/components/HandOverlay.tsx
@@ -5,9 +5,10 @@ import './HandOverlay.css'
 
 export interface HandOverlayData {
   player: string
-  trickIndex: number
+  subtitle: string // e.g. "hand before trick #3" or "hand before passing"
   hand: string[]
-  playedCard: string
+  highlight: string[] // cards to ring
+  footer: string
 }
 
 interface HandOverlayProps {
@@ -17,12 +18,13 @@ interface HandOverlayProps {
 }
 
 export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
+  const highlight = new Set(data.highlight)
   return (
     <div className="overlay-backdrop" onClick={onClose}>
       <div className="overlay-panel" onClick={(e) => e.stopPropagation()}>
         <div className="overlay-header">
           <span>
-            <strong><PlayerName d={name} /></strong> · hand before trick #{data.trickIndex + 1}
+            <strong><PlayerName d={name} /></strong> · {data.subtitle}
           </span>
           <button className="overlay-close" onClick={onClose} aria-label="Close">
             ×
@@ -30,12 +32,10 @@ export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
         </div>
         <div className="overlay-hand">
           {data.hand.map((c) => (
-            <Card key={c} code={c} highlight={c === data.playedCard} />
+            <Card key={c} code={c} highlight={highlight.has(c)} />
           ))}
         </div>
-        <div className="overlay-footer">
-          Highlighted card was the one played. ({data.hand.length} card{data.hand.length === 1 ? '' : 's'} in hand)
-        </div>
+        <div className="overlay-footer">{data.footer}</div>
       </div>
     </div>
   )

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -78,15 +78,10 @@ table.data tbody tr:hover {
 }
 
 .passing-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 90px 1fr 24px 90px;
   align-items: center;
   gap: 10px;
-  flex-wrap: wrap;
-}
-
-.passing-row__from,
-.passing-row__to {
-  min-width: 90px;
 }
 
 .passing-row__from {
@@ -96,6 +91,8 @@ table.data tbody tr:hover {
 .passing-row__cards {
   display: flex;
   gap: 4px;
+  align-items: center;
+  min-height: 34px;
 }
 
 .passing-row__arrow {

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -71,33 +71,73 @@ table.data tbody tr:hover {
   color: #4a5a6a;
 }
 
-.passing-rows {
+.passing-section {
+  text-align: center;
+}
+
+.passing-flow {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.passing-flow--across {
   flex-direction: column;
   gap: 6px;
 }
 
-.passing-row {
-  display: grid;
-  grid-template-columns: 90px 1fr 24px 90px;
+.passing-across__cols {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+}
+
+.passing-across__col {
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 2px;
 }
 
-.passing-row__from {
-  text-align: right;
+.passing-across__player {
+  font-weight: 600;
+  font-size: 15px;
+  white-space: nowrap;
 }
 
-.passing-row__cards {
+.passing-flow__cards {
   display: flex;
   gap: 4px;
   align-items: center;
-  min-height: 34px;
+  justify-content: center;
+  min-height: 46px;
 }
 
-.passing-row__arrow {
-  color: #888;
-  font-size: 18px;
+.passing-flow__arrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.passing-flow__arrow-label {
+  font-size: 11px;
+  color: #aab2bd;
+  white-space: nowrap;
+}
+
+.passing-flow__arrow-line {
+  font-size: 22px;
+  line-height: 1;
+  color: #c2c9d2;
+}
+
+.passing-flow__player {
+  font-weight: 600;
+  font-size: 15px;
+  white-space: nowrap;
 }
 
 .row-actions {

--- a/web/frontend/src/lib/auth.ts
+++ b/web/frontend/src/lib/auth.ts
@@ -1,0 +1,64 @@
+import { useSyncExternalStore } from 'react'
+
+export interface AuthState {
+  token: string | null
+  team: string | null
+  isAdmin: boolean
+}
+
+const STORAGE_KEY = 'hearts.auth'
+const listeners = new Set<() => void>()
+
+function read(): AuthState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw) as AuthState
+  } catch {
+    // ignore malformed storage
+  }
+  return { token: null, team: null, isAdmin: false }
+}
+
+let state: AuthState = read()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+export function getAuth(): AuthState {
+  return state
+}
+
+export function authToken(): string | null {
+  return state.token
+}
+
+function set(next: AuthState) {
+  state = next
+  try {
+    if (next.token) localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    else localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // ignore storage failures
+  }
+  emit()
+}
+
+export function setAuth(next: AuthState) {
+  set(next)
+}
+
+export function logout() {
+  set({ token: null, team: null, isAdmin: false })
+}
+
+export function useAuth(): AuthState {
+  return useSyncExternalStore(
+    (cb) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+    getAuth,
+    getAuth,
+  )
+}

--- a/web/frontend/src/lib/reconstruct.ts
+++ b/web/frontend/src/lib/reconstruct.ts
@@ -42,3 +42,22 @@ export function handBeforePlay(
   const playedCard = cardPlayedBy(round.tricks[trickIndex], playerOrder, player) ?? ''
   return { hand: sortBySuitThenRank(remaining), playedCard }
 }
+
+/**
+ * Reconstruct a player's hand right before they passed, plus the cards they passed.
+ *
+ * The post-pass hand (`hands_after_passing[player]`, == the cards they play this
+ * round) is the dealt hand minus the 3 passed cards plus the 3 received cards. So
+ * the pre-pass hand = post-pass − received + passed (13 cards).
+ */
+export function handBeforePassing(
+  round: RoundRecord,
+  player: string,
+  passed: string[],
+  received: string[],
+): { hand: string[]; passed: string[] } {
+  const post = round.hands_after_passing[player] ?? []
+  const receivedSet = new Set(received)
+  const pre = post.filter((c) => !receivedSet.has(c)).concat(passed)
+  return { hand: sortBySuitThenRank(pre), passed }
+}

--- a/web/frontend/src/lib/seating.ts
+++ b/web/frontend/src/lib/seating.ts
@@ -13,6 +13,19 @@ export function passRecipient(player: string, playerOrder: string[], passDir: st
   }
 }
 
+/** The player who passes TO `player` (the source of their received cards). */
+export function passSource(player: string, playerOrder: string[], passDir: string): string {
+  const n = playerOrder.length
+  const idx = playerOrder.indexOf(player)
+  if (idx < 0) return player
+  switch (passDir) {
+    case 'Left':   return playerOrder[(idx - 1 + n) % n]
+    case 'Right':  return playerOrder[(idx + 1) % n]
+    case 'Across': return playerOrder[(idx + 2) % n]
+    default:       return player
+  }
+}
+
 export const NUM_COLS = 7
 export const CENTER = 3
 

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -9,12 +9,13 @@ import { handBeforePlay } from '../lib/reconstruct'
 import { TrickRow } from '../components/TrickRow'
 import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
 import { Card } from '../components/Card'
+import { useAuth } from '../lib/auth'
 
 export function RoundDetail() {
   const { id = '', gameId = '', roundIdx = '0' } = useParams()
-  const { data, loading, error } = useFetch(() => api.game(id, gameId), [id, gameId])
+  const auth = useAuth()
+  const { data, loading, error } = useFetch(() => api.game(id, gameId), [id, gameId, auth.token])
   const round = data?.rounds[Number(roundIdx)]
-
   const [selected, setSelected] = useState<string>('')
   const [overlay, setOverlay] = useState<HandOverlayData | null>(null)
 
@@ -47,12 +48,12 @@ export function RoundDetail() {
         Round {Number(roundIdx) + 1} <span className="muted" style={{ fontSize: 15 }}>· pass {round.pass_direction}</span>
       </h1>
 
-      {round.cards_passed && (
+      {round.pass_direction !== 'Keeper' && (
         <div className="card-surface passing-section">
           <h3 style={{ margin: '0 0 8px' }}>Cards passed ({round.pass_direction})</h3>
           <div className="passing-rows">
             {data.player_order.map((p) => {
-              const cards = round.cards_passed![p] ?? []
+              const cards = round.cards_passed?.[p] ?? []
               const recipient = passRecipient(p, data.player_order, round.pass_direction)
               return (
                 <div key={p} className="passing-row">
@@ -60,7 +61,11 @@ export function RoundDetail() {
                     <PlayerName d={nameOf(p)} />
                   </div>
                   <div className="passing-row__cards">
-                    {cards.map((c) => <Card key={c} code={c} size="sm" />)}
+                    {cards.length > 0 ? (
+                      cards.map((c) => <Card key={c} code={c} size="sm" />)
+                    ) : (
+                      <span className="muted" style={{ fontSize: 12 }}>hidden</span>
+                    )}
                   </div>
                   <div className="passing-row__arrow">→</div>
                   <div className="passing-row__to">
@@ -70,6 +75,13 @@ export function RoundDetail() {
               )
             })}
           </div>
+          {!auth.isAdmin && (
+            <p className="muted" style={{ fontSize: 12, margin: '8px 0 0' }}>
+              {auth.team
+                ? 'Only your own team’s passed cards are shown. Sign in as admin to see all.'
+                : 'Passed cards are private. Sign in as a team to see your own, or as admin to see all.'}
+            </p>
+          )}
         </div>
       )}
 

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -4,8 +4,8 @@ import { api } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver, displayString } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
-import { columnSeats, NUM_COLS, CENTER, passRecipient } from '../lib/seating'
-import { handBeforePlay } from '../lib/reconstruct'
+import { columnSeats, NUM_COLS, CENTER, passRecipient, passSource } from '../lib/seating'
+import { handBeforePlay, handBeforePassing } from '../lib/reconstruct'
 import { TrickRow } from '../components/TrickRow'
 import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
 import { Card } from '../components/Card'
@@ -34,8 +34,78 @@ export function RoundDetail() {
 
   const handleCardClick = (player: string, _card: string, trickIndex: number) => {
     const { hand, playedCard } = handBeforePlay(round, data.player_order, player, trickIndex)
-    setOverlay({ player, trickIndex, hand, playedCard })
+    setOverlay({
+      player,
+      subtitle: `hand before trick #${trickIndex + 1}`,
+      hand,
+      highlight: playedCard ? [playedCard] : [],
+      footer: `Highlighted card was the one played. (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
+    })
   }
+
+  // Passing details for the currently selected player.
+  const dir = round.pass_direction
+  const isKeeper = dir === 'Keeper'
+  const isAcross = dir === 'Across'
+  // Left passes flow leftward, Right passes flow rightward.
+  const arrowGlyph = dir === 'Right' ? '⟶' : '⟵'
+  const passed = round.cards_passed?.[selected] ?? []
+  const sourcePlayer = passSource(selected, data.player_order, dir)
+  const received = round.cards_passed?.[sourcePlayer] ?? []
+  const recipient = passRecipient(selected, data.player_order, dir)
+  const canShowPrePass = passed.length > 0 && received.length > 0
+
+  const showPrePassHand = () => {
+    const { hand, passed: highlight } = handBeforePassing(round, selected, passed, received)
+    setOverlay({
+      player: selected,
+      subtitle: 'hand before passing',
+      hand,
+      highlight,
+      footer: `Highlighted cards were passed to ${displayString(nameOf(recipient))}.`,
+    })
+  }
+
+  // Card groups reused by both the horizontal (Left/Right) and Across layouts.
+  const passedCards =
+    passed.length > 0 ? (
+      passed.map((c) => (
+        <Card
+          key={c}
+          code={c}
+          size="sm"
+          onClick={canShowPrePass ? showPrePassHand : undefined}
+          title={canShowPrePass ? 'Click to see hand before passing' : undefined}
+        />
+      ))
+    ) : (
+      <span className="muted" style={{ fontSize: 12 }}>hidden</span>
+    )
+  const receivedCards =
+    received.length > 0 ? (
+      received.map((c) => <Card key={c} code={c} size="sm" />)
+    ) : (
+      <span className="muted" style={{ fontSize: 12 }}>hidden</span>
+    )
+
+  // Horizontal (Left/Right) flow elements. Left reads passed → player → received;
+  // Right is the mirror image so passed cards / recipient sit on the right.
+  const horizontalEls = [
+    <div className="passing-flow__cards" key="passed">{passedCards}</div>,
+    <div className="passing-flow__arrow" key="to">
+      <span className="passing-flow__arrow-label">to {displayString(nameOf(recipient))}</span>
+      <span className="passing-flow__arrow-line" aria-hidden="true">{arrowGlyph}</span>
+    </div>,
+    <div className="passing-flow__player" key="player">
+      <PlayerName d={nameOf(selected)} />
+    </div>,
+    <div className="passing-flow__arrow" key="from">
+      <span className="passing-flow__arrow-label">from {displayString(nameOf(sourcePlayer))}</span>
+      <span className="passing-flow__arrow-line" aria-hidden="true">{arrowGlyph}</span>
+    </div>,
+    <div className="passing-flow__cards" key="received">{receivedCards}</div>,
+  ]
+  if (dir === 'Right') horizontalEls.reverse()
 
   return (
     <div>
@@ -47,43 +117,6 @@ export function RoundDetail() {
       <h1>
         Round {Number(roundIdx) + 1} <span className="muted" style={{ fontSize: 15 }}>· pass {round.pass_direction}</span>
       </h1>
-
-      {round.pass_direction !== 'Keeper' && (
-        <div className="card-surface passing-section">
-          <h3 style={{ margin: '0 0 8px' }}>Cards passed ({round.pass_direction})</h3>
-          <div className="passing-rows">
-            {data.player_order.map((p) => {
-              const cards = round.cards_passed?.[p] ?? []
-              const recipient = passRecipient(p, data.player_order, round.pass_direction)
-              return (
-                <div key={p} className="passing-row">
-                  <div className="passing-row__from">
-                    <PlayerName d={nameOf(p)} />
-                  </div>
-                  <div className="passing-row__cards">
-                    {cards.length > 0 ? (
-                      cards.map((c) => <Card key={c} code={c} size="sm" />)
-                    ) : (
-                      <span className="muted" style={{ fontSize: 12 }}>hidden</span>
-                    )}
-                  </div>
-                  <div className="passing-row__arrow">→</div>
-                  <div className="passing-row__to">
-                    <PlayerName d={nameOf(recipient)} />
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-          {!auth.isAdmin && (
-            <p className="muted" style={{ fontSize: 12, margin: '8px 0 0' }}>
-              {auth.team
-                ? 'Only your own team’s passed cards are shown. Sign in as admin to see all.'
-                : 'Passed cards are private. Sign in as a team to see your own, or as admin to see all.'}
-            </p>
-          )}
-        </div>
-      )}
 
       <div className="row-actions">
         <label className="muted" style={{ fontSize: 13 }}>
@@ -99,6 +132,49 @@ export function RoundDetail() {
         <span className="muted" style={{ fontSize: 12 }}>
           Click any card to see that player's hand just before the play.
         </span>
+      </div>
+
+      <div className="card-surface passing-section">
+        {isKeeper ? (
+          <p className="muted" style={{ margin: 0, fontSize: 13 }}>No passing this round (Keeper).</p>
+        ) : (
+          <>
+            {isAcross ? (
+              <div className="passing-flow passing-flow--across">
+                <div className="passing-across__player">
+                  <PlayerName d={nameOf(recipient)} />
+                </div>
+                <div className="passing-across__cols">
+                  <div className="passing-across__col">
+                    <div className="passing-flow__cards">{passedCards}</div>
+                    <span className="passing-flow__arrow-line" aria-hidden="true">↑</span>
+                  </div>
+                  <div className="passing-across__col">
+                    <div className="passing-flow__cards">{receivedCards}</div>
+                    <span className="passing-flow__arrow-line" aria-hidden="true">↓</span>
+                  </div>
+                </div>
+                <div className="passing-across__player">
+                  <PlayerName d={nameOf(selected)} />
+                </div>
+              </div>
+            ) : (
+              <div className="passing-flow">{horizontalEls}</div>
+            )}
+            {canShowPrePass && (
+              <p className="muted" style={{ fontSize: 12, margin: '12px 0 0' }}>
+                Click a passed card to see this player's hand before passing.
+              </p>
+            )}
+            {!auth.isAdmin && passed.length === 0 && received.length === 0 && (
+              <p className="muted" style={{ fontSize: 12, margin: '12px 0 0' }}>
+                {auth.team
+                  ? 'Passing is private to each player — select one of your team’s players to view theirs.'
+                  : 'Passing is private. Sign in as a team to see your own players, or as admin to see all.'}
+              </p>
+            )}
+          </>
+        )}
       </div>
 
       <div className="card-surface">

--- a/web/run_web.sh
+++ b/web/run_web.sh
@@ -11,10 +11,16 @@
 #   SKIP_BUILD=1 web/run_web.sh    # serve existing dist without rebuilding
 #
 # Env vars:
-#   HOST         bind address     (default 0.0.0.0)
-#   PORT         bind port        (default 8000)
-#   RESULTS_DIR  results location (default <repo>/results)
-#   SKIP_BUILD   set to 1 to skip the npm build step
+#   HOST               bind address     (default 0.0.0.0)
+#   PORT               bind port        (default 8000)
+#   RESULTS_DIR        results location (default <repo>/results)
+#   SKIP_BUILD         set to 1 to skip the npm build step
+#
+# Auth (optional; controls who can see each round's private "cards passed"):
+#   WEB_ADMIN_PASSWORD admin login password — sign in with a blank team to see
+#                      every team's passed cards. If unset, admin login is off.
+#   Team login uses the TEAMS=name:password entries in tournament_server.env;
+#   a signed-in team sees only its own players' passed cards.
 
 set -e
 


### PR DESCRIPTION
## Summary
Phase 2 of the web UI: team and admin login that gates the only private data in a game — each round's `cards_passed`. Everything else (results, scores, post-pass hands, pass direction) stays public.

Visibility of passed cards:
- **admin** — signs in with the `WEB_ADMIN_PASSWORD` and a blank team; sees every player's passed cards.
- **team** — signs in with its `TEAMS=name:password` entry; sees only its own players' passed cards.
- **anonymous** — sees none.

This is the minimal redaction: given that post-pass hands and the pass direction are already public, `cards_passed` is the sole field that encodes what each player passed / received / held pre-pass.

## Backend
- `POST /api/login` validates credentials against `WEB_ADMIN_PASSWORD` or the `TEAMS=name:password` entries already in `tournament_server.env`, returning a stdlib **HMAC-signed bearer token** (no new dependency).
- The game-detail endpoint strips `cards_passed` entries the caller may not see (per-entry, keyed on the `team/...` segment of the player id).

## Frontend
- Header sign-in / sign-out control with a small popover form.
- Auth store persisted to `localStorage`; the token is attached to API requests, and game data refetches on login/logout.
- Round passing section shows a per-row **"hidden"** marker for redacted entries plus a hint telling the viewer how to reveal more.

## Verification
Verified in the browser against a synthetic game with populated `cards_passed` (real result files predate the passing-cards logging):
- anonymous → all four rows "hidden" + privacy hint;
- team `filler_1` → its own player's cards shown, opponents "hidden";
- admin → all four rows revealed;
- wrong password / admin-password-in-team-field → rejected (401); tampered/expired tokens rejected.
- `npm run build` (tsc + vite) passes; no console errors.

## Test plan
- [ ] Set `WEB_ADMIN_PASSWORD` in `tournament_server.env`, run `web/run_web.sh`, open a round with passing, and confirm anon/team/admin see the documented subsets.
