### PR TITLE
Make live tournament page update in real time

### DIFF
--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -798,7 +798,11 @@ static void writeResults(
     const std::vector<GameResult>& qualifying,
     const std::vector<GameResult>& finals,
     const std::map<std::string, int>& qualTotals,
-    const std::map<std::string, int>& finalTotals)
+    const std::map<std::string, int>& finalTotals,
+    // false for incremental mid-tournament progress writes, true for the final
+    // authoritative write. Consumers (web UI, integration tests) use this to tell
+    // an in-progress tournament from a finished one.
+    bool complete = true)
 {
     namespace fs = std::filesystem;
     fs::path tDir = fs::path(resultsDir) / tournamentId;
@@ -823,6 +827,7 @@ static void writeResults(
     summary["finals"]           = fn;
     summary["qualifying_totals"] = qualTotals;
     summary["finals_totals"]    = finalTotals;
+    summary["complete"]         = complete;
 
     std::ofstream sf(tDir / "summary.json");
     sf << summary.dump(2);
@@ -1161,7 +1166,7 @@ int main(int argc, char** argv)
         auto f = completedOnly(fin);
         auto qt = tabulateQualifyingPoints(q, cfg.qualifyingPoints);
         auto ft = tabulateQualifyingPoints(f, cfg.qualifyingPoints);
-        writeResults(cfg.resultsDir, tournamentId, q, f, qt, ft);
+        writeResults(cfg.resultsDir, tournamentId, q, f, qt, ft, /*complete=*/false);
     };
 
     // ── Stage 1: Qualifying ─────────────────────────────────────────────────

--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -22,6 +22,7 @@
 #include <condition_variable>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <future>
 #include <map>
 #include <mutex>
@@ -677,7 +678,10 @@ static std::vector<GameResult> runGames(
     const std::shared_ptr<Common::GameLogger>& nullLogger,
     int autoMoveAfterTimeouts,
     std::chrono::milliseconds moveTimeout,
-    int maxConcurrentPerTeam)
+    int maxConcurrentPerTeam,
+    // Optional: invoked after each game completes with the partial results vector
+    // (incomplete entries have an empty gameId). Used to write live progress.
+    const std::function<void(const std::vector<GameResult>&)>& onProgress = {})
 {
     std::vector<GameResult> results(assignments.size());
 
@@ -711,17 +715,23 @@ static std::vector<GameResult> runGames(
     if (maxConcurrentPerTeam <= 0)
     {
         // No limit: start everything at once.
+        std::mutex resultMtx; // serializes results[] writes + onProgress reads
         std::vector<std::future<GameResult>> futures;
         futures.reserve(assignments.size());
         for (size_t i = 0; i < assignments.size(); i++)
             futures.push_back(std::async(std::launch::async, [&, i]() -> GameResult {
                 auto r = runOneGame(assignments[i], resultsDir, sessionCounter,
                                     nullLogger, autoMoveAfterTimeouts, moveTimeout);
-                completedCount++;
+                {
+                    std::lock_guard<std::mutex> g(resultMtx);
+                    results[i] = r;
+                    completedCount++;
+                    if (onProgress) onProgress(results);
+                }
                 return r;
             }));
-        for (size_t i = 0; i < futures.size(); i++)
-            results[i] = futures[i].get();
+        // Wait for all to finish; results[] is already populated under resultMtx.
+        for (auto& f : futures) f.get();
         stopProgress();
         return results;
     }
@@ -753,13 +763,15 @@ static std::vector<GameResult> runGames(
             lock.unlock();
 
             threads.emplace_back([&, i]() {
-                results[i] = runOneGame(assignments[i], resultsDir, sessionCounter,
-                                        nullLogger, autoMoveAfterTimeouts, moveTimeout);
+                auto r = runOneGame(assignments[i], resultsDir, sessionCounter,
+                                    nullLogger, autoMoveAfterTimeouts, moveTimeout);
                 {
                     std::lock_guard<std::mutex> g(mtx);
+                    results[i] = r;
                     for (auto* slot : assignments[i].players) teamCount[teamOf(slot)]--;
                     completed++;
                     completedCount++;
+                    if (onProgress) onProgress(results);
                 }
                 cv.notify_all();
             });
@@ -815,21 +827,25 @@ static void writeResults(
     std::ofstream sf(tDir / "summary.json");
     sf << summary.dump(2);
 
-    // Append to competition index
+    // Append to competition index (idempotent: this is also called incrementally
+    // while a tournament is running, so only add the entry once).
     fs::path idxPath = fs::path(resultsDir) / "competition.json";
     json idx = json::array();
     if (fs::exists(idxPath)) {
         std::ifstream f(idxPath);
         try { f >> idx; } catch(...) {}
     }
-    json entry;
-    entry["tournament_id"] = tournamentId;
-    entry["summary"]       = tournamentId + "/summary.json";
-    idx.push_back(entry);
-    std::ofstream idxOut(idxPath);
-    idxOut << idx.dump(2);
-
-    LOG("Results written to %s/%s", resultsDir.c_str(), tournamentId.c_str());
+    bool present = false;
+    for (const auto& e : idx)
+        if (e.value("tournament_id", std::string{}) == tournamentId) { present = true; break; }
+    if (!present) {
+        json entry;
+        entry["tournament_id"] = tournamentId;
+        entry["summary"]       = tournamentId + "/summary.json";
+        idx.push_back(entry);
+        std::ofstream idxOut(idxPath);
+        idxOut << idx.dump(2);
+    }
 }
 
 // ─── Running one game ─────────────────────────────────────────────────────────
@@ -1124,13 +1140,38 @@ int main(int argc, char** argv)
     std::filesystem::create_directories(cfg.resultsDir);
     auto nullLogger = std::make_shared<GameLogger>(stdout);
 
+    // Live progress: write a partial summary.json (+ completed game files, + the
+    // competition index entry) as games finish, so the web UI's live page can show
+    // standings and counts mid-tournament. Throttled so frequent completions don't
+    // rewrite the files on every single game. The final writeResults() below always
+    // produces the authoritative, complete output.
+    auto completedOnly = [](const std::vector<GameResult>& v) {
+        std::vector<GameResult> out;
+        for (const auto& g : v) if (!g.gameId.empty()) out.push_back(g);
+        return out;
+    };
+    auto lastProgressWrite = std::make_shared<std::chrono::steady_clock::time_point>();
+    auto writeProgress = [&, completedOnly, lastProgressWrite](
+                             const std::vector<GameResult>& qual,
+                             const std::vector<GameResult>& fin) {
+        auto now = std::chrono::steady_clock::now();
+        if (now - *lastProgressWrite < std::chrono::seconds(2)) return;
+        *lastProgressWrite = now;
+        auto q = completedOnly(qual);
+        auto f = completedOnly(fin);
+        auto qt = tabulateQualifyingPoints(q, cfg.qualifyingPoints);
+        auto ft = tabulateQualifyingPoints(f, cfg.qualifyingPoints);
+        writeResults(cfg.resultsDir, tournamentId, q, f, qt, ft);
+    };
+
     // ── Stage 1: Qualifying ─────────────────────────────────────────────────
 
     auto qAssignments = scheduleGames(teamRosters, cfg.qualifyingGames, "qualifying");
     auto qualifyingResults = runGames(qAssignments, cfg.resultsDir, gameSessionCounter,
         nullLogger, cfg.autoMoveAfterTimeouts,
         std::chrono::milliseconds(cfg.moveTimeoutMs),
-        cfg.maxConcurrentGamesPerTeam);
+        cfg.maxConcurrentGamesPerTeam,
+        [&](const std::vector<GameResult>& partial) { writeProgress(partial, {}); });
 
     LOG("Qualifying complete. Tabulating scores...");
 
@@ -1259,7 +1300,8 @@ int main(int argc, char** argv)
     auto finalsResults = runGames(fAssignments, cfg.resultsDir, gameSessionCounter,
         nullLogger, cfg.autoMoveAfterTimeouts,
         std::chrono::milliseconds(cfg.moveTimeoutMs),
-        cfg.maxConcurrentGamesPerTeam);
+        cfg.maxConcurrentGamesPerTeam,
+        [&](const std::vector<GameResult>& partial) { writeProgress(qualifyingResults, partial); });
 
     // ── Notify clients and write results ────────────────────────────────────
 
@@ -1288,6 +1330,7 @@ int main(int argc, char** argv)
     }
 
     writeResults(cfg.resultsDir, tournamentId, qualifyingResults, finalsResults, qualTotals, finalTotals);
+    LOG("Results written to %s/%s", cfg.resultsDir.c_str(), tournamentId.c_str());
 
     LOG("Tournament %s complete.", tournamentId.c_str());
 

--- a/tests/competition_test.py
+++ b/tests/competition_test.py
@@ -76,6 +76,11 @@ def find_result(after_time: float, timeout_s: float) -> Tuple[Optional[dict], Op
                 break
             try:
                 data = json.loads(summary_path.read_text())
+                # summary.json is now written incrementally during a tournament;
+                # only accept the final, complete write (older summaries lack the
+                # flag and are always complete).
+                if not data.get('complete', True):
+                    continue
                 qtotals = data.get('qualifying_totals', {})
                 if all(any(k.startswith(f'{t}/') for k in qtotals) for t in TEAMS):
                     return data, summary_path.parent

--- a/web/backend/results.py
+++ b/web/backend/results.py
@@ -148,7 +148,8 @@ def get_live_stats() -> dict:
     tournaments = list_tournaments()
     current = tournaments[0] if tournaments else None
 
-    executed = 0
+    qualifying_executed = 0
+    finals_executed = 0
     standings: dict[str, int] = {}
     began_at = None
     tournament_id = None
@@ -156,10 +157,12 @@ def get_live_stats() -> dict:
         tournament_id = current["tournament_id"]
         began_at = current["began_at"]
         summary = get_summary(tournament_id) or {}
-        executed = len(summary.get("qualifying", [])) + len(summary.get("finals", []))
+        qualifying_executed = len(summary.get("qualifying", []))
+        finals_executed = len(summary.get("finals", []))
         # Standings: prefer finals totals once finals start, else qualifying.
         standings = summary.get("finals_totals") or summary.get("qualifying_totals") or {}
 
+    executed = qualifying_executed + finals_executed
     planned_total = planned_qualifying + planned_finals
     waiting = max(planned_total - executed, 0)
 
@@ -170,6 +173,8 @@ def get_live_stats() -> dict:
         "num_teams": len(teams),
         "planned_qualifying_games": planned_qualifying,
         "planned_finals_games": planned_finals,
+        "qualifying_executed": qualifying_executed,
+        "finals_executed": finals_executed,
         "games_executed": executed,
         "games_waiting": waiting,
         "standings": standings,

--- a/web/backend/results.py
+++ b/web/backend/results.py
@@ -67,7 +67,8 @@ def list_tournaments() -> list[dict]:
                 "winner": _tournament_winner(summary),
                 "num_qualifying": len((summary or {}).get("qualifying", [])),
                 "num_finals": len((summary or {}).get("finals", [])),
-                "complete": summary is not None,
+                # Older summaries predate the explicit flag; treat them as complete.
+                "complete": summary is not None and summary.get("complete", True),
             }
         )
     out.sort(key=lambda t: t["began_at"] or "", reverse=True)

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -73,6 +73,8 @@ export interface LiveStats {
   num_teams: number
   planned_qualifying_games: number
   planned_finals_games: number
+  qualifying_executed: number
+  finals_executed: number
   games_executed: number
   games_waiting: number
   standings: Record<string, number>

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -71,6 +71,49 @@ table.data tbody tr:hover {
   color: #4a5a6a;
 }
 
+.progress {
+  margin: 14px 0;
+}
+
+.progress:first-child {
+  margin-top: 0;
+}
+
+.progress:last-child {
+  margin-bottom: 0;
+}
+
+.progress__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+
+.progress__label {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.progress__count {
+  font-size: 12px;
+  color: #888;
+  font-variant-numeric: tabular-nums;
+}
+
+.progress__track {
+  height: 12px;
+  background: #eef2f7;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress__fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
 .passing-section {
   text-align: center;
 }

--- a/web/frontend/src/lib/useFetch.ts
+++ b/web/frontend/src/lib/useFetch.ts
@@ -21,3 +21,29 @@ export function useFetch<T>(fn: () => Promise<T>, deps: unknown[]): FetchState<T
   }, deps)
   return state
 }
+
+/**
+ * Like useFetch but re-runs `fn` every `intervalMs`. Background refreshes keep the
+ * previous data on screen (no loading flash, and transient errors don't blank it),
+ * so it's suitable for live/polling views.
+ */
+export function usePoll<T>(fn: () => Promise<T>, intervalMs: number, deps: unknown[]): FetchState<T> {
+  const [state, setState] = useState<FetchState<T>>({ data: null, loading: true, error: null })
+  useEffect(() => {
+    let alive = true
+    const load = () => {
+      fn()
+        .then((data) => alive && setState({ data, loading: false, error: null }))
+        .catch((e) => alive && setState((prev) => ({ data: prev.data, loading: false, error: String(e) })))
+    }
+    setState({ data: null, loading: true, error: null })
+    load()
+    const timer = setInterval(load, intervalMs)
+    return () => {
+      alive = false
+      clearInterval(timer)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+  return state
+}

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom'
 import { api } from '../api/client'
-import { useFetch } from '../lib/useFetch'
+import { usePoll } from '../lib/useFetch'
 import { nameResolver } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
+
+const REFRESH_MS = 5000
 
 function elapsedSince(iso: string | null): string {
   if (!iso) return '—'
@@ -16,10 +18,12 @@ function elapsedSince(iso: string | null): string {
 }
 
 export function LiveStats() {
-  const { data, loading, error } = useFetch(() => api.live(), [])
+  const { data, loading, error } = usePoll(() => api.live(), REFRESH_MS, [])
 
-  if (loading) return <p className="muted">Loading…</p>
-  if (error) return <p className="muted">Error: {error}</p>
+  // Only show the full-page loading/error states before the first successful load;
+  // once we have data, background poll failures keep the last-known data on screen.
+  if (loading && !data) return <p className="muted">Loading…</p>
+  if (error && !data) return <p className="muted">Error: {error}</p>
   if (!data || !data.tournament_id) return <p className="muted">No tournament data available.</p>
 
   const standings = Object.entries(data.standings).sort((a, b) => b[1] - a[1])
@@ -31,6 +35,9 @@ export function LiveStats() {
       <p className="muted" style={{ marginTop: -8 }}>
         Current tournament:{' '}
         <Link to={`/t/${encodeURIComponent(data.tournament_id)}`}>{data.tournament_id}</Link>
+        <span style={{ marginLeft: 8, fontSize: 12 }}>
+          · auto-refreshing every {REFRESH_MS / 1000}s{error ? ' (reconnecting…)' : ''}
+        </span>
       </p>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 }}>

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -43,8 +43,22 @@ export function LiveStats() {
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 }}>
         <Stat label="Began" value={elapsedSince(data.began_at)} />
         <Stat label="Teams" value={String(data.num_teams)} />
-        <Stat label="Games executed" value={String(data.games_executed)} />
-        <Stat label="Games waiting" value={String(data.games_waiting)} />
+      </div>
+
+      <h2>Games progress</h2>
+      <div className="card-surface">
+        <StageProgress
+          label="Qualifying"
+          done={data.qualifying_executed}
+          total={data.planned_qualifying_games}
+          color="#2a5bd7"
+        />
+        <StageProgress
+          label="Finals"
+          done={data.finals_executed}
+          total={data.planned_finals_games}
+          color="#1c9c7c"
+        />
       </div>
 
       <h2>Teams registered</h2>
@@ -81,6 +95,35 @@ export function LiveStats() {
       <p className="muted" style={{ marginTop: 16, fontSize: 12 }}>
         {data.note}
       </p>
+    </div>
+  )
+}
+
+function StageProgress({
+  label,
+  done,
+  total,
+  color,
+}: {
+  label: string
+  done: number
+  total: number
+  color: string
+}) {
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0
+  const complete = total > 0 && done >= total
+  return (
+    <div className="progress">
+      <div className="progress__head">
+        <span className="progress__label">{label}</span>
+        <span className="progress__count">
+          {done} / {total || '—'}
+          {complete ? ' · done' : total > 0 ? ` · ${pct}%` : ''}
+        </span>
+      </div>
+      <div className="progress__track">
+        <div className="progress__fill" style={{ width: `${pct}%`, background: color }} />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Tournament server now writes `summary.json` + `competition.json` incrementally as games complete (2s-throttled), so an in-progress tournament is visible via `/api/live` instead of only after the whole run finishes.
- `runGames` takes an `onProgress` callback; both qualifying and finals stages report partial results as each game finishes. The competition-index write is now idempotent (won't duplicate the tournament entry on repeated writes).
- Frontend adds a `usePoll` hook (keeps last-known data across background refreshes — no loading flash, transient errors don't blank the page) and the Live Stats page polls `/api/live` every 5s with a reconnecting indicator.

## Test plan
- [x] `bazel build //server:tournament_server`
- [x] `npm run build` (web/frontend)
- [x] Ran a real short tournament; confirmed the in-progress tournament appears in `competition.json` with a partial `summary.json` while the server is still running, and `/api/live` counts grow live (executed up, waiting down).
- [x] Confirmed frontend polls `/api/live` every 5s and shows the "auto-refreshing every 5s" indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)