### PR TITLE
Randomize player seating per game (#39)

### DIFF
--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -327,7 +327,14 @@ static std::vector<GameAssignment> scheduleGames(
             st.available.erase(st.available.begin() + idx);
         }
 
-        game.players = chosen;
+        // Randomize seating per game: the 4 players sit in a random order at the
+        // table (and that order then persists across all rounds of the game, since
+        // runOneGame builds the seating once from game.players). We shuffle a copy
+        // so the post-game roster bookkeeping below can stay aligned with
+        // gameTeams[t]/teamRefreshed[t]/chosen[t].
+        auto seating = chosen;
+        std::shuffle(seating.begin(), seating.end(), rng);
+        game.players = seating;
         assignments.push_back(game);
 
         // Post-game: move each chosen player to the right array.


### PR DESCRIPTION
## Summary
Fixes #39 — games now start with a random seating order of their four players, persisted across all rounds of the game.

Previously `scheduleGames` filled each game's four seats in a fixed team-rotation order (`gameTeams[t] = teamNames[(g*4+t) % numTeams]`). Because the team list is shuffled only **once per stage**, the same teams ended up in the same relative seat order in every game they shared — only *which* player each team fielded was randomized, not where they sat.

This shuffles the four chosen players into a random seat order per game. The shuffle operates on a copy so the post-game roster bookkeeping (keyed by team via `gameTeams[t]`/`teamRefreshed[t]`/`chosen[t]`) stays correct. Within a game the order is fixed because `runOneGame` builds the seating once from `game.players`.

## Test plan
- [x] `bazel build //server:tournament_server`
- [ ] CI: competition + integration tests (exercise full tournament scheduling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
