### PR TITLE
Show legal moves + group suits in hand overlay (#40)

### DIFF
--- a/web/frontend/src/components/Card.css
+++ b/web/frontend/src/components/Card.css
@@ -36,6 +36,16 @@
   box-shadow: 0 0 0 2px #f5b301, 0 1px 4px rgba(0, 0, 0, 0.25);
 }
 
+.card--legal {
+  border-color: #2e9b5b;
+  box-shadow: 0 0 0 2px rgba(46, 155, 91, 0.4), 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+
+.card--illegal {
+  opacity: 0.35;
+  filter: grayscale(0.6);
+}
+
 .card--clickable {
   cursor: pointer;
   transition: transform 0.08s ease;

--- a/web/frontend/src/components/Card.tsx
+++ b/web/frontend/src/components/Card.tsx
@@ -3,13 +3,14 @@ import './Card.css'
 
 interface CardProps {
   code: string
-  highlight?: boolean // winning card
+  highlight?: boolean // winning / played card
+  legal?: boolean // when defined: true = legal play (subtle cue), false = illegal (dimmed)
   onClick?: () => void
   size?: 'sm' | 'md'
   title?: string // tooltip override for clickable cards
 }
 
-export function Card({ code, highlight, onClick, size = 'md', title }: CardProps) {
+export function Card({ code, highlight, legal, onClick, size = 'md', title }: CardProps) {
   const { rank, suit } = parseCard(code)
   const red = isRedSuit(suit)
   const pts = cardPoints(code)
@@ -18,6 +19,9 @@ export function Card({ code, highlight, onClick, size = 'md', title }: CardProps
     `card--${size}`,
     red ? 'card--red' : 'card--black',
     highlight ? 'card--win' : '',
+    // Don't add the green legal ring to the played (gold) card; let gold win.
+    legal === true && !highlight ? 'card--legal' : '',
+    legal === false ? 'card--illegal' : '',
     onClick ? 'card--clickable' : '',
   ]
     .filter(Boolean)

--- a/web/frontend/src/components/HandOverlay.css
+++ b/web/frontend/src/components/HandOverlay.css
@@ -42,7 +42,13 @@
 .overlay-hand {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
+}
+
+/* Visual break between suit groups (hand is sorted by suit then rank). */
+.overlay-hand__gap {
+  width: 14px;
 }
 
 .overlay-footer {

--- a/web/frontend/src/components/HandOverlay.tsx
+++ b/web/frontend/src/components/HandOverlay.tsx
@@ -1,6 +1,8 @@
+import { Fragment } from 'react'
 import type { PlayerDisplay } from '../lib/playerId'
 import { Card } from './Card'
 import { PlayerName } from './PlayerName'
+import { parseCard } from '../lib/cards'
 import './HandOverlay.css'
 
 export interface HandOverlayData {
@@ -8,6 +10,7 @@ export interface HandOverlayData {
   subtitle: string // e.g. "hand before trick #3" or "hand before passing"
   hand: string[]
   highlight: string[] // cards to ring
+  legal?: string[] // legally-playable cards; when set, others are dimmed
   footer: string
 }
 
@@ -19,6 +22,7 @@ interface HandOverlayProps {
 
 export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
   const highlight = new Set(data.highlight)
+  const legal = data.legal ? new Set(data.legal) : null
   return (
     <div className="overlay-backdrop" onClick={onClose}>
       <div className="overlay-panel" onClick={(e) => e.stopPropagation()}>
@@ -31,9 +35,16 @@ export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
           </button>
         </div>
         <div className="overlay-hand">
-          {data.hand.map((c) => (
-            <Card key={c} code={c} highlight={highlight.has(c)} />
-          ))}
+          {data.hand.map((c, i) => {
+            const prev = data.hand[i - 1]
+            const gap = prev && parseCard(prev).suit !== parseCard(c).suit
+            return (
+              <Fragment key={c}>
+                {gap && <span className="overlay-hand__gap" aria-hidden="true" />}
+                <Card code={c} highlight={highlight.has(c)} legal={legal ? legal.has(c) : undefined} />
+              </Fragment>
+            )
+          })}
         </div>
         <div className="overlay-footer">{data.footer}</div>
       </div>

--- a/web/frontend/src/lib/reconstruct.ts
+++ b/web/frontend/src/lib/reconstruct.ts
@@ -1,5 +1,8 @@
 import type { RoundRecord } from '../api/client'
-import { sortBySuitThenRank } from './cards'
+import { sortBySuitThenRank, parseCard, type Suit } from './cards'
+
+/** The card every round must be led with on the first trick (2 of clubs). */
+const STARTING_CARD = '2C'
 
 /** The card a given player played in a specific trick (or undefined). */
 export function cardPlayedBy(
@@ -41,6 +44,53 @@ export function handBeforePlay(
   }
   const playedCard = cardPlayedBy(round.tricks[trickIndex], playerOrder, player) ?? ''
   return { hand: sortBySuitThenRank(remaining), playedCard }
+}
+
+/** Whether any heart had been played before `trickIndex` (so hearts are "broken"). */
+export function heartsBrokenBefore(round: RoundRecord, trickIndex: number): boolean {
+  for (let t = 0; t < trickIndex; t++) {
+    for (const c of round.tricks[t].moves) {
+      if (parseCard(c).suit === 'H') return true
+    }
+  }
+  return false
+}
+
+/**
+ * Which cards in `hand` were legal to play, mirroring the engine's
+ * `Trick::legalMovesForPlayer` (server/game/trick.h):
+ *  - Following a led suit: must play that suit if holding any.
+ *  - Leading before hearts are broken: cannot lead a heart unless hearts-only.
+ *  - First trick: leader must play the 2♣; followers cannot play the Q♠.
+ * `ledSuit` is null when this player is leading the trick.
+ */
+export function legalMovesForHand(
+  hand: string[],
+  trickIndex: number,
+  ledSuit: Suit | null,
+  heartsBroken: boolean,
+): string[] {
+  let legal = [...hand]
+  const leadingPlay = ledSuit === null
+
+  if (!leadingPlay) {
+    const matching = legal.filter((c) => parseCard(c).suit === ledSuit)
+    if (matching.length > 0) legal = matching
+  }
+
+  if (leadingPlay && !heartsBroken) {
+    const nonHearts = legal.filter((c) => parseCard(c).suit !== 'H')
+    if (nonHearts.length > 0) legal = nonHearts
+  }
+
+  if (trickIndex === 0) {
+    if (leadingPlay) {
+      return hand.includes(STARTING_CARD) ? [STARTING_CARD] : legal
+    }
+    legal = legal.filter((c) => c !== 'QS')
+  }
+
+  return legal
 }
 
 /**

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -5,7 +5,8 @@ import { useFetch } from '../lib/useFetch'
 import { nameResolver, displayString } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
 import { columnSeats, NUM_COLS, CENTER, passRecipient, passSource } from '../lib/seating'
-import { handBeforePlay, handBeforePassing } from '../lib/reconstruct'
+import { handBeforePlay, handBeforePassing, legalMovesForHand, heartsBrokenBefore } from '../lib/reconstruct'
+import { parseCard } from '../lib/cards'
 import { TrickRow } from '../components/TrickRow'
 import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
 import { Card } from '../components/Card'
@@ -34,12 +35,17 @@ export function RoundDetail() {
 
   const handleCardClick = (player: string, _card: string, trickIndex: number) => {
     const { hand, playedCard } = handBeforePlay(round, data.player_order, player, trickIndex)
+    const trick = round.tricks[trickIndex]
+    const leadingPlay = player === trick.first_player
+    const ledSuit = leadingPlay ? null : parseCard(trick.moves[0]).suit
+    const legal = legalMovesForHand(hand, trickIndex, ledSuit, heartsBrokenBefore(round, trickIndex))
     setOverlay({
       player,
       subtitle: `hand before trick #${trickIndex + 1}`,
       hand,
       highlight: playedCard ? [playedCard] : [],
-      footer: `Highlighted card was the one played. (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
+      legal,
+      footer: `Highlighted card was the one played; cards outlined in green were legal plays (others faded). (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
     })
   }
 


### PR DESCRIPTION
## Summary
Fixes #40 — the "hand before a play" overlay now communicates which cards were *legal* to play and groups the hand by suit.

- **Legal-move cue:** cards that were legal to play are outlined in green; the rest are faded/greyed. The played card keeps its gold ring.
- **Suit grouping:** a small gap is inserted between suit groups (the hand is already sorted suit-then-rank) so it reads more like a real fanned hand.

The legal-move logic is a faithful port of the engine's `Trick::legalMovesForPlayer` (`server/game/trick.h`):
- following a led suit, you must play that suit if you hold any;
- when leading before hearts are broken, you can't lead a heart unless that's all you have;
- on the first trick the leader must play the 2♣ and followers can't play the Q♠.

It's computed client-side in `RoundDetail` from the trick's `first_player` / led suit and whether any heart was played in earlier tricks — no backend change.

## Test plan
- [x] `npm run build` (tsc + vite) in `web/frontend`
- [x] Verified live in browser against a real finals game:
  - leading play, hearts not broken → all non-hearts legal, hearts faded
  - following the led suit → only led-suit cards legal, all off-suit (incl. Q♠) faded
  - first-trick follower → must-follow-clubs enforced, Q♠ correctly illegal
  - suit gaps render between club/diamond/heart/spade groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
