### PR TITLE
Target a specified env file in register/client (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,22 @@ If the server isn't on localhost, pass the organiser's config file:
 ```bash
 python3 register_team.py path/to/organisers/tournament.config.env
 ```
-This saves credentials to `team.config.env` (gitignored).
+This saves credentials to `config.env` (gitignored).
+
+To register **several teams from one machine**, give each its own env file with `--env-file`:
+```bash
+python3 register_team.py --team=alpha --password=a --env-file=alpha.env
+python3 register_team.py --team=beta  --password=b --env-file=beta.env
+```
 
 **Step 2 — start your player client(s)** (leave running for the whole competition):
 ```bash
 python3 clients/python/tournament_client.py --player=my_player
 ```
-The client retries until the first tournament server opens, plays, then automatically reconnects for every subsequent tournament. Run multiple clients with different `--player` or `--score` values to fill more slots.
+The client retries until the first tournament server opens, plays, then automatically reconnects for every subsequent tournament. Run multiple clients with different `--player` or `--score` values to fill more slots. To run a team whose credentials are in a non-default file, point the client at it:
+```bash
+python3 clients/python/tournament_client.py --env-file=alpha.env --player=my_player
+```
 
 > **Note for Claude / scripted use:** poll `nc -z 127.0.0.1 40406` until it succeeds before running `register_team.py --team=<name> --password=<pw>`. Start `tournament_client.py` processes immediately after — they retry automatically once the server opens.
 

--- a/clients/python/tournament_client.py
+++ b/clients/python/tournament_client.py
@@ -2,13 +2,18 @@
 """
 tournament_client.py — connect a player to a Hearts tournament.
 
-Credentials are read from config.env (written by register_team.py):
+Credentials (team name/password) and the server address are read from an env
+file — config.env by default, written by register_team.py:
     python3 clients/python/tournament_client.py --player=my_player [--score=3]
 
-Override credentials or env file explicitly:
+Point at a different env file to run a specific team (e.g. when several teams
+were registered to separate files):
+    python3 clients/python/tournament_client.py --env-file=alpha.env --player=my_player
+    python3 clients/python/tournament_client.py alpha.env --player=my_player   # positional also works
+
+Override credentials explicitly:
     python3 clients/python/tournament_client.py \\
-        --team=alpha --password=secret --player=my_player [--score=3] \\
-        [env_file]
+        --team=alpha --password=secret --player=my_player [--score=3] [env_file]
 
 Run multiple clients with different --player or --score values to fill all
 your team's slots.  The server tracks each slot separately on the leaderboard.
@@ -36,17 +41,31 @@ def _read_env(path) -> dict:
     return result
 
 
-# Env.py reads sys.argv[1] as the env file path.  Ensure an env file is at
-# position 1 before Env.py is imported.  Prefer an explicit positional arg;
-# fall back to config.env (which holds team credentials written by register_team.py
-# and server address).
-_non_flag = [i for i, a in enumerate(sys.argv[1:], 1) if not a.startswith('--')]
-if _non_flag:
-    _idx = _non_flag[-1]
-    if _idx != 1:
-        sys.argv.insert(1, sys.argv.pop(_idx))
-else:
-    sys.argv.insert(1, './config.env')
+# Env.py reads sys.argv[1] as the env file path, so the env file must be resolved
+# and placed at position 1 *before* Env.py is imported (i.e. before argparse runs).
+# Accept it as --env-file=PATH, --env-file PATH, or a bare positional path; fall
+# back to config.env.  The chosen file holds both the server address (read by
+# Env.py) and the team credentials (read in main()).
+def _resolve_env_file() -> str:
+    for i, a in enumerate(sys.argv[1:], 1):
+        if a.startswith('--env-file='):
+            path = a.split('=', 1)[1]
+            del sys.argv[i]
+            return path
+        if a == '--env-file' and i + 1 < len(sys.argv):
+            path = sys.argv[i + 1]
+            del sys.argv[i + 1]
+            del sys.argv[i]
+            return path
+    # No flag — use the last bare positional argument if present.
+    non_flag = [i for i, a in enumerate(sys.argv[1:], 1) if not a.startswith('--')]
+    if non_flag:
+        return sys.argv.pop(non_flag[-1])
+    return './config.env'
+
+
+ENV_FILE = _resolve_env_file()
+sys.argv.insert(1, ENV_FILE)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -67,26 +86,31 @@ def discover_player(module_name: str):
 
 
 def main():
-    cfg = _read_env('config.env')
+    # ENV_FILE was resolved at import time (above) and also fed to Env.py.
+    cfg = _read_env(ENV_FILE)
 
     parser = argparse.ArgumentParser(description='Hearts tournament client')
     parser.add_argument('--team',     default=cfg.get('TEAM_NAME'),
-                        help='Team name (default: TEAM_NAME from config.env)')
+                        help=f'Team name (default: TEAM_NAME from {ENV_FILE})')
     parser.add_argument('--password', default=cfg.get('TEAM_PASSWORD'),
-                        help='Team password (default: TEAM_PASSWORD from config.env)')
+                        help=f'Team password (default: TEAM_PASSWORD from {ENV_FILE})')
     parser.add_argument('--player',   required=True,  help='Player module name (e.g. my_player)')
     parser.add_argument('--score',    type=int, default=0,
                         help='Priority score — higher-scored clients get preferred slots')
     parser.add_argument('--host',     default=None,
                         help='Override server host (default: SERVER_ADDR from env file)')
+    # --env-file is consumed before argparse (Env.py needs it at import); declared
+    # here only so it shows up in --help.
+    parser.add_argument('--env-file', dest='env_file_opt', default=None,
+                        help='Env file with credentials + server address (default: config.env)')
     parser.add_argument('env_file',   nargs='?',
-                        help='Server config env file (default: config.env)')
+                        help='Env file (positional alias for --env-file; default: config.env)')
     args = parser.parse_args()
 
     if not args.team:
-        parser.error('--team is required (or run register_team.py to populate config.env)')
+        parser.error(f'--team is required (or run register_team.py to populate {ENV_FILE})')
     if not args.password:
-        parser.error('--password is required (or run register_team.py to populate config.env)')
+        parser.error(f'--password is required (or run register_team.py to populate {ENV_FILE})')
 
     player_cls = discover_player(args.player)
     tag = f"[{args.team}/{player_cls.player_tag}]"

--- a/register_team.py
+++ b/register_team.py
@@ -10,6 +10,12 @@ Usage:
     python3 register_team.py                              # interactive; uses server from config.env
     python3 register_team.py tournament_server.env        # reads server address from organiser's file
     python3 register_team.py --team=my_team --password=secret   # non-interactive
+
+Register several teams from one machine by writing each team's credentials to
+its own env file, then point a client at the same file:
+    python3 register_team.py --team=alpha --password=a --env-file=alpha.env
+    python3 register_team.py --team=beta  --password=b --env-file=beta.env
+    python3 clients/python/tournament_client.py --env-file=alpha.env --player=my_player
 """
 
 import argparse
@@ -19,7 +25,7 @@ import socket
 import sys
 from pathlib import Path
 
-CONFIG_ENV = Path('config.env')
+DEFAULT_ENV = 'config.env'
 
 
 def _read_env(path) -> dict:
@@ -68,17 +74,25 @@ def main():
     parser.add_argument('--team',     default=None, help='Team name (non-interactive)')
     parser.add_argument('--password', default=None, help='Team password (non-interactive)')
     parser.add_argument('--host',     default=None, help='Override server host')
+    parser.add_argument('--env-file', dest='out_env', default=DEFAULT_ENV,
+                        help=f'Env file to save this team\'s credentials to '
+                             f'(default: {DEFAULT_ENV}). Use a distinct file per team '
+                             f'to register and run several teams from one machine.')
     parser.add_argument('env_file',   nargs='?',
                         help="Organiser's config file — used to read server address "
                              "(e.g. their tournament_server.env or config.env)")
     args = parser.parse_args()
 
-    # Server address: --host flag first, then organiser's file, then local config.env, then defaults.
+    target_env = Path(args.out_env)
+
+    # Server address: --host flag first, then organiser's file, then the target
+    # env file (it may already carry an address), then defaults.
     organiser_cfg = _read_env(args.env_file) if args.env_file else {}
-    local_cfg     = _read_env(CONFIG_ENV)
-    host = args.host or organiser_cfg.get('SERVER_ADDR') or local_cfg.get('SERVER_ADDR', '127.0.0.1')
+    target_cfg    = _read_env(target_env)
+    host = (args.host or organiser_cfg.get('SERVER_ADDR')
+            or target_cfg.get('SERVER_ADDR', '127.0.0.1'))
     port = int(organiser_cfg.get('TOURNAMENT_PORT') or organiser_cfg.get('SERVER_PORT')
-               or local_cfg.get('TOURNAMENT_PORT') or local_cfg.get('SERVER_PORT', 40406))
+               or target_cfg.get('TOURNAMENT_PORT') or target_cfg.get('SERVER_PORT', 40406))
 
     non_interactive = args.team is not None and args.password is not None
 
@@ -126,17 +140,20 @@ def main():
         print('Make sure competition_runner.py is running and the registration window is open.')
         sys.exit(1)
 
-    _patch_env(CONFIG_ENV, {
+    _patch_env(target_env, {
         'TEAM_NAME':     name,
         'TEAM_PASSWORD': pw,
         'SERVER_ADDR':   host,
         'TOURNAMENT_PORT': str(port),
         'SERVER_PORT':   str(port),
     })
-    print(f'Credentials saved to {CONFIG_ENV}')
+    print(f'Credentials saved to {target_env}')
     if not non_interactive:
+        # Only the default env file is auto-discovered by the client; for any
+        # other file the client must be told which one to read.
+        env_flag = '' if target_env == Path(DEFAULT_ENV) else f' --env-file={target_env}'
         print('\nTo join a tournament, run:')
-        print('  python3 clients/python/tournament_client.py --player=my_player')
+        print(f'  python3 clients/python/tournament_client.py{env_flag} --player=my_player')
         print('\nRun multiple clients with different --player or --score values')
         print("to fill all your team's slots.")
 


### PR DESCRIPTION
## Summary
Fixes #37 — makes it easy to register and run **multiple teams from one machine** by letting both the registration and client commands target a specified env file.

- `register_team.py` gains `--env-file PATH` — writes the team's credentials (and server address) to that file instead of the default `config.env`.
- `clients/python/tournament_client.py` accepts `--env-file PATH` (a positional path still works too) and reads **both** the credentials (`TEAM_NAME`/`TEAM_PASSWORD`) and the server address from it. Previously credentials were always read from `config.env` while only the server address honored the positional file.

Workflow:
```bash
python3 register_team.py --team=alpha --password=a --env-file=alpha.env
python3 register_team.py --team=beta  --password=b --env-file=beta.env
python3 clients/python/tournament_client.py --env-file=alpha.env --player=my_player
python3 clients/python/tournament_client.py --env-file=beta.env  --player=my_player
```

Backwards compatible: with no flag both default to `config.env`; explicit `--team`/`--password` still override the file; the existing positional-path form keeps working (used by `competition_test.py`).

## Test plan
- [x] `tournament_client.py --env-file=FILE` and positional `FILE` both resolve the same file (verified via `--help` showing the path, and the connect log showing the team tag + port from the file).
- [x] Explicit `--team` overrides the file's `TEAM_NAME`.
- [x] `register_team.py --env-file=beta.env` writes `TEAM_NAME`/`TEAM_PASSWORD` to that file (verified against a mock registration listener) and reads the port from the target file.
- [x] Full round-trip: register → beta.env → client reads beta.env and connects as that team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
