### PR TITLE
Apply SpaceX-inspired design language to the web UI (#34)

### DIFF
--- a/web/frontend/DESIGN.md
+++ b/web/frontend/DESIGN.md
@@ -1,0 +1,363 @@
+---
+version: alpha
+name: Spasex-design-analysis
+description: An inspired interpretation of Spasex's design language — a mission-oriented aerospace brand built on pure black canvas, full-bleed photographic and video heroes of rockets and Mars landscapes, and uppercase D-DIN display type set in tight vertical leading. UI chrome is intentionally minimal: a single ghost outlined pill button per band, all-caps eyebrow microtext, and a fixed top nav over photography. The system is unapologetically austere — black, white, and the imagery itself.
+
+colors:
+  primary: "#000000"
+  ink: "#000000"
+  on-primary: "#ffffff"
+  on-primary-mute: "#f0f0fa"
+  canvas-night: "#000000"
+  canvas-night-soft: "#0a0a0a"
+  canvas-light: "#ffffff"
+  canvas-cool: "#f0f0fa"
+  hairline-on-dark: "#3a3a3f"
+  hairline-on-light: "#e0e0e8"
+  link-on-dark: "#ffffff"
+  link-blue-fallback: "#0000ee"
+  ink-mute: "#5a5a5f"
+
+typography:
+  display-xxl:
+    fontFamily: "D-DIN-Bold, Arial Narrow, Arial, Verdana, sans-serif"
+    fontSize: 80px
+    fontWeight: 700
+    lineHeight: 0.95
+    letterSpacing: 1.6px
+  display-xl:
+    fontFamily: "D-DIN-Bold, Arial Narrow, Arial, Verdana, sans-serif"
+    fontSize: 60px
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: 1.2px
+  display-lg:
+    fontFamily: "D-DIN-Bold, Arial Narrow, Arial, Verdana, sans-serif"
+    fontSize: 48px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: 0.96px
+  body-lg:
+    fontFamily: "D-DIN, Arial, Verdana, sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.7
+    letterSpacing: 0.32px
+  body-md:
+    fontFamily: "D-DIN, Arial, Verdana, sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0.32px
+  button-cap:
+    fontFamily: "D-DIN, Arial, Verdana, sans-serif"
+    fontSize: 13.008px
+    fontWeight: 700
+    lineHeight: 0.94
+    letterSpacing: 1.17px
+  micro-cap:
+    fontFamily: "D-DIN, Arial, Verdana, sans-serif"
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 2.0
+    letterSpacing: 0.96px
+  caption:
+    fontFamily: "D-DIN, Arial, Verdana, sans-serif"
+    fontSize: 13.008px
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: 0
+
+rounded:
+  xs: 4px
+  sm: 8px
+  md: 16px
+  pill: 32px
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 18px
+  xl: 24px
+  xxl: 32px
+  huge: 48px
+
+components:
+  button-ghost-on-dark:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-cap}"
+    rounded: "{rounded.pill}"
+    padding: 18px 24px
+  button-ghost-on-light:
+    backgroundColor: "{colors.canvas-light}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-cap}"
+    rounded: "{rounded.pill}"
+    padding: 18px 24px
+  button-filled-cool:
+    backgroundColor: "{colors.canvas-cool}"
+    textColor: "{colors.ink}"
+    typography: "{typography.button-cap}"
+    rounded: "{rounded.pill}"
+    padding: 18px 24px
+  text-input:
+    backgroundColor: "{colors.canvas-light}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xs}"
+    padding: 12px 16px
+  card-photo-band:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xs}"
+    padding: 0px
+  card-shop-product:
+    backgroundColor: "{colors.canvas-light}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 16px
+  nav-bar-overlay:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.button-cap}"
+    rounded: "{rounded.xs}"
+    padding: 24px 32px
+  link-on-dark:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.link-on-dark}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xs}"
+    padding: 0px
+  link-on-light:
+    backgroundColor: "{colors.canvas-light}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.xs}"
+    padding: 0px
+  footer-dark:
+    backgroundColor: "{colors.canvas-night}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.caption}"
+    rounded: "{rounded.xs}"
+    padding: 32px 24px
+---
+
+## Overview
+
+Spasex's design language is an exercise in negation: pure black canvas, white display type set in tight vertical leading and uppercase, full-bleed photography or autoplaying rocket-launch video as the only chrome. There is no brand color beyond black-and-white; there are no decorative shapes; there are no card grids or pricing tables on the marketing pages. Every band is a single full-viewport photograph or video paired with one all-caps headline at `{typography.display-xxl}` (80px D-DIN-Bold) and one ghost-outlined pill CTA. The composition is closer to a film title card than a SaaS landing page.
+
+The brand's depth is photographic. Mars landscapes, rocket exhaust plumes, the F9 booster on a launchpad at sunset — these are the design system. Type sits over them at high opacity with no scrim, no gradient overlay; the photographs are graded so the type lands cleanly. When type does need a background, it sits on `{colors.canvas-night-soft}` (a barely-lifted near-black) with a 1px hairline in `{colors.hairline-on-dark}`.
+
+Typography splits between **D-DIN-Bold** for display tiers (uppercase, tight tracking, condensed feel) and **D-DIN** regular for body and button labels. There is no third family — even pricing on the shop site uses the same two cuts. The display sizes are unusually tight in vertical leading (0.95–1.25) and unusually loose in horizontal tracking (1.6px positive at 80px) — the brand feels engineered rather than designed.
+
+**Key Characteristics:**
+- Single canvas: pure `{colors.canvas-night}` (`#000000`) for marketing; `{colors.canvas-light}` only on the shop site.
+- Display tier in uppercase D-DIN-Bold with positive horizontal tracking (1.6px at 80px) — the brand's typographic signature.
+- Full-bleed photography or autoplaying video as the dominant decorative element; type sits directly on imagery with no scrim.
+- Single ghost-outlined pill CTA per band, at `{rounded.pill}` 32px radius — never filled, never accent-colored.
+- All-caps eyebrow microtext (`{typography.micro-cap}` and `{typography.button-cap}`) with positive 0.96–1.17px tracking — every chrome element shouts in caps.
+- Fixed top nav overlaid on photography — no opaque background, just white-on-image.
+- Tight 0.95 line-height on the 80px display — vertical compression is the engineering aesthetic.
+
+## Colors
+
+> **Source pages:** home (`/`), `/shop`, `/vehicles/starship`, `/humanspaceflight/overview`, `/mission`.
+
+### Brand & Accent
+The brand has no accent colors. Black and white do all the chromatic work; photography supplies every other hue.
+
+### Surface
+- **Canvas Night** (`{colors.canvas-night}` — `#000000`): Default marketing canvas. Pure black, no tint.
+- **Canvas Night Soft** (`{colors.canvas-night-soft}` — `#0a0a0a`): Barely-lifted near-black for content sections that need a subtle separation from the pure-black hero.
+- **Canvas Light** (`{colors.canvas-light}` — `#ffffff`): The shop site's product surface.
+- **Canvas Cool** (`{colors.canvas-cool}` — `#f0f0fa`): A pale cool-blue-white used as the secondary surface on the shop site and as the hover-canvas of certain ghost buttons.
+- **Hairline on Dark** (`{colors.hairline-on-dark}` — `#3a3a3f`): 1px borders on dark surface chrome.
+- **Hairline on Light** (`{colors.hairline-on-light}` — `#e0e0e8`): Borders on shop-site cards.
+
+### Text
+- **On Primary** (`{colors.on-primary}` — `#ffffff`): Default text on dark canvas; the dominant text color across the marketing site.
+- **On Primary Mute** (`{colors.on-primary-mute}` — `#f0f0fa`): Slightly cooled-white used for secondary text on dark surfaces — barely distinguishable from `{colors.on-primary}` but enough to suggest a hierarchy.
+- **Ink** (`{colors.ink}` — `#000000`): Default text on light surfaces (shop site).
+- **Ink Mute** (`{colors.ink-mute}` — `#5a5a5f`): Secondary text on light surfaces.
+
+### Link
+- **Link on Dark** (`{colors.link-on-dark}` — `#ffffff`): Underlined inline link on dark canvas.
+- **Link Blue Fallback** (`{colors.link-blue-fallback}` — `#0000ee`): The browser default that appears in unstyled fallback contexts — documented for completeness, not used as a brand color.
+
+## Typography
+
+### Font Family
+
+The display tier is **D-DIN-Bold** — a condensed industrial sans inspired by the German DIN 1451 standard (used on autobahn road signage and engineering blueprints). When unavailable, fall back to **Arial Narrow**, then Arial, then Verdana — the fallback chain prioritizes width compression over ornament.
+
+The UI tier is **D-DIN** (regular weight) — the same family at standard width — used for body, button labels, and captions.
+
+D-DIN is freely available from the **DIN Type Foundry** (and a free version under the same name is widely distributed). For maximum brand fidelity, use D-DIN directly; as a substitute, **Inter** at heavy weights (700+) with letter-spacing of 1.6px positive tracking approximates the rhythm. Avoid serif or humanist sans alternatives.
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| `{typography.display-xxl}` | 80px | 700 | 0.95 | 1.6px | Hero headline (uppercase) |
+| `{typography.display-xl}` | 60px | 700 | 1.2 | 1.2px | Section opener (uppercase) |
+| `{typography.display-lg}` | 48px | 700 | 1.25 | 0.96px | Sub-section heading (uppercase) |
+| `{typography.body-lg}` | 16px | 400 | 1.7 | 0.32px | Marketing body lead |
+| `{typography.body-md}` | 16px | 400 | 1.5 | 0.32px | Default UI body |
+| `{typography.button-cap}` | 13.008px | 700 | 0.94 | 1.17px | All-caps button label |
+| `{typography.micro-cap}` | 12px | 400 | 2.0 | 0.96px | All-caps eyebrow / nav item |
+| `{typography.caption}` | 13.008px | 400 | 1.5 | 0 | Helper / footer text |
+
+### Principles
+- **Uppercase across display.** Every display tier renders in uppercase. The brand never uses sentence-case display headlines.
+- **Tight vertical leading on display.** 0.95 at 80px and 1.2 at 60px — the type stacks engineer-tight.
+- **Wide horizontal tracking.** Positive 0.96–1.6px tracking on display sizes; positive 0.96–1.17px on caps eyebrows. The wide tracking is the brand's signature optical air.
+- **No mono.** Code blocks are not part of the brand's typographic system.
+
+### Note on Font Substitutes
+**D-DIN** is freely available (the original DIN-style face under that name is widely distributed). When unavailable, use **Inter** at 700 weight with `letter-spacing: 1.6px`, `text-transform: uppercase`, and `line-height: 0.95` for display sizes — this matches the rhythm. Avoid Helvetica or Arial at default weights — the brand needs the condensed industrial cut. Avoid serif fallbacks entirely.
+
+## Layout
+
+### Spacing System
+- **Base unit**: 8px (with denser sub-units 4 / 12 / 16 / 18 / 24).
+- **Tokens**: `{spacing.xxs}` 4px · `{spacing.xs}` 8px · `{spacing.sm}` 12px · `{spacing.md}` 16px · `{spacing.lg}` 18px · `{spacing.xl}` 24px · `{spacing.xxl}` 32px · `{spacing.huge}` 48px.
+- **Section padding**: full-viewport bands on marketing — no internal padding above/below; the photograph IS the section. On the shop site, sections use 48–64px vertical padding.
+
+### Grid & Container
+- Marketing pages have no container — every band is full-viewport-width, full-viewport-height (or close to it) with photography filling the entire frame.
+- Shop product grid: 4-up at desktop, 2-up at tablet, 1-up at mobile.
+- Type sits inside an inner ~1200px reading column centered horizontally over the full-bleed photograph.
+
+### Whitespace Philosophy
+The marketing pages have minimal traditional whitespace — the photograph occupies all space. "Whitespace" here means the dark sky in a rocket photograph or the empty stretch of Martian terrain. Negative space is photographic, not a UI choice. On the shop site whitespace returns to standard 32px grid gutters.
+
+## Elevation & Depth
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 | Flat | Default — and the only level on marketing surfaces |
+| 1 | Photographic — full-bleed image or video | The primary depth medium; photographs do all the lifting |
+
+The brand does not use drop shadows, blurs, glows, or gradient overlays. Depth is photographic: a rocket launching at twilight has natural atmospheric depth that no CSS shadow could simulate. When type needs separation from imagery, the image is graded darker rather than scrimmed.
+
+### Decorative Depth
+Photography and autoplaying rocket-launch video are the only decorative depth. There are no illustrations, no icons beyond a few minimal SVG arrow chevrons in nav and CTA hover states.
+
+## Shapes
+
+### Border Radius Scale
+
+| Token | Value | Use |
+|---|---|---|
+| `{rounded.xs}` | 4px | Form inputs (shop site) |
+| `{rounded.sm}` | 8px | Shop product card chrome, video frames |
+| `{rounded.md}` | 16px | Larger surface chrome |
+| `{rounded.pill}` | 32px | Ghost outlined pill CTAs (the brand's signature button shape) |
+| `{rounded.full}` | 9999px | Circular play-button overlays on video frames |
+
+### Photography Geometry
+Every photograph is full-viewport-bleed, edge-to-edge, never inset in a card on the marketing site. On the shop site, product photography sits inside `{rounded.sm}` 8px containers with no shadow. Aspect ratios on marketing photography vary with the source image — there is no enforced ratio; the photograph leads.
+
+## Components
+
+### Buttons
+
+**`button-ghost-on-dark`** — the universal CTA on marketing surfaces.
+- Background `{colors.canvas-night}` (transparent against the photographed canvas), 1px solid `{colors.on-primary}` border, text `{colors.on-primary}`, type `{typography.button-cap}` (uppercase, 13px / 700 / 1.17px tracking), padding `{spacing.lg} {spacing.xl}` (18px 24px), rounded `{rounded.pill}` 32px.
+
+**`button-ghost-on-light`** — the same button on shop / light pages.
+- Background `{colors.canvas-light}` (transparent against light canvas), 1px solid `{colors.ink}` border, text `{colors.ink}`, otherwise identical.
+
+**`button-filled-cool`** — fill variant on shop product cards.
+- Background `{colors.canvas-cool}`, text `{colors.ink}`, same pill geometry. Used as "Add to cart" or similar product CTAs.
+
+### Cards & Containers
+
+**`card-photo-band`** — full-bleed photographic band on marketing pages.
+- Background `{colors.canvas-night}`, padding 0, rounded `{rounded.xs}`. The photograph fills the entire band; type and CTA sit overlaid.
+
+**`card-shop-product`** — product card on the shop site.
+- Background `{colors.canvas-light}`, padding `{spacing.md}` 16px, rounded `{rounded.sm}` 8px, 1px `{colors.hairline-on-light}` border. Product photo on top, name in `{typography.body-md}`, price in `{typography.body-md}` 700 weight, "Add to cart" button at the bottom.
+
+### Inputs & Forms
+
+**`text-input`** — form input on the shop site.
+- Background `{colors.canvas-light}`, text `{colors.ink}`, type `{typography.body-md}`, padding `{spacing.sm} {spacing.md}` (12px 16px), rounded `{rounded.xs}` 4px, 1px `{colors.hairline-on-light}` border.
+
+### Navigation
+
+**`nav-bar-overlay`** — top nav across the marketing site.
+- Background `{colors.canvas-night}` (transparent over the hero photo), text `{colors.on-primary}`, type `{typography.button-cap}` (uppercase). Logo wordmark on the left at ~147×19px, nav items horizontal in caps, padding `{spacing.xl} {spacing.xxl}` (24px 32px). The nav is fixed/sticky on scroll, retaining the overlay treatment.
+
+### Signature Components
+
+**Full-Bleed Photo / Video Hero** — every marketing band is a full-viewport photograph or autoplaying rocket-launch video. Type and CTA sit overlaid on the photograph at high opacity with no scrim. The photograph is graded so type lands cleanly without an overlay layer.
+
+**Uppercase Display Headline** — the 80px D-DIN-Bold uppercase headline with 1.6px positive tracking is the brand's most recognizable typographic moment. Always uppercase, always bold-weight, always positively tracked.
+
+**`link-on-dark`** — inline links on dark canvas.
+- Text `{colors.link-on-dark}` (white) with persistent underline.
+
+**`link-on-light`** — inline links on light canvas.
+- Text `{colors.ink}` with persistent underline.
+
+**`footer-dark`** — site-wide footer.
+- Background `{colors.canvas-night}`, text `{colors.on-primary}`, type `{typography.caption}`, padding `{spacing.xxl} {spacing.xl}` (32px 24px). Holds nav columns in `{typography.micro-cap}` (uppercase), and a small legal/copyright row at the bottom.
+
+## Do's and Don'ts
+
+### Do
+- Use full-bleed photography or autoplaying video as the dominant decorative element on every marketing band.
+- Render display tiers in uppercase D-DIN-Bold with positive 0.96–1.6px letter-spacing — the wide tracking is the signature.
+- Use a single `{button-ghost-on-dark}` per band — the brand does NOT show two CTAs side by side on marketing surfaces.
+- Pair every photograph with type that respects the imagery — no scrims, no gradients, no overlays. Grade the photo, not the canvas.
+- Keep nav overlay-style (transparent, white-on-image) on marketing pages.
+
+### Don't
+- Don't introduce brand accent colors — black, white, and photography are the entire palette.
+- Don't use drop shadows or gradient overlays on dark canvas — they fight the photography.
+- Don't render display tiers in sentence-case or title-case — uppercase is the brand.
+- Don't put filled buttons on marketing surfaces — the ghost outlined pill is the only marketing CTA.
+- Don't use serif or humanist sans alternatives — the condensed industrial DIN cut is non-negotiable.
+
+## Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Wide | ≥ 1500px | Full hero photograph; max-content type column at 1200px |
+| Desktop | 1280–1499px | Default desktop layout |
+| Laptop | 961–1279px | Type column tightens; photo crops adjust |
+| Tablet | 768–960px | Display drops 80 → 60px; nav compresses |
+| Mobile | 600–767px | Display drops to 48px; ghost button retains pill shape |
+| Small Mobile | < 600px | Display drops to 40px; nav becomes hamburger |
+
+### Touch Targets
+- Ghost pill buttons hit ≥ 50×50px due to the 18px vertical padding × 13px line-height. WCAG AAA compliant.
+- Form fields stay at the 44px minimum height.
+
+### Collapsing Strategy
+- Display sizes stair-step 80 → 60 → 48 → 40px through the breakpoints.
+- Photography re-crops to focal subject on smaller widths (rocket centered, Mars landscape centered).
+- Top nav collapses to hamburger below 768px; menu retains the dark overlay treatment.
+- Shop product grid stair-steps 4-up → 2-up → 1-up.
+
+### Image Behavior
+Marketing photography uses `srcset` for desktop / tablet / mobile with art-direction crops at major breakpoints. Mobile crops favor the central focal subject; wide crops favor environmental context (full launch pad, full Martian horizon).
+
+## Iteration Guide
+
+1. Focus on ONE component at a time.
+2. Reference component names and tokens directly (`{colors.canvas-night}`, `{button-ghost-on-dark}`, `{rounded.pill}`).
+3. Run `npx @google/design.md lint DESIGN.md` after edits.
+4. Add new variants as separate entries.
+5. Default body to `{typography.body-md}`; reserve `{typography.body-lg}` for marketing leads.
+6. The black-and-white-only rule is load-bearing — adding a brand accent color breaks the system.
+7. Ghost pill is the only marketing CTA; filled buttons live exclusively on the shop site.

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1,10 +1,11 @@
 import { Link, Outlet } from 'react-router-dom'
 import { AuthControl } from './components/AuthControl'
 import './App.css'
+import './theme-spacex.css'
 
 export function App() {
   return (
-    <div className="app">
+    <div className="app theme-spacex">
       <header className="app-header">
         <Link to="/" className="app-brand">
           ♥ Hearts

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -12,7 +12,6 @@ export function App() {
         </Link>
         <nav className="app-nav">
           <Link to="/">Competitions</Link>
-          <Link to="/live">Live</Link>
         </nav>
         <AuthControl />
       </header>

--- a/web/frontend/src/components/Card.css
+++ b/web/frontend/src/components/Card.css
@@ -36,14 +36,21 @@
   box-shadow: 0 0 0 2px #f5b301, 0 1px 4px rgba(0, 0, 0, 0.25);
 }
 
+/* Legal-to-play in the shown context: green ring. */
 .card--legal {
-  border-color: #2e9b5b;
-  box-shadow: 0 0 0 2px rgba(46, 155, 91, 0.4), 0 1px 2px rgba(0, 0, 0, 0.18);
+  border-color: #2bb673;
+  box-shadow: 0 0 0 2px #2bb673, 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-.card--illegal {
-  opacity: 0.35;
-  filter: grayscale(0.6);
+/* A legal card that also won the trick keeps the gold ring but stays green-tinted. */
+.card--legal.card--win {
+  box-shadow: 0 0 0 2px #f5b301, 0 0 0 4px #2bb673, 0 1px 4px rgba(0, 0, 0, 0.25);
+}
+
+/* Illegal in the shown context: faded back. */
+.card--dim {
+  opacity: 0.32;
+  filter: grayscale(0.5);
 }
 
 .card--clickable {

--- a/web/frontend/src/components/Card.css
+++ b/web/frontend/src/components/Card.css
@@ -36,21 +36,24 @@
   box-shadow: 0 0 0 2px #f5b301, 0 1px 4px rgba(0, 0, 0, 0.25);
 }
 
-/* Legal-to-play in the shown context: green ring. */
+/* Legal-to-play in the shown context: plain borderless card, no extra highlight. */
 .card--legal {
-  border-color: #2bb673;
-  box-shadow: 0 0 0 2px #2bb673, 0 1px 3px rgba(0, 0, 0, 0.2);
+  border-color: transparent;
+  box-shadow: none;
 }
 
-/* A legal card that also won the trick keeps the gold ring but stays green-tinted. */
+/* The played card keeps its gold ring even though it was legal to play. */
 .card--legal.card--win {
-  box-shadow: 0 0 0 2px #f5b301, 0 0 0 4px #2bb673, 0 1px 4px rgba(0, 0, 0, 0.25);
+  border-color: #f5b301;
+  box-shadow: 0 0 0 2px #f5b301, 0 1px 4px rgba(0, 0, 0, 0.25);
 }
 
-/* Illegal in the shown context: faded back. */
+/* Illegal in the shown context: greyed out, borderless. */
 .card--dim {
-  opacity: 0.32;
-  filter: grayscale(0.5);
+  border-color: transparent;
+  box-shadow: none;
+  opacity: 0.45;
+  filter: grayscale(1);
 }
 
 .card--clickable {

--- a/web/frontend/src/components/Card.tsx
+++ b/web/frontend/src/components/Card.tsx
@@ -3,14 +3,15 @@ import './Card.css'
 
 interface CardProps {
   code: string
-  highlight?: boolean // winning / played card
-  legal?: boolean // when defined: true = legal play (subtle cue), false = illegal (dimmed)
+  highlight?: boolean // winning card
+  legal?: boolean // legal to play in this context (green outline)
+  dim?: boolean // illegal in this context (faded)
   onClick?: () => void
   size?: 'sm' | 'md'
   title?: string // tooltip override for clickable cards
 }
 
-export function Card({ code, highlight, legal, onClick, size = 'md', title }: CardProps) {
+export function Card({ code, highlight, legal, dim, onClick, size = 'md', title }: CardProps) {
   const { rank, suit } = parseCard(code)
   const red = isRedSuit(suit)
   const pts = cardPoints(code)
@@ -19,9 +20,8 @@ export function Card({ code, highlight, legal, onClick, size = 'md', title }: Ca
     `card--${size}`,
     red ? 'card--red' : 'card--black',
     highlight ? 'card--win' : '',
-    // Don't add the green legal ring to the played (gold) card; let gold win.
-    legal === true && !highlight ? 'card--legal' : '',
-    legal === false ? 'card--illegal' : '',
+    legal ? 'card--legal' : '',
+    dim ? 'card--dim' : '',
     onClick ? 'card--clickable' : '',
   ]
     .filter(Boolean)

--- a/web/frontend/src/components/HandOverlay.css
+++ b/web/frontend/src/components/HandOverlay.css
@@ -43,12 +43,48 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  /* Gap between suit groups. */
+  gap: 18px;
+  row-gap: 10px;
+}
+
+/* Cards within a single suit sit tight together. */
+.overlay-suit-group {
+  display: flex;
   gap: 6px;
 }
 
-/* Visual break between suit groups (hand is sorted by suit then rank). */
-.overlay-hand__gap {
+.overlay-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 14px;
+  font-size: 12px;
+  color: #888;
+}
+
+.overlay-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.overlay-legend__swatch {
+  display: inline-block;
   width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  border: 1px solid #c7c7c7;
+}
+
+.overlay-legend__swatch--legal {
+  border-color: #2bb673;
+  box-shadow: 0 0 0 1px #2bb673;
+}
+
+.overlay-legend__swatch--dim {
+  opacity: 0.32;
+  filter: grayscale(0.5);
+  background: #ddd;
 }
 
 .overlay-footer {

--- a/web/frontend/src/components/HandOverlay.css
+++ b/web/frontend/src/components/HandOverlay.css
@@ -76,15 +76,11 @@
   border: 1px solid #c7c7c7;
 }
 
-.overlay-legend__swatch--legal {
-  border-color: #2bb673;
-  box-shadow: 0 0 0 1px #2bb673;
-}
-
 .overlay-legend__swatch--dim {
-  opacity: 0.32;
-  filter: grayscale(0.5);
-  background: #ddd;
+  border-color: transparent;
+  opacity: 0.45;
+  filter: grayscale(1);
+  background: #999;
 }
 
 .overlay-footer {

--- a/web/frontend/src/components/HandOverlay.tsx
+++ b/web/frontend/src/components/HandOverlay.tsx
@@ -1,16 +1,17 @@
-import { Fragment } from 'react'
 import type { PlayerDisplay } from '../lib/playerId'
+import { SUIT_ORDER, type Suit } from '../lib/cards'
 import { Card } from './Card'
 import { PlayerName } from './PlayerName'
-import { parseCard } from '../lib/cards'
 import './HandOverlay.css'
 
 export interface HandOverlayData {
   player: string
   subtitle: string // e.g. "hand before trick #3" or "hand before passing"
   hand: string[]
-  highlight: string[] // cards to ring
-  legal?: string[] // legally-playable cards; when set, others are dimmed
+  highlight: string[] // cards to ring (winning / passed card)
+  // When present, marks which cards were legal to play in this context: legal
+  // cards get a green ring, the rest are faded. Omit for non-play overlays.
+  legal?: string[]
   footer: string
 }
 
@@ -23,6 +24,12 @@ interface HandOverlayProps {
 export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
   const highlight = new Set(data.highlight)
   const legal = data.legal ? new Set(data.legal) : null
+  // Split the (suit-then-rank sorted) hand into per-suit groups so we can render
+  // a visible gap between suits.
+  const groups = SUIT_ORDER.map((s) => data.hand.filter((c) => (c[1] as Suit) === s)).filter(
+    (g) => g.length > 0,
+  )
+
   return (
     <div className="overlay-backdrop" onClick={onClose}>
       <div className="overlay-panel" onClick={(e) => e.stopPropagation()}>
@@ -35,17 +42,30 @@ export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
           </button>
         </div>
         <div className="overlay-hand">
-          {data.hand.map((c, i) => {
-            const prev = data.hand[i - 1]
-            const gap = prev && parseCard(prev).suit !== parseCard(c).suit
-            return (
-              <Fragment key={c}>
-                {gap && <span className="overlay-hand__gap" aria-hidden="true" />}
-                <Card code={c} highlight={highlight.has(c)} legal={legal ? legal.has(c) : undefined} />
-              </Fragment>
-            )
-          })}
+          {groups.map((g, i) => (
+            <div className="overlay-suit-group" key={i}>
+              {g.map((c) => (
+                <Card
+                  key={c}
+                  code={c}
+                  highlight={highlight.has(c)}
+                  legal={legal ? legal.has(c) : undefined}
+                  dim={legal ? !legal.has(c) : undefined}
+                />
+              ))}
+            </div>
+          ))}
         </div>
+        {legal && (
+          <div className="overlay-legend">
+            <span className="overlay-legend__item">
+              <span className="overlay-legend__swatch overlay-legend__swatch--legal" /> legal to play
+            </span>
+            <span className="overlay-legend__item">
+              <span className="overlay-legend__swatch overlay-legend__swatch--dim" /> not legal
+            </span>
+          </div>
+        )}
         <div className="overlay-footer">{data.footer}</div>
       </div>
     </div>

--- a/web/frontend/src/components/HandOverlay.tsx
+++ b/web/frontend/src/components/HandOverlay.tsx
@@ -59,10 +59,7 @@ export function HandOverlay({ data, name, onClose }: HandOverlayProps) {
         {legal && (
           <div className="overlay-legend">
             <span className="overlay-legend__item">
-              <span className="overlay-legend__swatch overlay-legend__swatch--legal" /> legal to play
-            </span>
-            <span className="overlay-legend__item">
-              <span className="overlay-legend__swatch overlay-legend__swatch--dim" /> not legal
+              <span className="overlay-legend__swatch overlay-legend__swatch--dim" /> greyed out = not legal to play
             </span>
           </div>
         )}

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -218,6 +218,16 @@ button.btn:hover {
   background: #f0f3f6;
 }
 
+/* Active toggle (e.g. selected tournament stage). */
+button.btn.btn--active {
+  background: #2a5bd7;
+  border-color: #2a5bd7;
+  color: #fff;
+}
+button.btn.btn--active:hover {
+  background: #2a5bd7;
+}
+
 .crumbs {
   font-size: 13px;
   margin-bottom: 12px;

--- a/web/frontend/src/lib/aggregate.ts
+++ b/web/frontend/src/lib/aggregate.ts
@@ -11,6 +11,7 @@ export interface GameFilter {
 export interface Aggregate {
   numGames: number
   // slotId -> total across the matching games
+  gamesByPlayer: Record<string, number>
   gamePointsByPlayer: Record<string, number>
   tournamentPointsByPlayer: Record<string, number>
   moonShotsByPlayer: Record<string, number>
@@ -38,18 +39,20 @@ function add(target: Record<string, number>, key: string, v: number) {
 }
 
 export function aggregate(games: GameSummary[]): Aggregate {
+  const gamesByPlayer: Record<string, number> = {}
   const gamePointsByPlayer: Record<string, number> = {}
   const tournamentPointsByPlayer: Record<string, number> = {}
   const moonShotsByPlayer: Record<string, number> = {}
   for (const g of games) {
     for (const p of gamePlayers(g)) {
       const key = slotId(p.id)
+      add(gamesByPlayer, key, 1)
       add(gamePointsByPlayer, key, p.game_score)
       add(tournamentPointsByPlayer, key, p.tournament_points)
     }
     for (const [id, v] of Object.entries(g.moon_shots ?? {})) add(moonShotsByPlayer, slotId(id), v)
   }
-  return { numGames: games.length, gamePointsByPlayer, tournamentPointsByPlayer, moonShotsByPlayer }
+  return { numGames: games.length, gamesByPlayer, gamePointsByPlayer, tournamentPointsByPlayer, moonShotsByPlayer }
 }
 
 /** All distinct slot ids appearing across a set of games (for filter dropdowns). */

--- a/web/frontend/src/lib/reconstruct.ts
+++ b/web/frontend/src/lib/reconstruct.ts
@@ -94,6 +94,61 @@ export function legalMovesForHand(
 }
 
 /**
+ * Which cards in a player's hand were legal to play when it was their turn in
+ * `trickIndex`. Mirrors the server's Trick::legalMovesForPlayer exactly:
+ *   - must follow the led suit if able;
+ *   - the leader may not lead hearts until hearts are broken (unless they hold
+ *     only hearts);
+ *   - on the first trick the leader must play 2♣ and no one may play the Q♠.
+ * Hearts are "broken" once any heart has been played in an earlier trick.
+ */
+export function legalMovesBeforePlay(
+  round: RoundRecord,
+  playerOrder: string[],
+  player: string,
+  trickIndex: number,
+): string[] {
+  const { hand } = handBeforePlay(round, playerOrder, player, trickIndex)
+  if (hand.length === 0) return []
+  const trick = round.tricks[trickIndex]
+  if (!trick) return hand
+
+  const n = playerOrder.length
+  const firstSeat = playerOrder.indexOf(trick.first_player)
+  let pos = -1
+  for (let i = 0; i < n; i++) {
+    if (playerOrder[(firstSeat + i) % n] === player) {
+      pos = i
+      break
+    }
+  }
+  const leading = pos === 0
+  const cardsBefore = pos > 0 ? trick.moves.slice(0, pos) : []
+
+  // Hearts are broken if any heart was played in a strictly earlier trick.
+  let heartsBroken = false
+  for (let t = 0; t < trickIndex && !heartsBroken; t++) {
+    if (round.tricks[t].moves.some((c) => c[1] === 'H')) heartsBroken = true
+  }
+
+  let legal = [...hand]
+  if (!leading) {
+    const ledSuit = cardsBefore[0]?.[1]
+    const matching = legal.filter((c) => c[1] === ledSuit)
+    if (matching.length > 0) legal = matching
+  } else if (!heartsBroken) {
+    const nonHearts = legal.filter((c) => c[1] !== 'H')
+    if (nonHearts.length > 0) legal = nonHearts
+  }
+
+  if (trickIndex === 0) {
+    if (leading) return legal.includes('2C') ? ['2C'] : legal
+    legal = legal.filter((c) => c !== 'QS')
+  }
+  return legal
+}
+
+/**
  * Reconstruct a player's hand right before they passed, plus the cards they passed.
  *
  * The post-pass hand (`hands_after_passing[player]`, == the cards they play this

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -5,7 +5,6 @@ import './index.css'
 import { App } from './App'
 import { CompetitionsList } from './pages/CompetitionsList'
 import { CompetitionDetail } from './pages/CompetitionDetail'
-import { LiveStats } from './pages/LiveStats'
 import { TournamentDetail } from './pages/TournamentDetail'
 import { GameDetail } from './pages/GameDetail'
 import { RoundDetail } from './pages/RoundDetail'
@@ -16,7 +15,6 @@ createRoot(document.getElementById('root')!).render(
       <Routes>
         <Route path="/" element={<App />}>
           <Route index element={<CompetitionsList />} />
-          <Route path="live" element={<LiveStats />} />
           <Route path="c/:cid" element={<CompetitionDetail />} />
           <Route path="c/:cid/t/:index" element={<TournamentDetail />} />
           <Route path="c/:cid/t/:index/g/:gameId" element={<GameDetail />} />

--- a/web/frontend/src/pages/CompetitionDetail.tsx
+++ b/web/frontend/src/pages/CompetitionDetail.tsx
@@ -33,6 +33,12 @@ export function CompetitionDetail() {
     return nameResolver(ids)
   }, [data])
 
+  // Show tournaments in competition order (index 1, 2, 3, …).
+  const tournaments = useMemo(
+    () => [...(data?.tournaments ?? [])].sort((a, b) => Number(a.index) - Number(b.index)),
+    [data],
+  )
+
   if (loading) return <p className="muted">Loading…</p>
   if (error) return <p className="muted">Error: {error}</p>
   if (!data) return <p className="muted">Not found.</p>
@@ -63,15 +69,15 @@ export function CompetitionDetail() {
             <tr>
               <th>Index</th>
               <th>Start time</th>
+              <th>Duration</th>
               <th>1st place</th>
               <th>2nd place</th>
               <th>3rd place</th>
               <th>4th place</th>
-              <th>Length</th>
             </tr>
           </thead>
           <tbody>
-            {data.tournaments.map((t) => (
+            {tournaments.map((t) => (
               <TournamentRowView key={t.index} t={t} cid={cid} nameOf={nameOf} navigate={navigate} />
             ))}
           </tbody>
@@ -107,11 +113,11 @@ function TournamentRowView({
         {!t.complete && <span className="muted" style={{ fontSize: 11 }}> (in progress)</span>}
       </td>
       <td>{t.began_at ? new Date(t.began_at).toLocaleString() : '—'}</td>
+      <td className="muted">{formatLength(t.length_seconds)}</td>
       <td style={{ fontSize: 12 }}>{place(0)}</td>
       <td style={{ fontSize: 12 }}>{place(1)}</td>
       <td style={{ fontSize: 12 }}>{place(2)}</td>
       <td style={{ fontSize: 12 }}>{place(3)}</td>
-      <td className="muted">{formatLength(t.length_seconds)}</td>
     </tr>
   )
 }

--- a/web/frontend/src/pages/CompetitionDetail.tsx
+++ b/web/frontend/src/pages/CompetitionDetail.tsx
@@ -39,6 +39,15 @@ export function CompetitionDetail() {
     [data],
   )
 
+  // The competition's rules come from the environment config and are identical
+  // across its tournaments, so we read them off the first tournament's rules.json.
+  // (Legacy bundles predate rules.json, so there is nothing to show.)
+  const rulesIndex = !data || data.is_legacy ? '' : tournaments[0]?.index ?? ''
+  const { data: rules } = useFetch(
+    () => (rulesIndex ? api.rules(cid, rulesIndex) : Promise.resolve(null)),
+    [cid, rulesIndex],
+  )
+
   if (loading) return <p className="muted">Loading…</p>
   if (error) return <p className="muted">Error: {error}</p>
   if (!data) return <p className="muted">Not found.</p>
@@ -62,6 +71,30 @@ export function CompetitionDetail() {
         Teams: {data.teams.length > 0 ? data.teams.join(', ') : '—'}
       </div>
 
+      {rules && (
+        <>
+          <h2>Rules</h2>
+          <div className="card-surface">
+            <table className="data rules-table">
+              <tbody>
+                <RuleRow label="Qualifying games" value={rules.qualifying_games} />
+                <RuleRow label="Finals games" value={rules.finals_games} />
+                <RuleRow
+                  label="Qualifying points (1st–4th)"
+                  value={rules.qualifying_points?.length ? rules.qualifying_points.join(' / ') : '—'}
+                />
+                <RuleRow label="Max players per team" value={rules.max_players_per_team} />
+                <RuleRow label="Allow multi-team finals" value={rules.allow_multi_team_finals ? 'Yes' : 'No'} />
+                <RuleRow label="Move timeout" value={`${rules.move_timeout_ms} ms`} />
+                <RuleRow label="Auto-move after timeouts" value={rules.auto_move_after_timeouts} />
+                <RuleRow label="Max concurrent games per team" value={rules.max_concurrent_games_per_team} />
+                <RuleRow label="Fallback player tag" value={rules.fallback_player_tag} />
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
       <h2>Tournaments ({data.tournaments.length})</h2>
       <div className="card-surface">
         <table className="data">
@@ -84,6 +117,15 @@ export function CompetitionDetail() {
         </table>
       </div>
     </div>
+  )
+}
+
+function RuleRow({ label, value }: { label: string; value: string | number | undefined }) {
+  return (
+    <tr>
+      <td className="muted" style={{ width: '55%' }}>{label}</td>
+      <td style={{ fontWeight: 600 }}>{value ?? '—'}</td>
+    </tr>
   )
 }
 

--- a/web/frontend/src/pages/CompetitionsList.tsx
+++ b/web/frontend/src/pages/CompetitionsList.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { api } from '../api/client'
 import { useFetch } from '../lib/useFetch'
+import { LiveStatsPanel } from './LiveStats'
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—'
@@ -12,13 +13,17 @@ export function CompetitionsList() {
   const { data, loading, error } = useFetch(() => api.competitions(), [])
   const navigate = useNavigate()
 
-  if (loading) return <p className="muted">Loading competitions…</p>
-  if (error) return <p className="muted">Error: {error}</p>
-  if (!data || data.length === 0) return <p className="muted">No competitions found.</p>
-
   return (
     <div>
+      <LiveStatsPanel />
       <h1>Competitions</h1>
+      {loading ? (
+        <p className="muted">Loading competitions…</p>
+      ) : error ? (
+        <p className="muted">Error: {error}</p>
+      ) : !data || data.length === 0 ? (
+        <p className="muted">No competitions found.</p>
+      ) : (
       <div className="card-surface">
         <table className="data">
           <thead>
@@ -62,6 +67,7 @@ export function CompetitionsList() {
           </tbody>
         </table>
       </div>
+      )}
     </div>
   )
 }

--- a/web/frontend/src/pages/GameDetail.tsx
+++ b/web/frontend/src/pages/GameDetail.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver } from '../lib/playerId'
@@ -7,6 +7,7 @@ import { PlayerName } from '../components/PlayerName'
 
 export function GameDetail() {
   const { cid = '', index = '', gameId = '' } = useParams()
+  const navigate = useNavigate()
   const { data, loading, error } = useFetch(() => api.game(cid, index, gameId), [cid, index, gameId])
 
   const totals = useMemo<Record<string, number>>(() => {
@@ -26,6 +27,9 @@ export function GameDetail() {
   // Rank: lowest total score wins (rank 1).
   const ranked = [...seating].sort((a, b) => totals[a] - totals[b])
   const rankOf = (p: string) => ranked.indexOf(p) + 1
+
+  const roundHref = (roundIdx: number) =>
+    `/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}/g/${encodeURIComponent(gameId)}/r/${roundIdx}`
 
   return (
     <div>
@@ -53,13 +57,9 @@ export function GameDetail() {
           </thead>
           <tbody>
             {data.rounds.map((r) => (
-              <tr key={r.round_idx}>
+              <tr key={r.round_idx} className="row-link" onClick={() => navigate(roundHref(r.round_idx))}>
                 <td>
-                  <Link
-                    to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}/g/${encodeURIComponent(gameId)}/r/${r.round_idx}`}
-                  >
-                    #{r.round_idx + 1}
-                  </Link>
+                  <Link to={roundHref(r.round_idx)}>#{r.round_idx + 1}</Link>
                 </td>
                 <td className="muted">{r.pass_direction}</td>
                 {seating.map((p) => (

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -17,21 +17,18 @@ function elapsedSince(iso: string | null): string {
   return h > 0 ? `${h}h ${m}m ago` : `${m}m ago`
 }
 
-export function LiveStats() {
-  const { data, loading, error } = usePoll(() => api.live(), REFRESH_MS, [])
+// Embeddable live panel. Renders nothing until there is an in-progress
+// tournament, so it can sit quietly at the top of the Competitions page.
+export function LiveStatsPanel() {
+  const { data, error } = usePoll(() => api.live(), REFRESH_MS, [])
 
-  // Only show the full-page loading/error states before the first successful load;
-  // once we have data, background poll failures keep the last-known data on screen.
-  if (loading && !data) return <p className="muted">Loading…</p>
-  if (error && !data) return <p className="muted">Error: {error}</p>
-  if (!data || !data.competition_id || !data.tournament_index)
-    return <p className="muted">No tournament data available.</p>
+  if (!data || !data.competition_id || !data.tournament_index) return null
 
   const standings = Object.entries(data.standings).sort((a, b) => b[1] - a[1])
   const nameOf = nameResolver(standings.map(([p]) => p))
 
   return (
-    <div>
+    <div style={{ marginBottom: 28 }}>
       <h1>Live tournament stats</h1>
       <p className="muted" style={{ marginTop: -8 }}>
         Current tournament:{' '}

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -5,8 +5,7 @@ import { useFetch } from '../lib/useFetch'
 import { nameResolver, displayString } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
 import { columnSeats, NUM_COLS, CENTER, passRecipient, passSource } from '../lib/seating'
-import { handBeforePlay, handBeforePassing, legalMovesForHand, heartsBrokenBefore } from '../lib/reconstruct'
-import { parseCard } from '../lib/cards'
+import { handBeforePlay, handBeforePassing, legalMovesBeforePlay } from '../lib/reconstruct'
 import { TrickRow } from '../components/TrickRow'
 import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
 import { Card } from '../components/Card'
@@ -35,17 +34,14 @@ export function RoundDetail() {
 
   const handleCardClick = (player: string, _card: string, trickIndex: number) => {
     const { hand, playedCard } = handBeforePlay(round, data.player_order, player, trickIndex)
-    const trick = round.tricks[trickIndex]
-    const leadingPlay = player === trick.first_player
-    const ledSuit = leadingPlay ? null : parseCard(trick.moves[0]).suit
-    const legal = legalMovesForHand(hand, trickIndex, ledSuit, heartsBrokenBefore(round, trickIndex))
+    const legal = legalMovesBeforePlay(round, data.player_order, player, trickIndex)
     setOverlay({
       player,
       subtitle: `hand before trick #${trickIndex + 1}`,
       hand,
       highlight: playedCard ? [playedCard] : [],
       legal,
-      footer: `Highlighted card was the one played; cards outlined in green were legal plays (others faded). (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
+      footer: `Gold ring = card played. Green = legal to play here; faded = not legal. (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
     })
   }
 

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -41,7 +41,7 @@ export function RoundDetail() {
       hand,
       highlight: playedCard ? [playedCard] : [],
       legal,
-      footer: `Gold ring = card played. Green = legal to play here; faded = not legal. (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
+      footer: `Gold ring = card played. Greyed-out cards weren't legal to play here. (${hand.length} card${hand.length === 1 ? '' : 's'} in hand)`,
     })
   }
 

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -8,7 +8,8 @@ import { aggregate, allPlayers, filterGames } from '../lib/aggregate'
 
 const PAGE_SIZE = 50
 
-type SortKey = 'player' | 'game' | 'tournament' | 'moon'
+type SortKey = 'team' | 'player' | 'gamesCount' | 'game' | 'tournament' | 'moon'
+const TEXT_SORTS: SortKey[] = ['team', 'player']
 
 export function TournamentDetail() {
   const { cid = '', index = '' } = useParams()
@@ -22,8 +23,8 @@ export function TournamentDetail() {
   const selectedPlayers = params.getAll('player')
   const minMoon = Number(params.get('minMoon')) || 0
   const page = Math.max(0, Number(params.get('page')) || 0)
-  const sortKey = (params.get('sort') as SortKey) || 'player'
-  const sortAsc = params.get('dir') ? params.get('dir') === 'asc' : sortKey === 'player'
+  const sortKey = (params.get('sort') as SortKey) || 'tournament'
+  const sortAsc = params.get('dir') ? params.get('dir') === 'asc' : TEXT_SORTS.includes(sortKey)
 
   // Merge a set of changes into the URL search params (preserving the rest).
   const patch = (changes: Record<string, string | string[] | null>) => {
@@ -75,8 +76,8 @@ export function TournamentDetail() {
     if (key === sortKey) {
       patch({ dir: sortAsc ? 'desc' : 'asc' })
     } else {
-      // Player defaults to A→Z; numeric columns default to highest first.
-      patch({ sort: key, dir: key === 'player' ? 'asc' : 'desc' })
+      // Text columns default to A→Z; numeric columns default to highest first.
+      patch({ sort: key, dir: TEXT_SORTS.includes(key) ? 'asc' : 'desc' })
     }
   }
 
@@ -85,7 +86,9 @@ export function TournamentDetail() {
     .filter((v, i, a) => a.indexOf(v) === i)
     .sort((a, b) => {
       let cmp: number
-      if (sortKey === 'player') cmp = playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
+      if (sortKey === 'team') cmp = (nameOf(a).team ?? '').localeCompare(nameOf(b).team ?? '')
+      else if (sortKey === 'player') cmp = playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
+      else if (sortKey === 'gamesCount') cmp = (agg.gamesByPlayer[a] ?? 0) - (agg.gamesByPlayer[b] ?? 0)
       else if (sortKey === 'game') cmp = (agg.gamePointsByPlayer[a] ?? 0) - (agg.gamePointsByPlayer[b] ?? 0)
       else if (sortKey === 'tournament')
         cmp = (agg.tournamentPointsByPlayer[a] ?? 0) - (agg.tournamentPointsByPlayer[b] ?? 0)
@@ -154,7 +157,9 @@ export function TournamentDetail() {
         <table className="data">
           <thead>
             <tr>
+              <SortTh label="Team" col="team" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Player" col="player" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
+              <SortTh label="Total games" col="gamesCount" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Total game points" col="game" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh
                 label="Total tournament points"
@@ -167,14 +172,19 @@ export function TournamentDetail() {
             </tr>
           </thead>
           <tbody>
-            {aggRows.map((p) => (
-              <tr key={p}>
-                <td><PlayerName d={nameOf(p)} /></td>
-                <td>{agg.gamePointsByPlayer[p] ?? 0}</td>
-                <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
-                <td>{agg.moonShotsByPlayer[p] ?? 0}</td>
-              </tr>
-            ))}
+            {aggRows.map((p) => {
+              const d = nameOf(p)
+              return (
+                <tr key={p}>
+                  <td style={{ color: d.color, fontWeight: 600 }}>{d.team ?? '—'}</td>
+                  <td><PlayerName d={d} /></td>
+                  <td>{agg.gamesByPlayer[p] ?? 0}</td>
+                  <td>{agg.gamePointsByPlayer[p] ?? 0}</td>
+                  <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
+                  <td>{agg.moonShotsByPlayer[p] ?? 0}</td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>
@@ -188,29 +198,40 @@ export function TournamentDetail() {
           <thead>
             <tr>
               <th>Game</th>
-              <th>Players (finish order)</th>
-              <th>Winner</th>
+              <th>1st</th>
+              <th>2nd</th>
+              <th>3rd</th>
+              <th>4th</th>
               <th>Rounds</th>
             </tr>
           </thead>
           <tbody>
-            {pageGames.map((g) => (
-              <tr key={g.game_id} className="row-link" onClick={() => navigate(gameHref(g.game_id))}>
-                <td>
-                  <Link to={gameHref(g.game_id)}>{g.game_id}</Link>
-                </td>
-                <td style={{ fontSize: 12 }}>
-                  {gamePlayers(g).map((p, i) => (
-                    <span key={p.id}>
-                      {i > 0 && <span className="muted">, </span>}
-                      <PlayerName d={nameOf(p.id)} />
-                    </span>
-                  ))}
-                </td>
-                <td><PlayerName d={nameOf(g.winner)} /></td>
-                <td className="muted">{g.rounds_played}</td>
-              </tr>
-            ))}
+            {pageGames.map((g) => {
+              const ranked = gamePlayers(g)
+              return (
+                <tr key={g.game_id} className="row-link" onClick={() => navigate(gameHref(g.game_id))}>
+                  <td>
+                    <Link to={gameHref(g.game_id)}>{g.game_id}</Link>
+                  </td>
+                  {[0, 1, 2, 3].map((i) => {
+                    const p = ranked[i]
+                    return (
+                      <td key={i} style={{ fontSize: 12 }}>
+                        {p ? (
+                          <>
+                            <PlayerName d={nameOf(p.id)} />{' '}
+                            <span className="muted">({p.game_score})</span>
+                          </>
+                        ) : (
+                          <span className="muted">—</span>
+                        )}
+                      </td>
+                    )
+                  })}
+                  <td className="muted">{g.rounds_played}</td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
         {numPages > 1 && (
@@ -264,7 +285,8 @@ function SortTh({
           color: active ? '#2a5bd7' : 'inherit',
         }}
       >
-        {label} {active ? (sortAsc ? '▲' : '▼') : <span style={{ opacity: 0.3 }}>↕</span>}
+        {label}
+        {active ? ` ${sortAsc ? '▲' : '▼'}` : ''}
       </button>
     </th>
   )

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -106,15 +106,13 @@ export function TournamentDetail() {
 
       <div className="row-actions">
         <button
-          className="btn"
-          style={stage === 'qualifying' ? { background: '#2a5bd7', color: '#fff' } : undefined}
+          className={`btn${stage === 'qualifying' ? ' btn--active' : ''}`}
           onClick={() => patch({ stage: 'qualifying', page: null })}
         >
           Qualifying ({data.qualifying.length})
         </button>
         <button
-          className="btn"
-          style={stage === 'finals' ? { background: '#2a5bd7', color: '#fff' } : undefined}
+          className={`btn${stage === 'finals' ? ' btn--active' : ''}`}
           onClick={() => patch({ stage: 'finals', page: null })}
         >
           Finals ({data.finals.length})

--- a/web/frontend/src/theme-spacex.css
+++ b/web/frontend/src/theme-spacex.css
@@ -1,0 +1,265 @@
+/*
+ * SpaceX-inspired design language (issue #34).
+ *
+ * Built from the official getdesign `DESIGN.md` token set (see
+ * web/frontend/DESIGN.md). Aesthetic: pure-black canvas, white uppercase
+ * D-DIN display type with wide positive tracking, ghost-outlined pill CTAs,
+ * 1px hairline rules, no accent color, no shadows. D-DIN is substituted with
+ * Inter (700 for display) per the doc's recommended fallback.
+ *
+ * Scoped under `.theme-spacex` (applied at the app root in App.tsx) so the
+ * whole treatment can be toggled cleanly.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+.theme-spacex {
+  /* --- tokens (DESIGN.md) --- */
+  --sx-canvas-night: #000000;
+  --sx-canvas-night-soft: #0a0a0a;
+  --sx-on-primary: #ffffff;
+  --sx-on-primary-mute: #f0f0fa;
+  --sx-muted: rgba(255, 255, 255, 0.55);
+  --sx-hairline: #3a3a3f;
+  --sx-hover: rgba(255, 255, 255, 0.06);
+
+  --sx-display: 'Inter', 'Arial Narrow', Arial, Verdana, sans-serif;
+  --sx-body: 'Inter', Arial, Verdana, sans-serif;
+
+  background: var(--sx-canvas-night);
+  color: var(--sx-on-primary);
+  min-height: 100vh;
+  font-family: var(--sx-body);
+  font-size: 16px;
+  font-weight: 400;
+  letter-spacing: 0.32px;
+  line-height: 1.5;
+}
+
+/* ---- Header / nav (nav-bar-overlay) ----------------------------------- */
+.theme-spacex .app-header {
+  background: var(--sx-canvas-night);
+  border-bottom: 1px solid var(--sx-hairline);
+  padding: 24px 32px;
+  gap: 40px;
+}
+
+.theme-spacex .app-brand {
+  font-family: var(--sx-display);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.6px;
+  font-size: 18px;
+}
+
+.theme-spacex .app-nav a {
+  /* micro-cap eyebrow */
+  color: var(--sx-on-primary-mute);
+  text-transform: uppercase;
+  letter-spacing: 1.17px;
+  font-size: 12px;
+  font-weight: 700;
+  transition: opacity 0.15s ease;
+  opacity: 0.7;
+}
+
+.theme-spacex .app-nav a:hover {
+  opacity: 1;
+}
+
+/* ---- Display typography ------------------------------------------------ */
+.theme-spacex h1 {
+  font-family: var(--sx-display);
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  font-weight: 700;
+  font-size: 40px;
+  line-height: 1.1;
+  margin: 0 0 20px;
+}
+
+.theme-spacex h2 {
+  font-family: var(--sx-display);
+  text-transform: uppercase;
+  letter-spacing: 0.96px;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--sx-on-primary-mute);
+  margin: 28px 0 12px;
+}
+
+.theme-spacex a {
+  color: var(--sx-on-primary);
+  text-decoration: none;
+}
+
+/* link-on-dark: persistent underline for inline links inside content */
+.theme-spacex .app-main a:not(.btn):hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.theme-spacex .muted {
+  color: var(--sx-muted);
+}
+
+/* ---- Surfaces (card-photo-band on canvas-night-soft) ------------------ */
+.theme-spacex .card-surface {
+  background: var(--sx-canvas-night-soft);
+  border: 1px solid var(--sx-hairline);
+  border-radius: 4px;
+  box-shadow: none;
+  padding: 20px 22px;
+}
+
+/* ---- Tables ------------------------------------------------------------ */
+.theme-spacex table.data th {
+  color: var(--sx-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.96px;
+  font-size: 11px;
+  font-weight: 700;
+  border-bottom: 1px solid var(--sx-hairline);
+  padding: 10px 12px;
+}
+
+.theme-spacex table.data td {
+  border-bottom: 1px solid var(--sx-hairline);
+  padding: 12px;
+}
+
+.theme-spacex table.data tbody tr:hover,
+.theme-spacex table.data tbody tr.row-link:hover {
+  background: var(--sx-hover);
+}
+
+/* ---- Pills / chips ----------------------------------------------------- */
+.theme-spacex .pill {
+  background: transparent;
+  border: 1px solid var(--sx-hairline);
+  border-radius: 32px;
+  color: var(--sx-on-primary-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.96px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 11px;
+}
+
+/* ---- Buttons (button-ghost-on-dark): ghost outline, pill -------------- */
+.theme-spacex button.btn,
+.theme-spacex select.btn {
+  background: transparent;
+  border: 1px solid var(--sx-on-primary);
+  border-radius: 32px;
+  color: var(--sx-on-primary);
+  text-transform: uppercase;
+  letter-spacing: 1.17px;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 10px 20px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.theme-spacex button.btn:hover {
+  background: var(--sx-on-primary);
+  color: var(--sx-canvas-night);
+}
+
+/* Active toggle inverts to solid white — no accent color (brand rule). */
+.theme-spacex button.btn.btn--active {
+  background: var(--sx-on-primary);
+  border-color: var(--sx-on-primary);
+  color: var(--sx-canvas-night);
+}
+
+.theme-spacex select.btn option {
+  background: #000;
+  color: #fff;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+/* ---- Breadcrumbs (micro-cap) ------------------------------------------ */
+.theme-spacex .crumbs {
+  color: var(--sx-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.96px;
+  font-size: 11px;
+}
+
+/* ---- Inputs (text-input: 4px radius) ---------------------------------- */
+.theme-spacex input[type='number'],
+.theme-spacex input[type='text'],
+.theme-spacex input[type='password'] {
+  background: var(--sx-canvas-night-soft);
+  border: 1px solid var(--sx-hairline);
+  color: var(--sx-on-primary);
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-family: var(--sx-body);
+}
+
+/* ---- Progress bars (live stats) --------------------------------------- */
+.theme-spacex .progress__track {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 32px;
+}
+.theme-spacex .progress__fill {
+  border-radius: 32px;
+}
+
+/* ---- Auth control (ghost pill, in keeping with the nav) --------------- */
+.theme-spacex .auth-who {
+  color: var(--sx-on-primary-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.96px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.theme-spacex .auth-btn {
+  background: transparent;
+  border: 1px solid var(--sx-on-primary);
+  border-radius: 32px;
+  color: var(--sx-on-primary);
+  text-transform: uppercase;
+  letter-spacing: 1.17px;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 8px 16px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.theme-spacex .auth-btn:hover {
+  background: var(--sx-on-primary);
+  color: var(--sx-canvas-night);
+}
+
+.theme-spacex .auth-popover {
+  background: var(--sx-canvas-night-soft);
+  border: 1px solid var(--sx-hairline);
+  border-radius: 4px;
+  color: var(--sx-on-primary);
+}
+
+.theme-spacex .auth-hint {
+  color: var(--sx-muted);
+}
+
+.theme-spacex .auth-input {
+  background: var(--sx-canvas-night);
+  border: 1px solid var(--sx-hairline);
+  color: var(--sx-on-primary);
+  border-radius: 4px;
+}
+
+.theme-spacex .auth-btn--primary {
+  background: var(--sx-on-primary);
+  color: var(--sx-canvas-night);
+}
+
+.theme-spacex .auth-btn--primary:hover {
+  opacity: 0.85;
+  background: var(--sx-on-primary);
+  color: var(--sx-canvas-night);
+}

--- a/web/frontend/src/theme-spacex.css
+++ b/web/frontend/src/theme-spacex.css
@@ -199,6 +199,44 @@
   font-family: var(--sx-body);
 }
 
+/* ---- Checkboxes (monochrome, white accent) ---------------------------- */
+.theme-spacex input[type='checkbox'] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--sx-on-primary-mute);
+  border-radius: 3px;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+  vertical-align: -2px;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.theme-spacex input[type='checkbox']:hover {
+  border-color: var(--sx-on-primary);
+}
+.theme-spacex input[type='checkbox']:checked {
+  background: var(--sx-on-primary);
+  border-color: var(--sx-on-primary);
+}
+.theme-spacex input[type='checkbox']:checked::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 3px;
+  height: 7px;
+  border: solid var(--sx-canvas-night);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+/* The whole filter pill brightens when its checkbox is checked. */
+.theme-spacex .pill:has(input[type='checkbox']:checked) {
+  border-color: var(--sx-on-primary);
+  color: var(--sx-on-primary);
+}
+
 /* ---- Progress bars (live stats) --------------------------------------- */
 .theme-spacex .progress__track {
   background: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
Closes #34.

> **Stacked on #38** — this PR's base is `feature/38-competitions-organization` so the diff shows only the SpaceX styling. Retarget to `main` once #38 (PR #46) merges.

## Summary
Restyles the web UI after the **SpaceX design language**, built from the official `getdesign` token set (`npx getdesign add spacex`), vendored as `web/frontend/DESIGN.md` for reference:

- **Pure-black canvas**, white **uppercase display type** with wide positive tracking, **ghost-outlined pill buttons**, 1px hairline rules, no shadows, no decorative accent color.
- D-DIN is substituted with **Inter** (700 for display) per the doc's recommended fallback.
- The entire treatment is one `theme-spacex.css` scoped under a `.theme-spacex` root class (applied in `App.tsx`), so it can be toggled cleanly.
- The tournament **stage toggle** moves from an inline blue accent to a `.btn--active` class — blue in the default theme, **inverted white** under SpaceX — honoring the brand's black-and-white-only rule.

### Intentional deviations
The "no accent color" rule is relaxed for two **functional** (non-decorative) cases that encode data: **team-colored player names** and the **qualifying/finals progress-bar fills**. These aid at-a-glance reading in a stats app; happy to fully monochrome them if preferred.

## Test plan
- [x] `npm run build` (tsc + vite) compiles clean.
- [x] Walked all page types in the browser under the theme: competitions list, competition detail (1st-4th + length), tournament detail (ghost-pill stage toggle now inverts white when active; filter/sort/URL state intact), game detail, round detail (white cards on black with winner rings + point badges), live stats.
- [x] Auth control (Sign out / Sign in popover) restyled to match.

## Screenshots
Competition detail, round detail (cards on black), and live stats all render in the stark black/white SpaceX aesthetic — verified via preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
