### PR TITLE
Record lobby games as browsable JSON + Lobby games tab

### DIFF
--- a/server/game/BUILD
+++ b/server/game/BUILD
@@ -2,8 +2,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "game",
-    srcs = ["game.h", "round.h", "trick.h", "remote_player.h", "game_observer.h"],
-    deps = ["//server/game/objects"],
+    srcs = ["game.h", "round.h", "trick.h", "remote_player.h", "game_observer.h", "game_recorder.h"],
+    deps = ["//server/game/objects", "@nlohmann_json//:json"],
     visibility = [
         "//server:__pkg__",
         "//server/matching:__pkg__",

--- a/server/game/game_recorder.h
+++ b/server/game/game_recorder.h
@@ -1,0 +1,340 @@
+#pragma once
+
+// Shared game-recording machinery used by both the tournament server and the
+// regular (lobby) server. A RecordingObserver accumulates per-game structure
+// (rounds, passes, tricks, scores, latency) during play; the helpers below turn
+// that into the browsable detail JSON the web UI reads.
+//
+// Tournament-specific fields (stage, placement points, slot mapping) live on the
+// same GameResult struct but are simply left empty for lobby games.
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "game_observer.h"
+
+namespace Common::Game {
+
+using json = nlohmann::json;
+
+// ─── Game result collection ───────────────────────────────────────────────────
+
+struct TrickRecord {
+    std::string firstPlayer;
+    std::vector<std::string> playerTags; // play order (playerTags[i] played cards[i])
+    std::vector<std::string> cards;
+    std::string winner;
+    int points;
+};
+
+struct RoundRecord {
+    int roundIdx;
+    std::string passDir;
+    std::map<std::string, std::vector<std::string>> cardsPassed;   // playerTagSession → 3 cards passed
+    std::map<std::string, std::vector<std::string>> handsAfterPass;
+    std::vector<TrickRecord> tricks;
+    std::map<std::string, int> roundScores;
+};
+
+struct GameResult {
+    std::string gameId;
+    std::string stage;
+    std::vector<std::string> playerOrder; // actual seating order (rotation around table)
+    std::map<std::string, int> finalScores;
+    std::string winner;
+    int roundsPlayed = 0;
+    std::map<std::string, int> moonShots;
+    std::map<std::string, long> totalMoveLatencyMs;
+    std::map<std::string, int> autoMoveCount;
+    // Latency breakdown (only for non-auto moves with metadata)
+    std::map<std::string, long> totalS2CMs;       // server→client (move_request delivery)
+    std::map<std::string, long> totalC2SMs;       // client→server (decided_move delivery)
+    std::map<std::string, long> totalThinkMs;     // client think time
+    std::map<std::string, long> maxThinkMs;       // per-player max think time
+    std::map<std::string, long> maxS2CMs;         // per-player max s2c
+    std::map<std::string, long> maxC2SMs;         // per-player max c2s
+    std::map<std::string, long> maxMoveLatencyMs; // per-player max total move time (server wall clock)
+    std::map<std::string, int>  latencyCount;     // number of moves with latency data
+    std::vector<RoundRecord> rounds;
+
+    // Placement points awarded in qualifying (tournament only)
+    std::map<std::string, int> placementPoints;
+
+    // Maps "playerTag(sessionId)" → slotId for score aggregation (tournament only)
+    std::map<std::string, std::string> playerTagToSlotId;
+};
+
+class RecordingObserver : public GameObserver {
+public:
+    GameResult result;
+
+    explicit RecordingObserver(const std::string& gameId, const std::string& stage = "lobby")
+    {
+        result.gameId = gameId;
+        result.stage  = stage;
+    }
+
+    void onStartRound(int roundIdx, const std::string& passDir) override
+    {
+        RoundRecord r;
+        r.roundIdx  = roundIdx;
+        r.passDir   = passDir;
+        result.rounds.push_back(std::move(r));
+    }
+
+    void onHandsAfterPass(const std::map<std::string, std::vector<std::string>>& hands) override
+    {
+        if (!result.rounds.empty())
+            result.rounds.back().handsAfterPass = hands;
+    }
+
+    void onCardsPassed(const std::map<std::string, std::vector<std::string>>& passed) override
+    {
+        if (!result.rounds.empty())
+            result.rounds.back().cardsPassed = passed;
+    }
+
+    void onTrickComplete(const std::vector<std::string>& playerOrder,
+                          const std::vector<std::string>& cards,
+                          const std::string& winner, int points) override
+    {
+        std::string firstPlayer = playerOrder.empty() ? "" : playerOrder[0];
+        if (!result.rounds.empty())
+            result.rounds.back().tricks.push_back({firstPlayer, playerOrder, cards, winner, points});
+    }
+
+    void onRoundComplete(int /*roundIdx*/, const std::map<std::string, int>& scores) override
+    {
+        result.roundsPlayed++;
+        if (!result.rounds.empty())
+            result.rounds.back().roundScores = scores;
+    }
+
+    void onMove(const std::string& playerTag, long latencyMs, bool autoMoved,
+                long s2cMs, long c2sMs, long thinkMs) override
+    {
+        result.totalMoveLatencyMs[playerTag] += latencyMs;
+        result.maxMoveLatencyMs[playerTag]    = std::max(result.maxMoveLatencyMs[playerTag], latencyMs);
+        if (autoMoved)
+        {
+            result.autoMoveCount[playerTag]++;
+        }
+        else if (s2cMs >= 0 && c2sMs >= 0 && thinkMs >= 0)
+        {
+            result.totalS2CMs[playerTag]   += s2cMs;
+            result.totalC2SMs[playerTag]   += c2sMs;
+            result.totalThinkMs[playerTag] += thinkMs;
+            result.maxThinkMs[playerTag]    = std::max(result.maxThinkMs[playerTag], thinkMs);
+            result.maxS2CMs[playerTag]      = std::max(result.maxS2CMs[playerTag], s2cMs);
+            result.maxC2SMs[playerTag]      = std::max(result.maxC2SMs[playerTag], c2sMs);
+            result.latencyCount[playerTag]++;
+        }
+    }
+
+    void onMoonShot(const std::string& shooter) override
+    {
+        result.moonShots[shooter]++;
+    }
+
+    void onGameComplete(const std::map<std::string, int>& finalScores,
+                         const std::string& winner) override
+    {
+        result.finalScores = finalScores;
+        result.winner      = winner;
+        // playerOrder is populated by the caller with the actual seating order.
+    }
+};
+
+// ─── Player ID helpers ────────────────────────────────────────────────────────
+
+// Standard player ID format: team/player_tag/slot/session_id
+// Truncated from the right when components are unavailable.
+//
+// toFullId: converts "playerTag(sessionId)" → "team/player_tag/slot/session_id"
+//   using the tagToSlotId map (which carries the team/player_tag/slot part).
+//   For lobby games tagToSlotId is empty, so the raw "playerTag(sessionId)" is
+//   returned unchanged — still internally consistent across all maps.
+inline std::string toFullId(const std::string& playerTagSession,
+                            const std::map<std::string, std::string>& tagToSlotId)
+{
+    auto it = tagToSlotId.find(playerTagSession);
+    if (it == tagToSlotId.end()) return playerTagSession;          // fallback: unknown
+    auto open  = playerTagSession.rfind('(');
+    auto close = playerTagSession.rfind(')');
+    if (open == std::string::npos || close == std::string::npos || close <= open)
+        return it->second;                                         // slotId only
+    return it->second + "/" + playerTagSession.substr(open + 1, close - open - 1);
+}
+
+// Remap keys of m through toFullId; values are preserved unchanged.
+template<typename V>
+inline json remapKeys(const std::map<std::string, V>& m,
+                      const std::map<std::string, std::string>& tagToSlotId)
+{
+    json j = json::object();
+    for (const auto& [k, v] : m)
+        j[toFullId(k, tagToSlotId)] = v;
+    return j;
+}
+
+// ─── Detail JSON (per-game rounds/tricks/hands) ───────────────────────────────
+
+inline json gameResultToDetailJson(const GameResult& gr)
+{
+    json j;
+    j["game_id"] = gr.gameId;
+
+    // Seating order — lets readers map moves[i] to the correct player.
+    // For each trick: find first_player's index in player_order, then moves[k]
+    // is player_order[(first_player_idx + k) % 4]'s card.
+    std::vector<std::string> fullOrder;
+    for (const auto& ts : gr.playerOrder)
+        fullOrder.push_back(toFullId(ts, gr.playerTagToSlotId));
+    j["player_order"] = fullOrder;
+
+    json rounds = json::array();
+    for (const auto& r : gr.rounds)
+    {
+        json rj;
+        rj["round_idx"]           = r.roundIdx;
+        rj["pass_direction"]      = r.passDir;
+        if (!r.cardsPassed.empty())
+            rj["cards_passed"]    = remapKeys(r.cardsPassed, gr.playerTagToSlotId);
+        rj["hands_after_passing"] = remapKeys(r.handsAfterPass, gr.playerTagToSlotId);
+
+        json tricks = json::array();
+        for (const auto& t : r.tricks)
+        {
+            json tj;
+            tj["first_player"] = toFullId(t.firstPlayer, gr.playerTagToSlotId);
+            tj["moves"]        = t.cards; // in play order starting from first_player
+            tj["winner"]       = toFullId(t.winner, gr.playerTagToSlotId);
+            tj["points"]       = t.points;
+            tricks.push_back(tj);
+        }
+        rj["tricks"]       = tricks;
+        rj["round_scores"] = remapKeys(r.roundScores, gr.playerTagToSlotId);
+        rounds.push_back(rj);
+    }
+    j["rounds"] = rounds;
+    return j;
+}
+
+// Compact the card arrays inside hands_after_passing sections of a JSON string.
+// Every player's hand (array of 2–3-char strings) is collapsed to one line;
+// the rest of the JSON keeps its normal indent.
+inline std::string compactHandArrays(const std::string& raw)
+{
+    std::string out;
+    out.reserve(raw.size());
+    std::size_t i = 0;
+    while (i < raw.size())
+    {
+        static const char kKey[] = "\"hands_after_passing\"";
+        auto found = raw.find(kKey, i);
+        if (found == std::string::npos) { out += raw.substr(i); break; }
+        // Copy up to and including the key
+        out += raw.substr(i, found - i + sizeof(kKey) - 1);
+        i = found + sizeof(kKey) - 1;
+        // Find the opening '{' of the value object
+        auto braceOpen = raw.find('{', i);
+        if (braceOpen == std::string::npos) { out += raw.substr(i); break; }
+        out += raw.substr(i, braceOpen - i + 1);
+        i = braceOpen + 1;
+        // Scan the hands object, compacting each player's card array
+        int depth = 1;
+        while (i < raw.size() && depth > 0)
+        {
+            char c = raw[i];
+            if      (c == '{') { ++depth; out += c; ++i; }
+            else if (c == '}') { --depth; if (depth > 0) out += c; ++i; }
+            else if (c == '[' && depth == 1)
+            {
+                // Compact this array to one line
+                auto end = raw.find(']', i);
+                if (end == std::string::npos) { out += c; ++i; continue; }
+                out += '[';
+                bool first = true;
+                std::size_t q = i + 1;
+                while (q <= end)
+                {
+                    auto q1 = raw.find('"', q);
+                    if (q1 == std::string::npos || q1 > end) break;
+                    auto q2 = raw.find('"', q1 + 1);
+                    if (q2 == std::string::npos || q2 > end) break;
+                    if (!first) out += ", ";
+                    out += '"'; out += raw.substr(q1 + 1, q2 - q1 - 1); out += '"';
+                    first = false;
+                    q = q2 + 1;
+                }
+                out += ']';
+                i = end + 1;
+            }
+            else { out += c; ++i; }
+        }
+        if (depth == 0) out += '}'; // closing brace of the hands object
+    }
+    return out;
+}
+
+// ─── Lobby result writing ─────────────────────────────────────────────────────
+//
+// Lobby (non-tournament) games are written under <resultsDir>/lobby/:
+//   <resultsDir>/lobby/games/<game_id>.json   detail (same shape as tournaments)
+//   <resultsDir>/lobby/index.json             append-only list of game metadata
+//
+// Concurrent games append to index.json under a process-wide mutex.
+
+inline json gameResultToLobbyIndexEntry(const GameResult& gr, const std::string& playedAt)
+{
+    json j;
+    j["game_id"]   = gr.gameId;
+    j["played_at"] = playedAt;
+    std::vector<std::string> order;
+    for (const auto& ts : gr.playerOrder)
+        order.push_back(toFullId(ts, gr.playerTagToSlotId));
+    j["player_order"]  = order;
+    j["winner"]        = toFullId(gr.winner, gr.playerTagToSlotId);
+    j["final_scores"]  = remapKeys(gr.finalScores, gr.playerTagToSlotId);
+    j["rounds_played"] = gr.roundsPlayed;
+    return j;
+}
+
+inline void writeLobbyGameResult(const std::filesystem::path& resultsDir,
+                                 const GameResult& gr, const std::string& playedAt)
+{
+    namespace fs = std::filesystem;
+    fs::path lobbyDir = resultsDir / "lobby";
+    fs::path gamesDir = lobbyDir / "games";
+    fs::create_directories(gamesDir);
+
+    // Per-game detail file.
+    {
+        std::ofstream f(gamesDir / (gr.gameId + ".json"));
+        f << compactHandArrays(gameResultToDetailJson(gr).dump(2));
+    }
+
+    // Append to the lobby index (guarded; games run concurrently).
+    static std::mutex sIndexMutex;
+    std::lock_guard<std::mutex> lock(sIndexMutex);
+    fs::path idxPath = lobbyDir / "index.json";
+    json arr = json::array();
+    if (fs::exists(idxPath))
+    {
+        std::ifstream in(idxPath);
+        try { in >> arr; } catch (...) { arr = json::array(); }
+        if (!arr.is_array()) arr = json::array();
+    }
+    arr.push_back(gameResultToLobbyIndexEntry(gr, playedAt));
+    std::ofstream out(idxPath);
+    out << arr.dump(2);
+}
+
+} // namespace Common::Game

--- a/server/matching/live_game.h
+++ b/server/matching/live_game.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <array>
+#include <thread>
 #include <utility>
 
+#include "server/game/game_recorder.h"
 #include "lobby.h"
 
 namespace Common::Server {
@@ -28,8 +31,43 @@ public:
 
     void startGame()
     {
-        Common::Game::Game game({mGamePlayers[0], mGamePlayers[1], mGamePlayers[2], mGamePlayers[3]}, mGameLogger);
-        std::thread(&Game::Game::runGame, game).detach();
+        // The LiveGame object is destroyed as soon as startGame() returns (its
+        // caller holds it on the stack), so everything the game thread needs is
+        // captured by value: the four players, the logger, and the recorder
+        // identity. The RecordingObserver lives inside the thread for the whole
+        // game and is used to write the browsable lobby JSON when it finishes.
+        std::array<Game::PlayerRef, 4> players =
+            {mGamePlayers[0], mGamePlayers[1], mGamePlayers[2], mGamePlayers[3]};
+        auto logger = mGameLogger;
+
+        // Shared YYYY-M-D_HH-MM-SS.mmm timestamp — same shape the web backend
+        // already parses for tournament directories.
+        std::string ts = Dates::GetStrDate('-') + "_" + Dates::GetStrTime('-');
+        std::string gameId   = ts + "_" + mGameID;
+        std::string playedAt = ts;
+        std::filesystem::path resultsDir =
+            EnvLoader->has("RESULTS_DIR") ? std::filesystem::path(ENV_STRING("RESULTS_DIR"))
+                                          : std::filesystem::path("results");
+
+        std::thread([players, logger, gameId, playedAt, resultsDir]() {
+            Common::Game::RecordingObserver recorder(gameId);
+            // Seating order = the order players were dealt into the game.
+            for (const auto& p : players)
+                recorder.result.playerOrder.push_back(p->getTagSession());
+
+            Common::Game::Game game(
+                {players[0], players[1], players[2], players[3]}, logger, &recorder);
+            game.runGame();
+
+            try
+            {
+                Common::Game::writeLobbyGameResult(resultsDir, recorder.result, playedAt);
+            }
+            catch (const std::exception& e)
+            {
+                logger->Log("Failed to write lobby game result: %s", e.what());
+            }
+        }).detach();
     }
 
 private:

--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -42,6 +42,7 @@
 #include "server/api/game_session.h"
 #include "server/game/game.h"
 #include "server/game/game_observer.h"
+#include "server/game/game_recorder.h"
 #include "server/game/remote_player.h"
 #include "server/util/assertions.h"
 #include "server/util/constants.h"
@@ -54,6 +55,16 @@ using namespace boost::asio;
 using namespace Common;
 using namespace Common::Server;
 using json = nlohmann::json;
+
+// Game-recording machinery shared with the regular (lobby) server.
+using Common::Game::TrickRecord;
+using Common::Game::RoundRecord;
+using Common::Game::GameResult;
+using Common::Game::RecordingObserver;
+using Common::Game::toFullId;
+using Common::Game::remapKeys;
+using Common::Game::gameResultToDetailJson;
+using Common::Game::compactHandArrays;
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -360,163 +371,13 @@ static std::vector<GameAssignment> scheduleGames(
     return assignments;
 }
 
-// ─── Game result collection ───────────────────────────────────────────────────
-
-struct TrickRecord {
-    std::string firstPlayer;
-    std::vector<std::string> playerTags; // play order (playerTags[i] played cards[i])
-    std::vector<std::string> cards;
-    std::string winner;
-    int points;
-};
-
-struct RoundRecord {
-    int roundIdx;
-    std::string passDir;
-    std::map<std::string, std::vector<std::string>> cardsPassed;   // playerTagSession → 3 cards passed
-    std::map<std::string, std::vector<std::string>> handsAfterPass;
-    std::vector<TrickRecord> tricks;
-    std::map<std::string, int> roundScores;
-};
-
-struct GameResult {
-    std::string gameId;
-    std::string stage;
-    std::vector<std::string> playerOrder; // actual seating order (rotation around table)
-    std::map<std::string, int> finalScores;
-    std::string winner;
-    int roundsPlayed = 0;
-    std::map<std::string, int> moonShots;
-    std::map<std::string, long> totalMoveLatencyMs;
-    std::map<std::string, int> autoMoveCount;
-    // Latency breakdown (only for non-auto moves with metadata)
-    std::map<std::string, long> totalS2CMs;       // server→client (move_request delivery)
-    std::map<std::string, long> totalC2SMs;       // client→server (decided_move delivery)
-    std::map<std::string, long> totalThinkMs;     // client think time
-    std::map<std::string, long> maxThinkMs;       // per-player max think time
-    std::map<std::string, long> maxS2CMs;         // per-player max s2c
-    std::map<std::string, long> maxC2SMs;         // per-player max c2s
-    std::map<std::string, long> maxMoveLatencyMs; // per-player max total move time (server wall clock)
-    std::map<std::string, int>  latencyCount;     // number of moves with latency data
-    std::vector<RoundRecord> rounds;
-
-    // Placement points awarded in qualifying
-    std::map<std::string, int> placementPoints;
-
-    // Maps "playerTag(sessionId)" → slotId for score aggregation
-    std::map<std::string, std::string> playerTagToSlotId;
-};
-
-class RecordingObserver : public Game::GameObserver {
-public:
-    GameResult result;
-
-    explicit RecordingObserver(const std::string& gameId, const std::string& stage)
-    {
-        result.gameId = gameId;
-        result.stage  = stage;
-    }
-
-    void onStartRound(int roundIdx, const std::string& passDir) override
-    {
-        RoundRecord r;
-        r.roundIdx  = roundIdx;
-        r.passDir   = passDir;
-        result.rounds.push_back(std::move(r));
-    }
-
-    void onHandsAfterPass(const std::map<std::string, std::vector<std::string>>& hands) override
-    {
-        if (!result.rounds.empty())
-            result.rounds.back().handsAfterPass = hands;
-    }
-
-    void onCardsPassed(const std::map<std::string, std::vector<std::string>>& passed) override
-    {
-        if (!result.rounds.empty())
-            result.rounds.back().cardsPassed = passed;
-    }
-
-    void onTrickComplete(const std::vector<std::string>& playerOrder,
-                          const std::vector<std::string>& cards,
-                          const std::string& winner, int points) override
-    {
-        std::string firstPlayer = playerOrder.empty() ? "" : playerOrder[0];
-        if (!result.rounds.empty())
-            result.rounds.back().tricks.push_back({firstPlayer, playerOrder, cards, winner, points});
-    }
-
-    void onRoundComplete(int /*roundIdx*/, const std::map<std::string, int>& scores) override
-    {
-        result.roundsPlayed++;
-        if (!result.rounds.empty())
-            result.rounds.back().roundScores = scores;
-    }
-
-    void onMove(const std::string& playerTag, long latencyMs, bool autoMoved,
-                long s2cMs, long c2sMs, long thinkMs) override
-    {
-        result.totalMoveLatencyMs[playerTag] += latencyMs;
-        result.maxMoveLatencyMs[playerTag]    = std::max(result.maxMoveLatencyMs[playerTag], latencyMs);
-        if (autoMoved)
-        {
-            result.autoMoveCount[playerTag]++;
-        }
-        else if (s2cMs >= 0 && c2sMs >= 0 && thinkMs >= 0)
-        {
-            result.totalS2CMs[playerTag]   += s2cMs;
-            result.totalC2SMs[playerTag]   += c2sMs;
-            result.totalThinkMs[playerTag] += thinkMs;
-            result.maxThinkMs[playerTag]    = std::max(result.maxThinkMs[playerTag], thinkMs);
-            result.maxS2CMs[playerTag]      = std::max(result.maxS2CMs[playerTag], s2cMs);
-            result.maxC2SMs[playerTag]      = std::max(result.maxC2SMs[playerTag], c2sMs);
-            result.latencyCount[playerTag]++;
-        }
-    }
-
-    void onMoonShot(const std::string& shooter) override
-    {
-        result.moonShots[shooter]++;
-    }
-
-    void onGameComplete(const std::map<std::string, int>& finalScores,
-                         const std::string& winner) override
-    {
-        result.finalScores = finalScores;
-        result.winner      = winner;
-        // playerOrder is populated with the actual seating order in runOneGame.
-    }
-};
-
 // ─── Result JSON writing ──────────────────────────────────────────────────────
-
-// Standard player ID format: team/player_tag/slot/session_id
-// Truncated from the right when components are unavailable.
 //
-// toFullId: converts "playerTag(sessionId)" → "team/player_tag/slot/session_id"
-//   using the tagToSlotId map (which carries the team/player_tag/slot part).
-static std::string toFullId(const std::string& playerTagSession,
-                             const std::map<std::string, std::string>& tagToSlotId)
-{
-    auto it = tagToSlotId.find(playerTagSession);
-    if (it == tagToSlotId.end()) return playerTagSession;          // fallback: unknown
-    auto open  = playerTagSession.rfind('(');
-    auto close = playerTagSession.rfind(')');
-    if (open == std::string::npos || close == std::string::npos || close <= open)
-        return it->second;                                         // slotId only
-    return it->second + "/" + playerTagSession.substr(open + 1, close - open - 1);
-}
-
-// Remap keys of m through toFullId; values are preserved unchanged.
-template<typename V>
-static json remapKeys(const std::map<std::string, V>& m,
-                      const std::map<std::string, std::string>& tagToSlotId)
-{
-    json j = json::object();
-    for (const auto& [k, v] : m)
-        j[toFullId(k, tagToSlotId)] = v;
-    return j;
-}
+// The GameResult struct, RecordingObserver, toFullId, remapKeys,
+// gameResultToDetailJson and compactHandArrays now live in the shared header
+// server/game/game_recorder.h (imported via the using-declarations above). Only
+// the tournament-specific summary JSON (placement points, stage, latency stats)
+// remains here.
 
 static json gameResultToSummaryJson(const GameResult& gr)
 {
@@ -571,104 +432,6 @@ static json gameResultToSummaryJson(const GameResult& gr)
     }
     j["players"] = players;
     return j;
-}
-
-static json gameResultToDetailJson(const GameResult& gr)
-{
-    json j;
-    j["game_id"] = gr.gameId;
-
-    // Seating order — lets readers map moves[i] to the correct player.
-    // For each trick: find first_player's index in player_order, then moves[k]
-    // is player_order[(first_player_idx + k) % 4]'s card.
-    std::vector<std::string> fullOrder;
-    for (const auto& ts : gr.playerOrder)
-        fullOrder.push_back(toFullId(ts, gr.playerTagToSlotId));
-    j["player_order"] = fullOrder;
-
-    json rounds = json::array();
-    for (const auto& r : gr.rounds)
-    {
-        json rj;
-        rj["round_idx"]           = r.roundIdx;
-        rj["pass_direction"]      = r.passDir;
-        if (!r.cardsPassed.empty())
-            rj["cards_passed"]    = remapKeys(r.cardsPassed, gr.playerTagToSlotId);
-        rj["hands_after_passing"] = remapKeys(r.handsAfterPass, gr.playerTagToSlotId);
-
-        json tricks = json::array();
-        for (const auto& t : r.tricks)
-        {
-            json tj;
-            tj["first_player"] = toFullId(t.firstPlayer, gr.playerTagToSlotId);
-            tj["moves"]        = t.cards; // in play order starting from first_player
-            tj["winner"]       = toFullId(t.winner, gr.playerTagToSlotId);
-            tj["points"]       = t.points;
-            tricks.push_back(tj);
-        }
-        rj["tricks"]       = tricks;
-        rj["round_scores"] = remapKeys(r.roundScores, gr.playerTagToSlotId);
-        rounds.push_back(rj);
-    }
-    j["rounds"] = rounds;
-    return j;
-}
-
-// Compact the card arrays inside hands_after_passing sections of a JSON string.
-// Every player's hand (array of 2–3-char strings) is collapsed to one line;
-// the rest of the JSON keeps its normal indent.
-static std::string compactHandArrays(const std::string& raw)
-{
-    std::string out;
-    out.reserve(raw.size());
-    std::size_t i = 0;
-    while (i < raw.size())
-    {
-        static const char kKey[] = "\"hands_after_passing\"";
-        auto found = raw.find(kKey, i);
-        if (found == std::string::npos) { out += raw.substr(i); break; }
-        // Copy up to and including the key
-        out += raw.substr(i, found - i + sizeof(kKey) - 1);
-        i = found + sizeof(kKey) - 1;
-        // Find the opening '{' of the value object
-        auto braceOpen = raw.find('{', i);
-        if (braceOpen == std::string::npos) { out += raw.substr(i); break; }
-        out += raw.substr(i, braceOpen - i + 1);
-        i = braceOpen + 1;
-        // Scan the hands object, compacting each player's card array
-        int depth = 1;
-        while (i < raw.size() && depth > 0)
-        {
-            char c = raw[i];
-            if      (c == '{') { ++depth; out += c; ++i; }
-            else if (c == '}') { --depth; if (depth > 0) out += c; ++i; }
-            else if (c == '[' && depth == 1)
-            {
-                // Compact this array to one line
-                auto end = raw.find(']', i);
-                if (end == std::string::npos) { out += c; ++i; continue; }
-                out += '[';
-                bool first = true;
-                std::size_t q = i + 1;
-                while (q <= end)
-                {
-                    auto q1 = raw.find('"', q);
-                    if (q1 == std::string::npos || q1 > end) break;
-                    auto q2 = raw.find('"', q1 + 1);
-                    if (q2 == std::string::npos || q2 > end) break;
-                    if (!first) out += ", ";
-                    out += '"'; out += raw.substr(q1 + 1, q2 - q1 - 1); out += '"';
-                    first = false;
-                    q = q2 + 1;
-                }
-                out += ']';
-                i = end + 1;
-            }
-            else { out += c; ++i; }
-        }
-        if (depth == 0) out += '}'; // closing brace of the hands object
-    }
-    return out;
 }
 
 // Forward declaration (defined after writeResults)

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -73,6 +73,19 @@ def game(competition_id: str, index: str, game_id: str,
     return auth.redact_game(detail, auth.principal_from_header(authorization))
 
 
+@app.get("/api/lobby/games")
+def lobby_games():
+    return results.list_lobby_games()
+
+
+@app.get("/api/lobby/games/{game_id}")
+def lobby_game(game_id: str):
+    detail = results.get_lobby_game(game_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="lobby game not found")
+    return detail
+
+
 @app.get("/api/live")
 def live():
     return results.get_live_stats()

--- a/web/backend/results.py
+++ b/web/backend/results.py
@@ -300,6 +300,52 @@ def get_game(competition_id: str, index: str, game_id: str) -> Optional[dict]:
     return _read_json(target)
 
 
+# ─── Lobby (practice) games ────────────────────────────────────────────────────
+#
+# The regular (non-tournament) server records every completed lobby game the same
+# way tournaments do, under <RESULTS_DIR>/lobby/:
+#   lobby/index.json          append-only array of game metadata (newest appended)
+#   lobby/games/<id>.json     full detail (player_order + rounds), same shape as
+#                             tournament game detail, so the existing game/round
+#                             views render it unchanged.
+# Lobby games are public practice games with no team secrecy, so passed cards are
+# returned to everyone (no redaction).
+
+def _lobby_dir() -> Path:
+    return results_dir() / "lobby"
+
+
+def list_lobby_games() -> list[dict]:
+    """All recorded lobby games, newest first."""
+    index = _read_json(_lobby_dir() / "index.json")
+    if not isinstance(index, list):
+        return []
+    out: list[dict] = []
+    for entry in index:
+        if not isinstance(entry, dict):
+            continue
+        played_at = entry.get("played_at")
+        out.append({
+            "game_id": entry.get("game_id"),
+            "played_at": parse_tournament_time(played_at) or played_at,
+            "player_order": entry.get("player_order", []),
+            "winner": entry.get("winner"),
+            "final_scores": entry.get("final_scores", {}),
+            "rounds_played": entry.get("rounds_played"),
+        })
+    out.sort(key=lambda g: (g["played_at"] or "", g["game_id"] or ""), reverse=True)
+    return out
+
+
+def get_lobby_game(game_id: str) -> Optional[dict]:
+    """Full detail for one lobby game (player_order + rounds), or None."""
+    base = _lobby_dir().resolve()
+    target = (base / "games" / f"{game_id}.json").resolve()
+    if base not in target.parents:
+        return None
+    return _read_json(target)
+
+
 # ─── Env / live stats ──────────────────────────────────────────────────────────
 
 def _parse_env_file(path: Path) -> dict[str, str]:

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -12,6 +12,7 @@ export function App() {
         </Link>
         <nav className="app-nav">
           <Link to="/">Competitions</Link>
+          <Link to="/lobby">Lobby games</Link>
         </nav>
         <AuthControl />
       </header>

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -114,6 +114,15 @@ export interface GameDetail {
   rounds: RoundRecord[]
 }
 
+export interface LobbyGameListEntry {
+  game_id: string
+  played_at: string | null
+  player_order: string[]
+  winner: string
+  final_scores: Record<string, number>
+  rounds_played: number | null
+}
+
 export interface LiveStats {
   competition_id: string | null
   tournament_index: string | null
@@ -154,6 +163,8 @@ export const api = {
   rules: (cid: string, index: string) => getJSON<TournamentRules>(`${tBase(cid, index)}/rules`),
   game: (cid: string, index: string, gameId: string) =>
     getJSON<GameDetail>(`${tBase(cid, index)}/games/${encodeURIComponent(gameId)}`),
+  lobbyGames: () => getJSON<LobbyGameListEntry[]>('/api/lobby/games'),
+  lobbyGame: (gameId: string) => getJSON<GameDetail>(`/api/lobby/games/${encodeURIComponent(gameId)}`),
   live: () => getJSON<LiveStats>('/api/live'),
   login: async (team: string | null, password: string): Promise<LoginResult> => {
     const res = await fetch('/api/login', {

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import { CompetitionDetail } from './pages/CompetitionDetail'
 import { TournamentDetail } from './pages/TournamentDetail'
 import { GameDetail } from './pages/GameDetail'
 import { RoundDetail } from './pages/RoundDetail'
+import { LobbyGamesList } from './pages/LobbyGamesList'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -19,6 +20,9 @@ createRoot(document.getElementById('root')!).render(
           <Route path="c/:cid/t/:index" element={<TournamentDetail />} />
           <Route path="c/:cid/t/:index/g/:gameId" element={<GameDetail />} />
           <Route path="c/:cid/t/:index/g/:gameId/r/:roundIdx" element={<RoundDetail />} />
+          <Route path="lobby" element={<LobbyGamesList />} />
+          <Route path="lobby/g/:gameId" element={<GameDetail lobby />} />
+          <Route path="lobby/g/:gameId/r/:roundIdx" element={<RoundDetail lobby />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/frontend/src/pages/GameDetail.tsx
+++ b/web/frontend/src/pages/GameDetail.tsx
@@ -5,10 +5,13 @@ import { useFetch } from '../lib/useFetch'
 import { nameResolver } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
 
-export function GameDetail() {
+export function GameDetail({ lobby = false }: { lobby?: boolean }) {
   const { cid = '', index = '', gameId = '' } = useParams()
   const navigate = useNavigate()
-  const { data, loading, error } = useFetch(() => api.game(cid, index, gameId), [cid, index, gameId])
+  const { data, loading, error } = useFetch(
+    () => (lobby ? api.lobbyGame(gameId) : api.game(cid, index, gameId)),
+    [cid, index, gameId, lobby],
+  )
 
   const totals = useMemo<Record<string, number>>(() => {
     const t: Record<string, number> = {}
@@ -29,13 +32,23 @@ export function GameDetail() {
   const rankOf = (p: string) => ranked.indexOf(p) + 1
 
   const roundHref = (roundIdx: number) =>
-    `/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}/g/${encodeURIComponent(gameId)}/r/${roundIdx}`
+    lobby
+      ? `/lobby/g/${encodeURIComponent(gameId)}/r/${roundIdx}`
+      : `/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}/g/${encodeURIComponent(gameId)}/r/${roundIdx}`
 
   return (
     <div>
       <div className="crumbs">
-        <Link to="/">Competitions</Link> / <Link to={`/c/${encodeURIComponent(cid)}`}>{cid}</Link> /{' '}
-        <Link to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}`}>#{index}</Link> / {gameId}
+        {lobby ? (
+          <>
+            <Link to="/lobby">Lobby games</Link> / {gameId}
+          </>
+        ) : (
+          <>
+            <Link to="/">Competitions</Link> / <Link to={`/c/${encodeURIComponent(cid)}`}>{cid}</Link> /{' '}
+            <Link to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}`}>#{index}</Link> / {gameId}
+          </>
+        )}
       </div>
       <h1>Game {gameId}</h1>
 

--- a/web/frontend/src/pages/LobbyGamesList.tsx
+++ b/web/frontend/src/pages/LobbyGamesList.tsx
@@ -1,0 +1,71 @@
+import { useNavigate } from 'react-router-dom'
+import { api } from '../api/client'
+import { useFetch } from '../lib/useFetch'
+import { nameResolver } from '../lib/playerId'
+import { PlayerName } from '../components/PlayerName'
+
+function formatTime(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+export function LobbyGamesList() {
+  const { data, loading, error } = useFetch(() => api.lobbyGames(), [])
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <h1>Lobby games</h1>
+      <p className="muted" style={{ marginTop: -8 }}>
+        Practice games played on the regular server (outside any tournament).
+      </p>
+      {loading ? (
+        <p className="muted">Loading lobby games…</p>
+      ) : error ? (
+        <p className="muted">Error: {error}</p>
+      ) : !data || data.length === 0 ? (
+        <p className="muted">No lobby games recorded yet.</p>
+      ) : (
+        <div className="card-surface">
+          <table className="data">
+            <thead>
+              <tr>
+                <th>Played</th>
+                <th>Players (seating)</th>
+                <th>Winner</th>
+                <th>Rounds</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((g) => {
+                const nameOf = nameResolver(g.player_order)
+                return (
+                  <tr
+                    key={g.game_id}
+                    className="row-link"
+                    onClick={() => navigate(`/lobby/g/${encodeURIComponent(g.game_id)}`)}
+                  >
+                    <td>{formatTime(g.played_at)}</td>
+                    <td style={{ fontSize: 12 }}>
+                      {g.player_order.map((p, i) => (
+                        <span key={p}>
+                          {i > 0 && <span className="muted"> · </span>}
+                          <PlayerName d={nameOf(p)} />
+                        </span>
+                      ))}
+                    </td>
+                    <td>
+                      <PlayerName d={nameOf(g.winner)} />
+                    </td>
+                    <td className="muted">{g.rounds_played ?? '—'}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -11,10 +11,13 @@ import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
 import { Card } from '../components/Card'
 import { useAuth } from '../lib/auth'
 
-export function RoundDetail() {
+export function RoundDetail({ lobby = false }: { lobby?: boolean }) {
   const { cid = '', index = '', gameId = '', roundIdx = '0' } = useParams()
   const auth = useAuth()
-  const { data, loading, error } = useFetch(() => api.game(cid, index, gameId), [cid, index, gameId, auth.token])
+  const { data, loading, error } = useFetch(
+    () => (lobby ? api.lobbyGame(gameId) : api.game(cid, index, gameId)),
+    [cid, index, gameId, lobby, auth.token],
+  )
   const round = data?.rounds[Number(roundIdx)]
   const [selected, setSelected] = useState<string>('')
   const [overlay, setOverlay] = useState<HandOverlayData | null>(null)
@@ -112,12 +115,21 @@ export function RoundDetail() {
   return (
     <div>
       <div className="crumbs">
-        <Link to="/">Competitions</Link> / <Link to={`/c/${encodeURIComponent(cid)}`}>{cid}</Link> /{' '}
-        <Link to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}`}>#{index}</Link> /{' '}
-        <Link to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}/g/${encodeURIComponent(gameId)}`}>
-          {gameId}
-        </Link>{' '}
-        / round {Number(roundIdx) + 1}
+        {lobby ? (
+          <>
+            <Link to="/lobby">Lobby games</Link> /{' '}
+            <Link to={`/lobby/g/${encodeURIComponent(gameId)}`}>{gameId}</Link> / round {Number(roundIdx) + 1}
+          </>
+        ) : (
+          <>
+            <Link to="/">Competitions</Link> / <Link to={`/c/${encodeURIComponent(cid)}`}>{cid}</Link> /{' '}
+            <Link to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}`}>#{index}</Link> /{' '}
+            <Link to={`/c/${encodeURIComponent(cid)}/t/${encodeURIComponent(index)}/g/${encodeURIComponent(gameId)}`}>
+              {gameId}
+            </Link>{' '}
+            / round {Number(roundIdx) + 1}
+          </>
+        )}
       </div>
       <h1>
         Round {Number(roundIdx) + 1} <span className="muted" style={{ fontSize: 15 }}>· pass {round.pass_direction}</span>
@@ -171,7 +183,7 @@ export function RoundDetail() {
                 Click a passed card to see this player's hand before passing.
               </p>
             )}
-            {!auth.isAdmin && passed.length === 0 && received.length === 0 && (
+            {!lobby && !auth.isAdmin && passed.length === 0 && received.length === 0 && (
               <p className="muted" style={{ fontSize: 12, margin: '12px 0 0' }}>
                 {auth.team
                   ? 'Passing is private to each player — select one of your team’s players to view theirs.'


### PR DESCRIPTION
## Summary
Phase 3 of the web UI: the regular (non-tournament) server now records every completed **lobby game** as JSON the same way tournaments do, and the web app gains a dedicated **Lobby games** tab to browse them with the existing game / round / trick views.

### Server
- Extracted the tournament server recording machinery (`RecordingObserver`, `GameResult`, detail-JSON helpers) into a shared `server/game/game_recorder.h` (`namespace Common::Game`). `tournament_server.cpp` now reuses it and keeps only its tournament-specific summary JSON — no behavior change for tournaments.
- `LiveGame::startGame` owns a `RecordingObserver` inside the game thread (the `LiveGame` stack object is gone by the time the thread runs) and writes `<RESULTS_DIR>/lobby/{index.json, games/<id>.json}` on completion. `RESULTS_DIR` defaults to `results`. Concurrent games append to `index.json` under a process-wide mutex.

### Web
- **Backend:** `GET /api/lobby/games` (list) and `GET /api/lobby/games/{id}` (detail). Lobby games are public practice games, so passed cards are returned unredacted.
- **Frontend:** a "Lobby games" nav tab + list page, reusing the Game/Round detail pages (via a `lobby` prop) and the `Card` / `TrickRow` / `HandOverlay` components.

## Test plan
- [x] `bazel build //server:server` and `//server:tournament_server` — both clean.
- [x] `bazel test //tests:all` — all pass (no tournament regression).
- [x] Ran 4 real lobby games (server + 4 random players); verified `lobby/index.json` (4 entries, correct winners, clean concurrent appends) and a detail file (player_order + rounds + cards_passed + hands_after_passing + tricks, hands of 13).
- [x] Backend endpoints return list (newest-first, ISO `played_at`) + detail; traversal/missing guards return None.
- [x] `npm run build` (tsc + vite) clean.
- [x] Browser: Lobby tab → list → game detail (rank columns) → round detail (13 trick rows, 52 cards, winner rings, point badges, public passing section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
