### PR TITLE
Live lobby play: browser-hosted human + AI Hearts games

### DIFF
--- a/clients/python/players/tim_claude_heuristic.py
+++ b/clients/python/players/tim_claude_heuristic.py
@@ -101,7 +101,9 @@ class TimClaudeHeuristic(Player):
             self._last_winner = winner
             self._streak = 1
 
-    def handle_move(self, player, card: Card) -> None:
+    def handle_move(self, player, card: Card,
+                    report_latency_ms: Optional[int] = None,
+                    decided_move_latency_ms: Optional[int] = None) -> None:
         self.played_cards.add(card)
         if card.suit == Suit.HEARTS:
             self.hearts_broken = True
@@ -212,7 +214,8 @@ class TimClaudeHeuristic(Player):
         return scored[:3]
 
     # ── playing ────────────────────────────────────────────────────────────
-    def get_move(self, trick: Trick, legal_moves: List[Card]) -> Card:
+    def get_move(self, trick: Trick, legal_moves: List[Card],
+                 move_request_latency_ms: Optional[int] = None) -> Card:
         assert legal_moves
         try:
             return self._move_inner(trick, legal_moves)

--- a/clients/python/players/tim_claude_player_moon_aggressive.py
+++ b/clients/python/players/tim_claude_player_moon_aggressive.py
@@ -86,7 +86,8 @@ class TimClaudePlayerMoonAggressive(ClaudePlayer):
         if score >= self.POST_RECEIVE_THRESHOLD:
             self.shooting = True
 
-    def get_move(self, trick: Trick, legal_moves: List[Card]) -> Card:
+    def get_move(self, trick: Trick, legal_moves: List[Card],
+                 move_request_latency_ms: Optional[int] = None) -> Card:
         if self.shooting:
             return self._shoot_move(trick, legal_moves)
         return super().get_move(trick, legal_moves)

--- a/clients/python/players/tim_claude_player_moon_reckless.py
+++ b/clients/python/players/tim_claude_player_moon_reckless.py
@@ -95,7 +95,8 @@ class TimClaudePlayerMoonReckless(ClaudePlayer):
         if score >= self.POST_RECEIVE_THRESHOLD:
             self.shooting = True
 
-    def get_move(self, trick: Trick, legal_moves: List[Card]) -> Card:
+    def get_move(self, trick: Trick, legal_moves: List[Card],
+                 move_request_latency_ms: Optional[int] = None) -> Card:
         if self.shooting:
             return self._shoot_move(trick, legal_moves)
         return super().get_move(trick, legal_moves)

--- a/clients/python/util/Env.py
+++ b/clients/python/util/Env.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import sys
 
 class EnvReader:
@@ -21,7 +22,26 @@ class EnvReader:
         return self.env_dict[key]
 
 
-ENV_FILEPATH = sys.argv[1] if len(sys.argv) > 1 else "./config.env"
+def _resolve_env_filepath() -> str:
+    """Locate the config .env file.
+
+    Priority:
+      1. HEARTS_CONFIG_ENV environment variable — lets the SDK be imported
+         in-process by hosts that own argv (e.g. uvicorn, where sys.argv[1]
+         is the ASGI app target like "main:app", not a config file).
+      2. sys.argv[1], but only if it points at an existing file (preserves the
+         long-standing `python player.py path/to/config.env` invocation).
+      3. ./config.env fallback.
+    """
+    override = os.environ.get("HEARTS_CONFIG_ENV")
+    if override:
+        return override
+    if len(sys.argv) > 1 and os.path.isfile(sys.argv[1]):
+        return sys.argv[1]
+    return "./config.env"
+
+
+ENV_FILEPATH = _resolve_env_filepath()
 ENV = EnvReader(ENV_FILEPATH)
 
 SERVER_IP = ENV.get("SERVER_ADDR")

--- a/config.env
+++ b/config.env
@@ -5,3 +5,9 @@ SERVER_ADDR=127.0.0.1
 LOG_DIR=./log
 TEAM_NAME=one
 TEAM_PASSWORD=one
+# Per-move wait before the lobby server gives up on a seat. Lobby play is
+# interactive, so this is generous: it sits just above the web backend's human
+# decision budget (HEARTS_HUMAN_TIMEOUT_S=115) and just below its SDK session
+# timeout (HEARTS_SDK_TIMEOUT_S=150). Combined with auto-move being disabled for
+# lobby sessions, a human is never played for under normal use.
+MOVE_TIMEOUT_MS=120000

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Run the complete Hearts dev environment in one command:
+#   * the C++ Hearts "lobby" server (handles matching + live games), and
+#   * the web UI (FastAPI backend + built React SPA), which talks to that server.
+#
+# Before starting anything, every required port is checked. If a port is already
+# taken the script EARLY-EXITS and tells you exactly which process is holding it
+# (PID + command) and how to free it — so the lobby server only ever launches on
+# a port that has been pre-sanitized.
+#
+# Usage:
+#   ./run.sh                      # build + run lobby server + serve web on 0.0.0.0:8000
+#   PORT=9000 ./run.sh            # override the web port
+#   SKIP_BUILD=1 ./run.sh         # serve the existing dist/ without rebuilding
+#   SKIP_SERVER=1 ./run.sh        # web only — don't build/run the C++ lobby server
+#
+# Env vars:
+#   HOST               web bind address        (default 0.0.0.0)
+#   PORT               web bind port           (default 8000)
+#   RESULTS_DIR        results location        (default <repo>/results)
+#   SKIP_BUILD         set to 1 to skip the npm build
+#   SKIP_SERVER        set to 1 to skip the C++ lobby server
+#
+# Auth (optional; controls who can see each round's private "cards passed"):
+#   WEB_ADMIN_PASSWORD admin login password — sign in with a blank team to see
+#                      every team's passed cards. If unset, admin login is off.
+#   Team login uses the TEAMS=name:password entries in tournament_server.env;
+#   a signed-in team sees only its own players' passed cards.
+
+set -e
+
+# Resolve paths relative to this script so it runs from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WEB_DIR="$SCRIPT_DIR/web"
+BACKEND_DIR="$WEB_DIR/backend"
+FRONTEND_DIR="$WEB_DIR/frontend"
+CONFIG_FILE="$SCRIPT_DIR/config.env"
+
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-8000}"
+RESULTS_DIR="${RESULTS_DIR:-$SCRIPT_DIR/results}"
+VENV="$BACKEND_DIR/.venv"
+RUN_SERVER=1
+[ "${SKIP_SERVER:-0}" = "1" ] && RUN_SERVER=0
+
+# The C++ lobby server reads its listen port from config.env (SERVER_PORT). The
+# web backend's live-play SDK connects to that same port, so they must agree.
+SERVER_PORT="${SERVER_PORT:-40405}"
+if [ -f "$CONFIG_FILE" ]; then
+    PARSED_PORT=$(grep "^SERVER_PORT=" "$CONFIG_FILE" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]' || true)
+    [ -n "$PARSED_PORT" ] && SERVER_PORT="$PARSED_PORT"
+fi
+
+# ============================================================================
+# PRE-FLIGHT — validate everything before starting any service
+# ============================================================================
+echo "==> Pre-flight checks"
+FAILED=0
+
+require_cmd() {  # require_cmd <command> <human label>
+    if command -v "$1" &> /dev/null; then
+        echo "  ✓ $2"
+    else
+        echo "  ✗ $2 not found in PATH"
+        FAILED=1
+    fi
+}
+
+require_file() {  # require_file <path> <human label>
+    if [ -f "$1" ]; then
+        echo "  ✓ $2"
+    else
+        echo "  ✗ $2 not found ($1)"
+        FAILED=1
+    fi
+}
+
+# Print the listener(s) on a TCP port, or nothing if it's free.
+port_pids() { lsof -ti tcp:"$1" -sTCP:LISTEN 2>/dev/null || true; }
+
+# Toolchain + project files.
+require_cmd python3 "Python 3"
+require_cmd npm "npm"
+require_file "$BACKEND_DIR/requirements.txt" "backend requirements.txt"
+require_file "$FRONTEND_DIR/package.json" "frontend package.json"
+require_file "$CONFIG_FILE" "config.env"
+if [ "$RUN_SERVER" = "1" ]; then
+    require_cmd bazel "Bazel (needed to build the C++ lobby server)"
+fi
+
+# Port availability. Collect every conflict first so the user sees them all at
+# once, with the exact process + kill command, then bail before doing any work.
+PORT_CONFLICTS=()
+check_port() {  # check_port <port> <label>
+    local p="$1" label="$2" pids
+    if ! command -v lsof &> /dev/null; then
+        echo "  ⚠ Cannot verify $label (port $p): lsof not found"
+        return
+    fi
+    pids="$(port_pids "$p")"
+    if [ -z "$pids" ]; then
+        echo "  ✓ $label (port $p) is free"
+        return
+    fi
+    FAILED=1
+    for pid in $pids; do
+        local cmd
+        cmd="$(ps -p "$pid" -o command= 2>/dev/null | sed 's/^[[:space:]]*//')"
+        echo "  ✗ $label (port $p) is in use by PID $pid: ${cmd:-unknown}"
+        PORT_CONFLICTS+=("port $p ($label): PID $pid — ${cmd:-unknown}")
+    done
+}
+
+check_port "$PORT" "web UI"
+[ "$RUN_SERVER" = "1" ] && check_port "$SERVER_PORT" "C++ lobby server"
+
+# ---- Early exit on any failure ---------------------------------------------
+if [ "$FAILED" != "0" ]; then
+    echo ""
+    if [ "${#PORT_CONFLICTS[@]}" -gt 0 ]; then
+        echo "❌ One or more required ports are already in use:"
+        echo ""
+        for c in "${PORT_CONFLICTS[@]}"; do
+            echo "   • $c"
+        done
+        # Build a de-duplicated kill command from the conflicting PIDs.
+        kill_pids="$(printf '%s\n' "${PORT_CONFLICTS[@]}" | grep -oE 'PID [0-9]+' | awk '{print $2}' | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+        echo ""
+        echo "   Free them by stopping those processes, e.g.:"
+        echo "       kill ${kill_pids}"
+        echo "   (use 'kill -9 ${kill_pids}' if they don't stop, or set PORT=... / SERVER_PORT=... to use different ports)"
+    fi
+    echo ""
+    echo "❌ Pre-flight failed — nothing was started. Fix the issues above and re-run."
+    exit 1
+fi
+
+echo ""
+echo "✅ Pre-flight passed"
+echo ""
+
+# ============================================================================
+# STARTUP — only after every check passed
+# ============================================================================
+
+# --- C++ lobby server --------------------------------------------------------
+if [ "$RUN_SERVER" = "1" ]; then
+    echo "==> Starting Hearts C++ lobby server on pre-sanitized port $SERVER_PORT"
+    cd "$SCRIPT_DIR"
+    bazel run //server:server -- "$CONFIG_FILE" &
+    SERVER_PID=$!
+    echo "    Lobby server PID: $SERVER_PID"
+    # Tear the server down when the web process (and thus this script) exits.
+    trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+    sleep 2
+else
+    echo "==> Skipping C++ lobby server (SKIP_SERVER=1)"
+fi
+
+# --- Python backend ----------------------------------------------------------
+echo "==> Setting up Python backend"
+if [ ! -d "$VENV" ]; then
+    echo "    Creating venv at $VENV"
+    python3 -m venv "$VENV"
+fi
+"$VENV/bin/pip" install -q -r "$BACKEND_DIR/requirements.txt"
+echo "    Backend dependencies installed"
+
+# --- Frontend ----------------------------------------------------------------
+echo "==> Setting up frontend"
+if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
+    echo "    Installing node modules"
+    npm --prefix "$FRONTEND_DIR" install
+fi
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+    echo "    Building frontend"
+    npm --prefix "$FRONTEND_DIR" run build
+else
+    echo "    Using existing dist/ (SKIP_BUILD=1)"
+fi
+if [ ! -d "$FRONTEND_DIR/dist" ]; then
+    echo "ERROR: $FRONTEND_DIR/dist not found; cannot serve the SPA." >&2
+    exit 1
+fi
+echo "    Frontend ready"
+
+echo ""
+echo "==> Serving web UI on http://$HOST:$PORT  (RESULTS_DIR=$RESULTS_DIR)"
+echo "Ready! Open http://localhost:$PORT in your browser"
+echo ""
+
+cd "$BACKEND_DIR"
+exec env RESULTS_DIR="$RESULTS_DIR" "$VENV/bin/uvicorn" main:app --host "$HOST" --port "$PORT"

--- a/server/api/managed_connection.h
+++ b/server/api/managed_connection.h
@@ -59,6 +59,11 @@ public:
         playerGameSessions.emplace(sessionId, std::move(parts));
     }
 
+    // Auto-move threshold applied to sessions that ConnectionListener auto-registers
+    // (the client-initiated path). The lobby server sets this to 0 so a human's turn
+    // never times out into a server-played move. Defaults to 2 (tournament behavior).
+    void setNewSessionAutoMoveThreshold(int threshold) { mNewSessionAutoMoveThreshold = threshold; }
+
     void ConnectionListener(
         const std::function<PlayerGameSessionID (ManagedConnection &, Message::Message)> &new_session_callback,
         const std::function<bool(const Message::Message &)> &is_new_session =
@@ -70,8 +75,10 @@ public:
                 if (is_new_session(message)) {
                     PlayerGameSessionID sessionID = new_session_callback(*this, message);
                     {
+                        auto parts = std::make_unique<SessionParts>();
+                        parts->autoMoveThreshold = mNewSessionAutoMoveThreshold;
                         std::lock_guard<std::mutex> lock(mSessionsMtx);
-                        playerGameSessions.emplace(sessionID, std::make_unique<SessionParts>());
+                        playerGameSessions.emplace(sessionID, std::move(parts));
                     }
                 } else {
                     auto sessionId = message.getJson()[Tags::SESSION_ID].get<PlayerGameSessionID>();
@@ -209,6 +216,7 @@ public:
 private:
     std::mutex mSessionsMtx;
     std::unordered_map<PlayerGameSessionID, std::unique_ptr<SessionParts>> playerGameSessions;
+    int mNewSessionAutoMoveThreshold = 2;
 };
 
 }

--- a/server/matching/matcher.h
+++ b/server/matching/matcher.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <chrono>
+
 #include "server/api/game_session.h"
 #include "server/game/remote_player.h"
 #include "server/util/dates.h"
+#include "server/util/env.h"
 #include "lobby.h"
 
 namespace Common::Server
@@ -45,7 +48,16 @@ public:
     SessionRef createPlayerGameSession(ManagedConnection &connection, const PlayerTag& playerTag)
     {
         auto sessionID = sessionCounter.fetch_add(1, std::memory_order_relaxed);
-        auto session = std::make_shared<PlayerGameSession>(sessionID, playerTag, connection);
+        // Allow the regular server's per-move wait to be tuned via config so that
+        // interactive (human) lobby players get enough time to think. Mirrors the
+        // tournament server's MOVE_TIMEOUT_MS handling; defaults to 15s otherwise.
+        std::chrono::milliseconds moveTimeout = std::chrono::seconds(15);
+        if (EnvLoader && EnvLoader->has("MOVE_TIMEOUT_MS"))
+        {
+            moveTimeout = std::chrono::milliseconds(std::stoi(ENV_STRING("MOVE_TIMEOUT_MS")));
+        }
+        auto session = std::make_shared<PlayerGameSession>(sessionID, playerTag, connection,
+                                                           /*starting_seq=*/1, moveTimeout);
         session->Setup();
         return session;
     }

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -33,6 +33,11 @@ int main(int argc, char **argv)
             acceptor.accept(*socket);
             auto & connection = connections.emplace_back(std::make_unique<ManagedConnection>(socket));
             auto* conn_ptr = connection.get();
+            // Lobby play is interactive: a human seat must be able to take as long
+            // as it likes without the server timing out and playing for them. Unlike
+            // the tournament server (which auto-moves after N timeouts to keep a bracket
+            // moving), disable auto-move entirely here.
+            conn_ptr->setNewSessionAutoMoveThreshold(0);
             std::thread([conn_ptr]() {
                 conn_ptr->ConnectionListener(Matcher::HandleSessionRequest);
             }).detach();

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -1,0 +1,580 @@
+"""Live lobby play: browser-hosted human + AI players against the running C++ server.
+
+This module bridges three worlds:
+
+  * the React frontend, over a WebSocket (one connection per browser "client"),
+  * FastAPI's asyncio event loop, and
+  * the Hearts Python SDK, whose ``GameSession.run_game`` runs in a blocking
+    thread doing socket I/O against the C++ game server.
+
+A :class:`Table` owns up to four seats. Each seat is filled by either an AI
+player (an existing SDK ``Player`` subclass) or a human (a dynamically created
+``Player`` subclass whose ``get_move`` / ``get_cards_to_pass`` block on a
+thread-safe queue while the browser is prompted over the WebSocket). When the
+table is started we spawn one ``GameSession`` per seat, all sharing a unique
+lobby code, so the server's FIFO matcher pairs them into a single game.
+
+Public game state is reconstructed from the SDK observer hooks. Because all four
+seat threads observe the same public events, every update is written
+*idempotently* keyed by round/trick index, so concurrent writers converge.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import random
+import string
+import sys
+import threading
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# --- SDK bootstrap -----------------------------------------------------------
+# The SDK imports as ``clients.python.*`` from the repo root and reads its
+# connection target from a config .env at import time. Under uvicorn ``sys.argv``
+# is the ASGI target (e.g. "main:app"), so we point the SDK at a config file via
+# the HEARTS_CONFIG_ENV override (see clients/python/util/Env.py).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+os.environ.setdefault("HEARTS_CONFIG_ENV", str(_REPO_ROOT / "config.env"))
+
+from clients.python.api.networking.ManagedConnection import ManagedConnection  # noqa: E402
+from clients.python.api.networking.SessionHelpers import MakeSession  # noqa: E402
+from clients.python.api.Player import Player  # noqa: E402
+from clients.python.api.types.Card import Card  # noqa: E402
+from clients.python.util.Constants import GameType  # noqa: E402
+from clients.python.players.random_player import RandomPlayer  # noqa: E402
+from clients.python.players.rob_player import RobPlayer  # noqa: E402
+from clients.python.players.claude_player import RobClaudePlayer  # noqa: E402
+
+# AI personalities the browser can drop into a seat.
+AI_TYPES: Dict[str, type] = {
+    "random": RandomPlayer,
+    "rob": RobPlayer,
+    "claude": RobClaudePlayer,
+}
+
+# Timing budget for a human move. The server auto-moves after MOVE_TIMEOUT_MS
+# (configured when launching the server); we return a fallback just under that
+# so the human's decided_move stays ahead of the server's auto-move, and the SDK
+# session timeout sits above both so waiting seat threads don't give up early.
+HUMAN_DECISION_TIMEOUT_S = float(os.environ.get("HEARTS_HUMAN_TIMEOUT_S", "115"))
+SDK_SESSION_TIMEOUT_S = int(os.environ.get("HEARTS_SDK_TIMEOUT_S", "150"))
+
+_ABORT = object()  # sentinel pushed onto a seat queue to unblock a thinking human
+
+
+def _pid(player_tag_session) -> str:
+    """Full server-side id, e.g. ``"alice_0_AB12(1003)"``."""
+    return str(player_tag_session)
+
+
+def _sanitize(name: str) -> str:
+    cleaned = "".join(ch for ch in name if ch.isalnum() or ch in "_-")
+    return cleaned[:24] or "player"
+
+
+# --- Seat & player bridge ----------------------------------------------------
+
+
+@dataclass
+class Seat:
+    index: int
+    seat_id: str
+    kind: str = "empty"  # "empty" | "human" | "ai"
+    name: str = ""
+    ai_type: Optional[str] = None
+    owner_client_id: Optional[str] = None
+    # Runtime (populated when the game starts)
+    player_tag: Optional[str] = None
+    pid: Optional[str] = None  # resolved "tag(session)" once the game begins
+    pending: Optional[dict] = None
+    response_queue: "queue.Queue" = field(default_factory=queue.Queue)
+    cards_ref: List[Card] = field(default_factory=list)  # live hand reference
+
+    def public_view(self, client_id: Optional[str]) -> dict:
+        return {
+            "index": self.index,
+            "seat_id": self.seat_id,
+            "kind": self.kind,
+            "name": self.name,
+            "ai_type": self.ai_type,
+            "mine": self.kind == "human" and self.owner_client_id == client_id,
+        }
+
+
+class WebHumanPlayer(Player):
+    """Base for per-seat human players. Concrete subclasses are created at game
+    start with ``player_tag`` / ``_table`` / ``_seat`` set as class attributes
+    (``GameSession`` instantiates players with only a PlayerTagSession)."""
+
+    player_tag = None
+    _table: "Table" = None
+    _seat: Seat = None
+
+    def __init__(self, player_tag_session):
+        super().__init__(player_tag_session)
+        self._seat.pid = _pid(player_tag_session)
+
+    # -- observer hooks: narrate public state -------------------------------
+    def initialize_for_game(self, game):
+        self._table.on_init(game)
+
+    def handle_new_round(self, round):
+        self._seat.cards_ref = round.cards_in_hand  # live, mutated by framework
+        self._table.on_new_round(round)
+
+    def handle_new_trick(self, trick):
+        self._table.on_new_trick(trick)
+
+    def handle_move(self, player, card, report_latency_ms=None, decided_move_latency_ms=None):
+        self._table.on_move(player, card)
+
+    def handle_finished_trick(self, trick, winning_player):
+        self._table.on_finished_trick(trick, winning_player)
+
+    def handle_finished_round(self, round, round_points):
+        self._table.on_finished_round(round, round_points)
+
+    def handle_end_game(self, players_to_points, winner):
+        self._table.on_end_game(players_to_points, winner)
+
+    def receive_passed_cards(self, cards, pass_dir, donating_player):
+        self._table.schedule_broadcast()
+
+    # -- decisions: block on the browser ------------------------------------
+    def get_cards_to_pass(self, pass_dir, receiving_player):
+        seat = self._seat
+        hand = [str(c) for c in seat.cards_ref]
+        seat.pending = {
+            "kind": "pass",
+            "hand": hand,
+            "pass_direction": pass_dir.value,
+            "receiving_player": _pid(receiving_player),
+        }
+        self._table.schedule_broadcast()
+        chosen = self._await_response()
+        seat.pending = None
+        cards = self._coerce_pass(chosen, seat.cards_ref)
+        self._table.schedule_broadcast()
+        return cards
+
+    def get_move(self, trick, legal_moves, move_request_latency_ms=None):
+        seat = self._seat
+        legal = [str(c) for c in legal_moves]
+        hand = [str(c) for c in seat.cards_ref]
+        seat.pending = {"kind": "move", "hand": hand, "legal_moves": legal, "trick_idx": trick.trick_idx}
+        self._table.set_turn(seat.pid)
+        self._table.schedule_broadcast()
+        chosen = self._await_response()
+        seat.pending = None
+        card = self._coerce_move(chosen, legal_moves)
+        self._table.schedule_broadcast()
+        return card
+
+    # -- helpers ------------------------------------------------------------
+    def _await_response(self):
+        try:
+            return self._seat.response_queue.get(timeout=HUMAN_DECISION_TIMEOUT_S)
+        except queue.Empty:
+            return _ABORT
+
+    @staticmethod
+    def _coerce_move(chosen, legal_moves: List[Card]) -> Card:
+        if isinstance(chosen, str):
+            try:
+                card = Card(chosen)
+                if card in legal_moves:
+                    return card
+            except Exception:
+                pass
+        return legal_moves[0]  # fallback: timeout / disconnect / invalid
+
+    @staticmethod
+    def _coerce_pass(chosen, hand: List[Card]) -> List[Card]:
+        if isinstance(chosen, list):
+            picked: List[Card] = []
+            for c in chosen:
+                try:
+                    card = Card(c)
+                except Exception:
+                    continue
+                if card in hand and card not in picked:
+                    picked.append(card)
+            if len(picked) == 3:
+                return picked
+        # fallback: first three cards in hand
+        return list(hand)[:3]
+
+
+def _make_human_cls(table: "Table", seat: Seat) -> type:
+    return type(
+        f"WebHuman_{seat.player_tag}",
+        (WebHumanPlayer,),
+        {"player_tag": seat.player_tag, "_table": table, "_seat": seat},
+    )
+
+
+def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
+    """Subclass an existing AI player so it keeps its strategy but also narrates
+    public state to the table via the observer hooks."""
+
+    def initialize_for_game(self, game):
+        base_cls.initialize_for_game(self, game)
+        table.on_init(game)
+
+    def handle_new_round(self, round):
+        base_cls.handle_new_round(self, round)
+        table.on_new_round(round)
+
+    def handle_new_trick(self, trick):
+        base_cls.handle_new_trick(self, trick)
+        table.on_new_trick(trick)
+
+    def handle_move(self, player, card, report_latency_ms=None, decided_move_latency_ms=None):
+        base_cls.handle_move(self, player, card,
+                             report_latency_ms=report_latency_ms,
+                             decided_move_latency_ms=decided_move_latency_ms)
+        table.on_move(player, card)
+
+    def handle_finished_trick(self, trick, winning_player):
+        base_cls.handle_finished_trick(self, trick, winning_player)
+        table.on_finished_trick(trick, winning_player)
+
+    def handle_finished_round(self, round, round_points):
+        base_cls.handle_finished_round(self, round, round_points)
+        table.on_finished_round(round, round_points)
+
+    def handle_end_game(self, players_to_points, winner):
+        base_cls.handle_end_game(self, players_to_points, winner)
+        table.on_end_game(players_to_points, winner)
+
+    return type(
+        f"WebAI_{seat.player_tag}",
+        (base_cls,),
+        {
+            "player_tag": seat.player_tag,
+            "initialize_for_game": initialize_for_game,
+            "handle_new_round": handle_new_round,
+            "handle_new_trick": handle_new_trick,
+            "handle_move": handle_move,
+            "handle_finished_trick": handle_finished_trick,
+            "handle_finished_round": handle_finished_round,
+            "handle_end_game": handle_end_game,
+        },
+    )
+
+
+# --- Table -------------------------------------------------------------------
+
+
+class Table:
+    def __init__(self, code: str):
+        self.code = code
+        self.lobby_code = f"weblive_{code}_{uuid.uuid4().hex[:8]}"
+        self.seats: List[Seat] = [Seat(index=i, seat_id=f"seat-{i}") for i in range(4)]
+        self.status = "lobby"  # "lobby" | "playing" | "finished"
+
+        # WebSocket clients (browser connections) keyed by client_id.
+        self.clients: Dict[str, object] = {}
+        self.loop = None  # asyncio loop, captured on first WS connect
+
+        # SDK runtime
+        self.connection: Optional[ManagedConnection] = None
+        self.threads: List[threading.Thread] = []
+
+        # Public reconstructed state (guarded by _state_lock)
+        self._state_lock = threading.Lock()
+        self._player_order: List[str] = []
+        self._players: Dict[str, dict] = {}  # pid -> {name, seat_id, kind}
+        self._round_idx: Optional[int] = None
+        self._pass_direction: Optional[str] = None
+        self._current_trick: dict = {"trick_idx": None, "moves": {}, "order": [], "leader": None}
+        self._completed_tricks: Dict[int, dict] = {}  # current round only
+        self._round_results: Dict[int, Dict[str, int]] = {}
+        self._turn: Optional[str] = None
+        self._winner: Optional[str] = None
+        self._final_points: Dict[str, int] = {}
+
+    # -- seat management (lobby phase) --------------------------------------
+    def _seat(self, seat_id: str) -> Optional[Seat]:
+        return next((s for s in self.seats if s.seat_id == seat_id), None)
+
+    def add_human(self, seat_id: str, name: str, client_id: str) -> Optional[str]:
+        if self.status != "lobby":
+            return "Game already started"
+        seat = self._seat(seat_id)
+        if seat is None:
+            return "No such seat"
+        seat.kind = "human"
+        seat.name = _sanitize(name) if name else f"You-{seat.index}"
+        seat.ai_type = None
+        seat.owner_client_id = client_id
+        return None
+
+    def add_ai(self, seat_id: str, ai_type: str, name: str = "") -> Optional[str]:
+        if self.status != "lobby":
+            return "Game already started"
+        if ai_type not in AI_TYPES:
+            return f"Unknown AI type '{ai_type}'"
+        seat = self._seat(seat_id)
+        if seat is None:
+            return "No such seat"
+        seat.kind = "ai"
+        seat.ai_type = ai_type
+        seat.name = _sanitize(name) if name else f"{ai_type}-{seat.index}"
+        seat.owner_client_id = None
+        return None
+
+    def clear_seat(self, seat_id: str) -> Optional[str]:
+        if self.status != "lobby":
+            return "Game already started"
+        seat = self._seat(seat_id)
+        if seat is None:
+            return "No such seat"
+        seat.kind = "empty"
+        seat.name = ""
+        seat.ai_type = None
+        seat.owner_client_id = None
+        return None
+
+    # -- start --------------------------------------------------------------
+    def start(self) -> Optional[str]:
+        """Spawn one SDK GameSession per seat (blocking; run off the event loop)."""
+        if self.status != "lobby":
+            return "Game already started"
+        if any(s.kind == "empty" for s in self.seats):
+            return "All four seats must be filled before starting"
+
+        try:
+            self.connection = ManagedConnection(timeout_s=SDK_SESSION_TIMEOUT_S)
+        except Exception as e:  # server down / unreachable
+            return f"Could not connect to game server: {e}"
+
+        for seat in self.seats:
+            seat.player_tag = f"{_sanitize(seat.name)}_{seat.index}_{self.code}"
+            seat.response_queue = queue.Queue()
+            if seat.kind == "human":
+                player_cls = _make_human_cls(self, seat)
+            else:
+                player_cls = _make_ai_cls(self, seat, AI_TYPES[seat.ai_type])
+            try:
+                thread, _session = MakeSession(
+                    self.connection, GameType.ANY, player_cls,
+                    lobby_code=self.lobby_code, timeout_s=SDK_SESSION_TIMEOUT_S,
+                )
+            except Exception as e:
+                return f"Failed to create session for {seat.name}: {e}"
+            self.threads.append(thread)
+
+        self.status = "playing"
+        for thread in self.threads:
+            thread.start()
+        # Reap threads so we can flip to "finished" without blocking the loop.
+        threading.Thread(target=self._await_completion, daemon=True).start()
+        return None
+
+    def _await_completion(self):
+        for thread in self.threads:
+            thread.join()
+        with self._state_lock:
+            self.status = "finished"
+        self.schedule_broadcast()
+
+    def abort(self):
+        """Unblock any thinking humans so their sessions can finish/fall back."""
+        for seat in self.seats:
+            if seat.kind == "human":
+                seat.response_queue.put(_ABORT)
+
+    def submit_decision(self, seat_id: str, client_id: str, value) -> Optional[str]:
+        seat = self._seat(seat_id)
+        if seat is None:
+            return "No such seat"
+        if seat.kind != "human" or seat.owner_client_id != client_id:
+            return "Not your seat"
+        if seat.pending is None:
+            return "No decision pending"
+        seat.response_queue.put(value)
+        return None
+
+    # -- public-state narration (idempotent, multi-thread safe) -------------
+    def on_init(self, game):
+        with self._state_lock:
+            order = [_pid(p) for p in game.player_order]
+            self._player_order = order
+            for pts in game.player_order:
+                seat = self._seat_for_tag(pts.player_tag.tag)
+                self._players[_pid(pts)] = {
+                    "name": seat.name if seat else str(pts.player_tag),
+                    "seat_id": seat.seat_id if seat else None,
+                    "kind": seat.kind if seat else "ai",
+                }
+                if seat is not None:
+                    seat.pid = _pid(pts)
+        self.schedule_broadcast()
+
+    def on_new_round(self, round):
+        with self._state_lock:
+            if self._round_idx != round.round_idx:
+                self._round_idx = round.round_idx
+                self._pass_direction = round.pass_direction.value
+                self._current_trick = {"trick_idx": None, "moves": {}, "order": [], "leader": None}
+                self._completed_tricks = {}
+                self._turn = None
+        self.schedule_broadcast()
+
+    def on_new_trick(self, trick):
+        with self._state_lock:
+            if self._current_trick.get("trick_idx") != trick.trick_idx:
+                leader = _pid(trick.player_order[0]) if trick.player_order else None
+                self._current_trick = {
+                    "trick_idx": trick.trick_idx, "moves": {}, "order": [], "leader": leader,
+                }
+        self.schedule_broadcast()
+
+    def on_move(self, player, card):
+        pid = _pid(player)
+        with self._state_lock:
+            self._current_trick["moves"][pid] = str(card)
+            if pid not in self._current_trick["order"]:
+                self._current_trick["order"].append(pid)
+            if self._turn == pid:
+                self._turn = None
+        self.schedule_broadcast()
+
+    def on_finished_trick(self, trick, winning_player):
+        with self._state_lock:
+            self._completed_tricks[trick.trick_idx] = {
+                "trick_idx": trick.trick_idx,
+                "winner": _pid(winning_player),
+                "points": trick.get_current_point_value(),
+            }
+        self.schedule_broadcast()
+
+    def on_finished_round(self, round, round_points):
+        with self._state_lock:
+            self._round_results[round.round_idx] = {_pid(p): v for p, v in round_points.items()}
+        self.schedule_broadcast()
+
+    def on_end_game(self, players_to_points, winner):
+        with self._state_lock:
+            self._winner = _pid(winner)
+            self._final_points = {_pid(p): v for p, v in players_to_points.items()}
+        self.schedule_broadcast()
+
+    def set_turn(self, pid: Optional[str]):
+        with self._state_lock:
+            self._turn = pid
+
+    def _seat_for_tag(self, tag: str) -> Optional[Seat]:
+        return next((s for s in self.seats if s.player_tag == tag), None)
+
+    # -- snapshots ----------------------------------------------------------
+    def _cumulative_scores(self) -> Dict[str, int]:
+        scores = {pid: 0 for pid in self._player_order}
+        for result in self._round_results.values():
+            for pid, pts in result.items():
+                scores[pid] = scores.get(pid, 0) + pts
+        return scores
+
+    def _round_running_points(self) -> Dict[str, int]:
+        pts = {pid: 0 for pid in self._player_order}
+        for t in self._completed_tricks.values():
+            pts[t["winner"]] = pts.get(t["winner"], 0) + t["points"]
+        return pts
+
+    def _public_state(self) -> dict:
+        with self._state_lock:
+            ct = self._current_trick
+            moves = [{"player": pid, "card": ct["moves"][pid]} for pid in ct["order"]]
+            return {
+                "status": self.status,
+                "player_order": list(self._player_order),
+                "players": dict(self._players),
+                "round_idx": self._round_idx,
+                "pass_direction": self._pass_direction,
+                "scores": self._cumulative_scores(),
+                "round_points": self._round_running_points(),
+                "current_trick": {
+                    "trick_idx": ct["trick_idx"],
+                    "leader": ct["leader"],
+                    "moves": moves,
+                },
+                "completed_trick_count": len(self._completed_tricks),
+                "turn": self._turn,
+                "winner": self._winner,
+                "final_points": dict(self._final_points),
+            }
+
+    def snapshot_for(self, client_id: Optional[str]) -> dict:
+        mine = []
+        for seat in self.seats:
+            if seat.kind == "human" and seat.owner_client_id == client_id and seat.pid:
+                mine.append({
+                    "seat_id": seat.seat_id,
+                    "player_tag": seat.player_tag,
+                    "pid": seat.pid,
+                    "name": seat.name,
+                    "pending": seat.pending,
+                })
+        return {
+            "type": "state",
+            "table": {
+                "code": self.code,
+                "status": self.status,
+                "seats": [s.public_view(client_id) for s in self.seats],
+            },
+            "public": self._public_state() if self.status != "lobby" else None,
+            "you": {"client_id": client_id, "seats": mine},
+        }
+
+    # -- broadcast (thread -> asyncio bridge) -------------------------------
+    def schedule_broadcast(self):
+        loop = self.loop
+        if loop is None:
+            return
+        try:
+            import asyncio
+            asyncio.run_coroutine_threadsafe(self._broadcast(), loop)
+        except RuntimeError:
+            pass
+
+    async def _broadcast(self):
+        dead = []
+        for cid, ws in list(self.clients.items()):
+            try:
+                await ws.send_json(self.snapshot_for(cid))
+            except Exception:
+                dead.append(cid)
+        for cid in dead:
+            self.clients.pop(cid, None)
+
+
+# --- Registry ----------------------------------------------------------------
+
+
+class TableManager:
+    def __init__(self):
+        self._tables: Dict[str, Table] = {}
+        self._lock = threading.Lock()
+
+    def create(self) -> Table:
+        with self._lock:
+            for _ in range(20):
+                code = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
+                if code not in self._tables:
+                    break
+            table = Table(code)
+            self._tables[code] = table
+            return table
+
+    def get(self, code: str) -> Optional[Table]:
+        return self._tables.get(code.upper())
+
+
+manager = TableManager()

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -21,12 +21,16 @@ seat threads observe the same public events, every update is written
 
 from __future__ import annotations
 
+import importlib
+import inspect
 import os
+import pkgutil
 import queue
 import random
 import string
 import sys
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -47,16 +51,70 @@ from clients.python.api.networking.SessionHelpers import MakeSession  # noqa: E4
 from clients.python.api.Player import Player  # noqa: E402
 from clients.python.api.types.Card import Card  # noqa: E402
 from clients.python.util.Constants import GameType  # noqa: E402
-from clients.python.players.random_player import RandomPlayer  # noqa: E402
-from clients.python.players.rob_player import RobPlayer  # noqa: E402
-from clients.python.players.claude_player import RobClaudePlayer  # noqa: E402
+import clients.python.players as _players_pkg  # noqa: E402
 
-# AI personalities the browser can drop into a seat.
-AI_TYPES: Dict[str, type] = {
-    "random": RandomPlayer,
-    "rob": RobPlayer,
-    "claude": RobClaudePlayer,
-}
+
+# --- AI player discovery -----------------------------------------------------
+# Any unmodified ``Player`` subclass under ``clients/python/players/`` is offered
+# as a seat option — no per-client wiring here. Dropping a new player file in
+# makes it appear in the browser automatically. The live wrapper (_make_ai_cls)
+# is already strategy-agnostic, so a discovered class needs no changes.
+
+
+def _label_for(tag: str) -> str:
+    """Human label for a dropdown, e.g. ``rob_claude_player`` -> ``Rob Claude``."""
+    cleaned = tag.replace("_player", "").replace("_", " ").strip()
+    return cleaned.title() or tag
+
+
+def _discover_ai_types() -> Dict[str, dict]:
+    """Scan the players package for concrete, self-contained AI players.
+
+    A class qualifies when it is a concrete ``Player`` subclass *defined in* the
+    scanned module and declares ``player_tag`` directly on itself. The own-tag
+    requirement excludes wrappers such as ``DebuggerPlayer`` (which inherits its
+    tag and blocks on stdin) while keeping every real bot, including subclassed
+    strategy variants that set their own tag.
+    """
+    registry: Dict[str, dict] = {}
+    for mod_info in pkgutil.iter_modules(_players_pkg.__path__):
+        if mod_info.name.startswith("_"):
+            continue
+        try:
+            module = importlib.import_module(f"clients.python.players.{mod_info.name}")
+        except Exception:
+            continue  # a player file that fails to import just isn't offered
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(cls, Player) or cls is Player:
+                continue
+            if cls.__module__ != module.__name__:
+                continue  # imported into this module, not defined here
+            if "player_tag" not in cls.__dict__ or cls.player_tag is None:
+                continue
+            if inspect.isabstract(cls):
+                continue
+            registry[cls.player_tag] = {"cls": cls, "label": _label_for(cls.player_tag)}
+    return registry
+
+
+# AI personalities the browser can drop into a seat (keyed by player_tag).
+AI_TYPES: Dict[str, dict] = _discover_ai_types()
+
+
+def ai_type_options() -> List[dict]:
+    """``[{value, label}, ...]`` for the seat-picker dropdown, sorted by label."""
+    return [
+        {"value": tag, "label": meta["label"]}
+        for tag, meta in sorted(AI_TYPES.items(), key=lambda kv: kv[1]["label"])
+    ]
+
+
+def default_ai_type() -> Optional[str]:
+    """A sensible default seat AI (random if available, else the first option)."""
+    if "random_player" in AI_TYPES:
+        return "random_player"
+    opts = ai_type_options()
+    return opts[0]["value"] if opts else None
 
 # Timing budget for a human move. The server auto-moves after MOVE_TIMEOUT_MS
 # (configured when launching the server); we return a fallback just under that
@@ -66,6 +124,8 @@ HUMAN_DECISION_TIMEOUT_S = float(os.environ.get("HEARTS_HUMAN_TIMEOUT_S", "115")
 SDK_SESSION_TIMEOUT_S = int(os.environ.get("HEARTS_SDK_TIMEOUT_S", "150"))
 
 _ABORT = object()  # sentinel pushed onto a seat queue to unblock a thinking human
+
+LIVE_LOG_CAP = 60  # max activity-log entries kept per AI seat
 
 
 def _pid(player_tag_session) -> str:
@@ -97,6 +157,9 @@ class Seat:
     cards_ref: List[Card] = field(default_factory=list)  # live hand reference
     passed: List[str] = field(default_factory=list)      # cards I passed this round
     received: List[str] = field(default_factory=list)    # cards passed to me this round
+    # Activity log for AI seats (so the owning browser can watch what its bot is
+    # doing / whether it's hung). Each entry: {t, kind, text, pending}.
+    log: List[dict] = field(default_factory=list)
 
     def public_view(self, client_id: Optional[str]) -> dict:
         return {
@@ -120,14 +183,37 @@ class WebHumanPlayer(Player):
 
     def __init__(self, player_tag_session):
         super().__init__(player_tag_session)
+        self._round = None  # live ActiveRound, captured each round
         self._seat.pid = _pid(player_tag_session)
+
+    def _hand_strings(self) -> List[str]:
+        """The player's *true* current hand as 2-char codes.
+
+        The SDK never mutates ``round.cards_in_hand`` — it stays the originally
+        dealt 13 for the whole round — so we reconstruct from authoritative round
+        state: dealt cards, minus the cards we donated, plus the cards we
+        received, minus everything we've already played this round.
+        """
+        rnd = self._round
+        if rnd is None:
+            return []
+        me = self.player_tag_session
+        donated = list(getattr(rnd, "donating_cards", []) or [])
+        received = list(getattr(rnd, "received_cards", []) or [])
+        played = {m.card for t in rnd.tricks for m in t.moves if m.player == me}
+        hand = [c for c in rnd.cards_in_hand if c not in donated]
+        for c in received:
+            if c not in hand:
+                hand.append(c)
+        return [str(c) for c in hand if c not in played]
 
     # -- observer hooks: narrate public state -------------------------------
     def initialize_for_game(self, game):
         self._table.on_init(game)
 
     def handle_new_round(self, round):
-        self._seat.cards_ref = round.cards_in_hand  # live, mutated by framework
+        self._round = round  # authoritative source for _hand_strings()
+        self._seat.cards_ref = round.cards_in_hand  # dealt 13 (pass-pool fallback)
         self._seat.passed = []      # reset passing record for the new round
         self._seat.received = []
         self._table.on_new_round(round)
@@ -154,7 +240,7 @@ class WebHumanPlayer(Player):
     # -- decisions: block on the browser ------------------------------------
     def get_cards_to_pass(self, pass_dir, receiving_player):
         seat = self._seat
-        hand = [str(c) for c in seat.cards_ref]
+        hand = self._hand_strings()
         seat.pending = {
             "kind": "pass",
             "hand": hand,
@@ -172,7 +258,7 @@ class WebHumanPlayer(Player):
     def get_move(self, trick, legal_moves, move_request_latency_ms=None):
         seat = self._seat
         legal = [str(c) for c in legal_moves]
-        hand = [str(c) for c in seat.cards_ref]
+        hand = self._hand_strings()
         seat.pending = {"kind": "move", "hand": hand, "legal_moves": legal, "trick_idx": trick.trick_idx}
         self._table.set_turn(seat.pid)
         self._table.schedule_broadcast()
@@ -227,37 +313,91 @@ def _make_human_cls(table: "Table", seat: Seat) -> type:
 
 def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
     """Subclass an existing AI player so it keeps its strategy but also narrates
-    public state to the table via the observer hooks."""
+    public state to the table via the observer hooks, and logs its own decision
+    activity so the owning browser can watch what the bot is doing (and tell a
+    slow/hung bot apart from a broken live-play pipeline)."""
+
+    def _safe(label: str, fn):
+        """Run a base-class hook; if the bot's own code raises, surface the
+        error in its activity log before re-raising. An exception in an observer
+        hook (e.g. an outdated handle_move signature) otherwise kills the seat
+        thread silently — the log entry tells the operator it's the bot's fault."""
+        try:
+            return fn()
+        except Exception as exc:
+            table.log_seat(seat, "error", f"{label} raised {type(exc).__name__}: {exc}")
+            raise
 
     def initialize_for_game(self, game):
-        base_cls.initialize_for_game(self, game)
+        _safe("initialize_for_game", lambda: base_cls.initialize_for_game(self, game))
+        table.log_seat(seat, "game", "Joined game, waiting to start")
         table.on_init(game)
 
     def handle_new_round(self, round):
-        base_cls.handle_new_round(self, round)
+        _safe("handle_new_round", lambda: base_cls.handle_new_round(self, round))
+        table.log_seat(seat, "round", f"Round {round.round_idx + 1} — dealt {len(round.cards_in_hand)} cards")
         table.on_new_round(round)
 
     def handle_new_trick(self, trick):
-        base_cls.handle_new_trick(self, trick)
+        _safe("handle_new_trick", lambda: base_cls.handle_new_trick(self, trick))
         table.on_new_trick(trick)
 
     def handle_move(self, player, card, report_latency_ms=None, decided_move_latency_ms=None):
-        base_cls.handle_move(self, player, card,
-                             report_latency_ms=report_latency_ms,
-                             decided_move_latency_ms=decided_move_latency_ms)
+        _safe("handle_move", lambda: base_cls.handle_move(
+            self, player, card,
+            report_latency_ms=report_latency_ms,
+            decided_move_latency_ms=decided_move_latency_ms))
         table.on_move(player, card)
 
     def handle_finished_trick(self, trick, winning_player):
-        base_cls.handle_finished_trick(self, trick, winning_player)
+        _safe("handle_finished_trick", lambda: base_cls.handle_finished_trick(self, trick, winning_player))
         table.on_finished_trick(trick, winning_player)
 
     def handle_finished_round(self, round, round_points):
-        base_cls.handle_finished_round(self, round, round_points)
+        _safe("handle_finished_round", lambda: base_cls.handle_finished_round(self, round, round_points))
         table.on_finished_round(round, round_points)
 
     def handle_end_game(self, players_to_points, winner):
-        base_cls.handle_end_game(self, players_to_points, winner)
+        _safe("handle_end_game", lambda: base_cls.handle_end_game(self, players_to_points, winner))
+        table.log_seat(seat, "game", "Game over")
         table.on_end_game(players_to_points, winner)
+
+    # -- decision instrumentation: time the bot's own thinking --------------
+    def get_cards_to_pass(self, pass_dir, receiving_player):
+        table.log_seat(seat, "think", f"Choosing 3 cards to pass {pass_dir.value.lower()}…", pending=True)
+        t0 = time.time()
+        try:
+            cards = base_cls.get_cards_to_pass(self, pass_dir, receiving_player)
+        except Exception as exc:
+            table.log_seat(seat, "error", f"get_cards_to_pass raised {type(exc).__name__}: {exc}")
+            raise
+        ms = int((time.time() - t0) * 1000)
+        table.log_seat(seat, "pass", f"Passed {' '.join(str(c) for c in cards)} ({ms} ms)")
+        return cards
+
+    def get_move(self, trick, legal_moves, move_request_latency_ms=None):
+        table.log_seat(seat, "think",
+                       f"Thinking · trick {trick.trick_idx + 1} · {len(legal_moves)} legal…",
+                       pending=True)
+        t0 = time.time()
+        try:
+            card = base_cls.get_move(self, trick, legal_moves,
+                                     move_request_latency_ms=move_request_latency_ms)
+        except Exception as exc:
+            table.log_seat(seat, "error", f"get_move raised {type(exc).__name__}: {exc}")
+            raise
+        ms = int((time.time() - t0) * 1000)
+        table.log_seat(seat, "move", f"Played {card} ({ms} ms)")
+        return card
+
+    def handle_auto_move(self):
+        base_cls.handle_auto_move(self)
+        table.log_seat(seat, "error", "Server auto-moved (bot was too slow or returned an invalid move)")
+
+    def handle_auto_pass(self, cards):
+        base_cls.handle_auto_pass(self, cards)
+        table.log_seat(seat, "error",
+                       f"Server auto-passed {' '.join(str(c) for c in cards)} (bot was too slow or invalid)")
 
     return type(
         f"WebAI_{seat.player_tag}",
@@ -271,6 +411,10 @@ def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
             "handle_finished_trick": handle_finished_trick,
             "handle_finished_round": handle_finished_round,
             "handle_end_game": handle_end_game,
+            "get_cards_to_pass": get_cards_to_pass,
+            "get_move": get_move,
+            "handle_auto_move": handle_auto_move,
+            "handle_auto_pass": handle_auto_pass,
         },
     )
 
@@ -285,8 +429,11 @@ class Table:
         self.seats: List[Seat] = [Seat(index=i, seat_id=f"seat-{i}") for i in range(4)]
         self.status = "lobby"  # "lobby" | "playing" | "finished"
 
-        # WebSocket clients (browser connections) keyed by client_id.
-        self.clients: Dict[str, object] = {}
+        # WebSocket connections keyed by a unique per-connection id -> (ws,
+        # client_id). Keyed by connection (not client_id) so two sockets sharing
+        # a client_id both keep receiving broadcasts and closing one never evicts
+        # the other.
+        self.clients: Dict[str, tuple] = {}
         self.loop = None  # asyncio loop, captured on first WS connect
 
         # SDK runtime
@@ -322,7 +469,8 @@ class Table:
         seat.owner_client_id = client_id
         return None
 
-    def add_ai(self, seat_id: str, ai_type: str, name: str = "") -> Optional[str]:
+    def add_ai(self, seat_id: str, ai_type: str, name: str = "",
+               client_id: Optional[str] = None) -> Optional[str]:
         if self.status != "lobby":
             return "Game already started"
         if ai_type not in AI_TYPES:
@@ -333,7 +481,10 @@ class Table:
         seat.kind = "ai"
         seat.ai_type = ai_type
         seat.name = _sanitize(name) if name else f"{ai_type}-{seat.index}"
-        seat.owner_client_id = None
+        # Track which browser hosted this bot so we can show *that* browser the
+        # bot's activity log (it runs in this backend process either way).
+        seat.owner_client_id = client_id
+        seat.log = []
         return None
 
     def clear_seat(self, seat_id: str) -> Optional[str]:
@@ -346,6 +497,7 @@ class Table:
         seat.name = ""
         seat.ai_type = None
         seat.owner_client_id = None
+        seat.log = []
         return None
 
     # -- start --------------------------------------------------------------
@@ -367,7 +519,7 @@ class Table:
             if seat.kind == "human":
                 player_cls = _make_human_cls(self, seat)
             else:
-                player_cls = _make_ai_cls(self, seat, AI_TYPES[seat.ai_type])
+                player_cls = _make_ai_cls(self, seat, AI_TYPES[seat.ai_type]["cls"])
             try:
                 thread, _session = MakeSession(
                     self.connection, GameType.ANY, player_cls,
@@ -485,6 +637,20 @@ class Table:
         with self._state_lock:
             self._turn = pid
 
+    # -- AI activity log ----------------------------------------------------
+    def log_seat(self, seat: Seat, kind: str, text: str, *, pending: bool = False):
+        """Append an activity entry for an AI seat and push it to watchers.
+
+        ``pending=True`` marks an open-ended action (e.g. "thinking…") that the
+        frontend renders with a live elapsed timer until a later entry lands.
+        """
+        entry = {"t": time.time(), "kind": kind, "text": text, "pending": pending}
+        with self._state_lock:
+            seat.log.append(entry)
+            if len(seat.log) > LIVE_LOG_CAP:
+                del seat.log[: len(seat.log) - LIVE_LOG_CAP]
+        self.schedule_broadcast()
+
     def _seat_for_tag(self, tag: str) -> Optional[Seat]:
         return next((s for s in self.seats if s.player_tag == tag), None)
 
@@ -529,6 +695,7 @@ class Table:
 
     def snapshot_for(self, client_id: Optional[str]) -> dict:
         mine = []
+        ai = []
         for seat in self.seats:
             if seat.kind == "human" and seat.owner_client_id == client_id and seat.pid:
                 mine.append({
@@ -540,6 +707,16 @@ class Table:
                     "passed": list(seat.passed),
                     "received": list(seat.received),
                 })
+            # AI seats this browser added: surface their activity log so the
+            # owner can watch the bot (and spot a hung/slow one).
+            elif seat.kind == "ai" and seat.owner_client_id == client_id:
+                ai.append({
+                    "seat_id": seat.seat_id,
+                    "ai_type": seat.ai_type,
+                    "name": seat.name,
+                    "pid": seat.pid,
+                    "log": list(seat.log),
+                })
         return {
             "type": "state",
             "table": {
@@ -548,7 +725,7 @@ class Table:
                 "seats": [s.public_view(client_id) for s in self.seats],
             },
             "public": self._public_state() if self.status != "lobby" else None,
-            "you": {"client_id": client_id, "seats": mine},
+            "you": {"client_id": client_id, "seats": mine, "ai": ai},
         }
 
     # -- broadcast (thread -> asyncio bridge) -------------------------------
@@ -564,13 +741,13 @@ class Table:
 
     async def _broadcast(self):
         dead = []
-        for cid, ws in list(self.clients.items()):
+        for conn_key, (ws, client_id) in list(self.clients.items()):
             try:
-                await ws.send_json(self.snapshot_for(cid))
+                await ws.send_json(self.snapshot_for(client_id))
             except Exception:
-                dead.append(cid)
-        for cid in dead:
-            self.clients.pop(cid, None)
+                dead.append(conn_key)
+        for conn_key in dead:
+            self.clients.pop(conn_key, None)
 
 
 # --- Registry ----------------------------------------------------------------

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -128,6 +128,67 @@ _ABORT = object()  # sentinel pushed onto a seat queue to unblock a thinking hum
 LIVE_LOG_CAP = 60  # max activity-log entries kept per AI seat
 
 
+# --- stdout capture: route a bot's print() into its seat log -----------------
+# Each AI seat's SDK session runs in its own thread. We install a process-wide
+# stdout proxy that, when the *current thread* has registered a sink (done in
+# the seat's initialize_for_game hook, which runs in that thread), routes the
+# text line-by-line into that seat's activity log instead of the console. Using
+# threading.local means the routing is automatically thread-isolated and cleaned
+# up when the thread dies — no manual unregister bookkeeping or thread-id reuse
+# hazard. Threads with no sink (uvicorn, the event loop) write through untouched.
+
+_seat_sink = threading.local()
+
+
+class _StdoutRouter:
+    def __init__(self, original):
+        self._original = original
+
+    def write(self, s):
+        fn = getattr(_seat_sink, "fn", None)
+        if fn is None:
+            return self._original.write(s)
+        try:
+            fn(s)
+        except Exception:
+            return self._original.write(s)
+        return len(s)
+
+    def flush(self):
+        self._original.flush()
+
+    def __getattr__(self, name):  # delegate isatty/encoding/etc. to the real stream
+        return getattr(self._original, name)
+
+
+_stdout_installed = False
+
+
+def _ensure_stdout_router():
+    global _stdout_installed
+    if not _stdout_installed:
+        sys.stdout = _StdoutRouter(sys.stdout)
+        _stdout_installed = True
+
+
+def _route_print(table: "Table", seat: "Seat", text: str):
+    """Buffer a thread's stdout writes and emit one log entry per complete line."""
+    buf = getattr(_seat_sink, "buf", "") + text
+    *lines, rest = buf.split("\n")
+    _seat_sink.buf = rest
+    for line in lines:
+        if line.strip():
+            table.log_seat(seat, "print", line.rstrip())
+
+
+def _flush_print(table: "Table", seat: "Seat"):
+    """Emit any trailing partial line (no terminating newline) at game end."""
+    rest = getattr(_seat_sink, "buf", "")
+    _seat_sink.buf = ""
+    if rest.strip():
+        table.log_seat(seat, "print", rest.rstrip())
+
+
 def _pid(player_tag_session) -> str:
     """Full server-side id, e.g. ``"alice_0_AB12(1003)"``."""
     return str(player_tag_session)
@@ -157,6 +218,11 @@ class Seat:
     cards_ref: List[Card] = field(default_factory=list)  # live hand reference
     passed: List[str] = field(default_factory=list)      # cards I passed this round
     received: List[str] = field(default_factory=list)    # cards passed to me this round
+    # Per-round passing history (round_idx -> cards), so the live view's
+    # expandable per-round tables can show passing for every round, not just the
+    # current one. Only populated for "my" (this-client) seats.
+    passed_by_round: Dict[int, List[str]] = field(default_factory=dict)
+    received_by_round: Dict[int, List[str]] = field(default_factory=dict)
     # Activity log for AI seats (so the owning browser can watch what its bot is
     # doing / whether it's hung). Each entry: {t, kind, text, pending}.
     log: List[dict] = field(default_factory=list)
@@ -235,6 +301,8 @@ class WebHumanPlayer(Player):
 
     def receive_passed_cards(self, cards, pass_dir, donating_player):
         self._seat.received = [str(c) for c in cards]
+        if self._round is not None:
+            self._seat.received_by_round[self._round.round_idx] = list(self._seat.received)
         self._table.schedule_broadcast()
 
     # -- decisions: block on the browser ------------------------------------
@@ -246,12 +314,16 @@ class WebHumanPlayer(Player):
             "hand": hand,
             "pass_direction": pass_dir.value,
             "receiving_player": _pid(receiving_player),
+            "deadline": time.time() + HUMAN_DECISION_TIMEOUT_S,
+            "timeout_s": HUMAN_DECISION_TIMEOUT_S,
         }
         self._table.schedule_broadcast()
         chosen = self._await_response()
         seat.pending = None
         cards = self._coerce_pass(chosen, seat.cards_ref)
         seat.passed = [str(c) for c in cards]
+        if self._round is not None:
+            seat.passed_by_round[self._round.round_idx] = list(seat.passed)
         self._table.schedule_broadcast()
         return cards
 
@@ -259,7 +331,11 @@ class WebHumanPlayer(Player):
         seat = self._seat
         legal = [str(c) for c in legal_moves]
         hand = self._hand_strings()
-        seat.pending = {"kind": "move", "hand": hand, "legal_moves": legal, "trick_idx": trick.trick_idx}
+        seat.pending = {
+            "kind": "move", "hand": hand, "legal_moves": legal, "trick_idx": trick.trick_idx,
+            "deadline": time.time() + HUMAN_DECISION_TIMEOUT_S,
+            "timeout_s": HUMAN_DECISION_TIMEOUT_S,
+        }
         self._table.set_turn(seat.pid)
         self._table.schedule_broadcast()
         chosen = self._await_response()
@@ -329,6 +405,10 @@ def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
             raise
 
     def initialize_for_game(self, game):
+        # Runs in this seat's session thread — register stdout routing here so
+        # the bot's print() output lands in *this* seat's log.
+        _seat_sink.fn = lambda s: _route_print(table, seat, s)
+        _seat_sink.buf = ""
         _safe("initialize_for_game", lambda: base_cls.initialize_for_game(self, game))
         table.log_seat(seat, "game", "Joined game, waiting to start")
         table.on_init(game)
@@ -359,6 +439,8 @@ def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
 
     def handle_end_game(self, players_to_points, winner):
         _safe("handle_end_game", lambda: base_cls.handle_end_game(self, players_to_points, winner))
+        _flush_print(table, seat)
+        _seat_sink.fn = None
         table.log_seat(seat, "game", "Game over")
         table.on_end_game(players_to_points, winner)
 
@@ -447,7 +529,10 @@ class Table:
         self._round_idx: Optional[int] = None
         self._pass_direction: Optional[str] = None
         self._current_trick: dict = {"trick_idx": None, "moves": {}, "order": [], "leader": None}
-        self._completed_tricks: Dict[int, dict] = {}  # current round only
+        # Full per-round history (kept for the whole game, not just the current
+        # round) so the live view can show an expandable table per round.
+        self._round_tricks: Dict[int, Dict[int, dict]] = {}   # round_idx -> trick_idx -> trick
+        self._round_pass_dir: Dict[int, str] = {}             # round_idx -> pass direction
         self._round_results: Dict[int, Dict[str, int]] = {}
         self._turn: Optional[str] = None
         self._winner: Optional[str] = None
@@ -507,6 +592,8 @@ class Table:
             return "Game already started"
         if any(s.kind == "empty" for s in self.seats):
             return "All four seats must be filled before starting"
+
+        _ensure_stdout_router()  # so bots' print() output is captured per seat
 
         try:
             self.connection = ManagedConnection(timeout_s=SDK_SESSION_TIMEOUT_S)
@@ -581,8 +668,9 @@ class Table:
             if self._round_idx != round.round_idx:
                 self._round_idx = round.round_idx
                 self._pass_direction = round.pass_direction.value
+                self._round_pass_dir[round.round_idx] = round.pass_direction.value
+                self._round_tricks.setdefault(round.round_idx, {})
                 self._current_trick = {"trick_idx": None, "moves": {}, "order": [], "leader": None}
-                self._completed_tricks = {}
                 self._turn = None
         self.schedule_broadcast()
 
@@ -613,7 +701,7 @@ class Table:
         moves = [str(m.card) for m in trick.moves]
         first_player = _pid(trick.moves[0].player) if trick.moves else None
         with self._state_lock:
-            self._completed_tricks[trick.trick_idx] = {
+            self._round_tricks.setdefault(self._round_idx, {})[trick.trick_idx] = {
                 "trick_idx": trick.trick_idx,
                 "first_player": first_player,
                 "moves": moves,
@@ -664,15 +752,34 @@ class Table:
 
     def _round_running_points(self) -> Dict[str, int]:
         pts = {pid: 0 for pid in self._player_order}
-        for t in self._completed_tricks.values():
+        for t in self._round_tricks.get(self._round_idx, {}).values():
             pts[t["winner"]] = pts.get(t["winner"], 0) + t["points"]
         return pts
+
+    def _round_tricks_sorted(self, round_idx: Optional[int]) -> List[dict]:
+        bucket = self._round_tricks.get(round_idx, {})
+        return [bucket[k] for k in sorted(bucket)]
+
+    def _rounds_history(self) -> List[dict]:
+        """Every round seen so far, oldest first, each with its pass direction,
+        completed tricks (in order) and per-player round scores. Drives the
+        expandable per-round tables in the live view."""
+        rounds = []
+        for ridx in sorted(self._round_tricks):
+            rounds.append({
+                "round_idx": ridx,
+                "pass_direction": self._round_pass_dir.get(ridx),
+                "tricks": self._round_tricks_sorted(ridx),
+                "scores": dict(self._round_results.get(ridx, {})),
+                "complete": ridx in self._round_results,
+            })
+        return rounds
 
     def _public_state(self) -> dict:
         with self._state_lock:
             ct = self._current_trick
             moves = [{"player": pid, "card": ct["moves"][pid]} for pid in ct["order"]]
-            completed_tricks = [self._completed_tricks[k] for k in sorted(self._completed_tricks)]
+            completed_tricks = self._round_tricks_sorted(self._round_idx)
             return {
                 "status": self.status,
                 "player_order": list(self._player_order),
@@ -686,8 +793,9 @@ class Table:
                     "leader": ct["leader"],
                     "moves": moves,
                 },
-                "completed_trick_count": len(self._completed_tricks),
+                "completed_trick_count": len(completed_tricks),
                 "completed_tricks": completed_tricks,
+                "rounds": self._rounds_history(),
                 "turn": self._turn,
                 "winner": self._winner,
                 "final_points": dict(self._final_points),
@@ -706,6 +814,8 @@ class Table:
                     "pending": seat.pending,
                     "passed": list(seat.passed),
                     "received": list(seat.received),
+                    "passed_by_round": {str(k): v for k, v in seat.passed_by_round.items()},
+                    "received_by_round": {str(k): v for k, v in seat.received_by_round.items()},
                 })
             # AI seats this browser added: surface their activity log so the
             # owner can watch the bot (and spot a hung/slow one).
@@ -719,6 +829,7 @@ class Table:
                 })
         return {
             "type": "state",
+            "server_now": time.time(),  # lets the client cancel clock skew on timers
             "table": {
                 "code": self.code,
                 "status": self.status,

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -95,6 +95,8 @@ class Seat:
     pending: Optional[dict] = None
     response_queue: "queue.Queue" = field(default_factory=queue.Queue)
     cards_ref: List[Card] = field(default_factory=list)  # live hand reference
+    passed: List[str] = field(default_factory=list)      # cards I passed this round
+    received: List[str] = field(default_factory=list)    # cards passed to me this round
 
     def public_view(self, client_id: Optional[str]) -> dict:
         return {
@@ -126,6 +128,8 @@ class WebHumanPlayer(Player):
 
     def handle_new_round(self, round):
         self._seat.cards_ref = round.cards_in_hand  # live, mutated by framework
+        self._seat.passed = []      # reset passing record for the new round
+        self._seat.received = []
         self._table.on_new_round(round)
 
     def handle_new_trick(self, trick):
@@ -144,6 +148,7 @@ class WebHumanPlayer(Player):
         self._table.on_end_game(players_to_points, winner)
 
     def receive_passed_cards(self, cards, pass_dir, donating_player):
+        self._seat.received = [str(c) for c in cards]
         self._table.schedule_broadcast()
 
     # -- decisions: block on the browser ------------------------------------
@@ -160,6 +165,7 @@ class WebHumanPlayer(Player):
         chosen = self._await_response()
         seat.pending = None
         cards = self._coerce_pass(chosen, seat.cards_ref)
+        seat.passed = [str(c) for c in cards]
         self._table.schedule_broadcast()
         return cards
 
@@ -448,9 +454,17 @@ class Table:
         self.schedule_broadcast()
 
     def on_finished_trick(self, trick, winning_player):
+        # Capture the full trick straight off the SDK Trick object (moves are in
+        # play order), so the frontend can render it with the same TrickRow UI as
+        # tournament rounds. Reading from `trick` (not shared state) avoids races
+        # with another seat thread already advancing to the next trick.
+        moves = [str(m.card) for m in trick.moves]
+        first_player = _pid(trick.moves[0].player) if trick.moves else None
         with self._state_lock:
             self._completed_tricks[trick.trick_idx] = {
                 "trick_idx": trick.trick_idx,
+                "first_player": first_player,
+                "moves": moves,
                 "winner": _pid(winning_player),
                 "points": trick.get_current_point_value(),
             }
@@ -492,6 +506,7 @@ class Table:
         with self._state_lock:
             ct = self._current_trick
             moves = [{"player": pid, "card": ct["moves"][pid]} for pid in ct["order"]]
+            completed_tricks = [self._completed_tricks[k] for k in sorted(self._completed_tricks)]
             return {
                 "status": self.status,
                 "player_order": list(self._player_order),
@@ -506,6 +521,7 @@ class Table:
                     "moves": moves,
                 },
                 "completed_trick_count": len(self._completed_tricks),
+                "completed_tricks": completed_tricks,
                 "turn": self._turn,
                 "winner": self._winner,
                 "final_points": dict(self._final_points),
@@ -521,6 +537,8 @@ class Table:
                     "pid": seat.pid,
                     "name": seat.name,
                     "pending": seat.pending,
+                    "passed": list(seat.passed),
+                    "received": list(seat.received),
                 })
         return {
             "type": "state",

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 import asyncio
+import uuid
 
 from fastapi import FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -97,6 +98,11 @@ def live_stats():
 # --- Live lobby play ---------------------------------------------------------
 
 
+@app.get("/api/live/ai-types")
+def live_ai_types():
+    return {"ai_types": live.ai_type_options()}
+
+
 @app.post("/api/live/tables")
 def create_live_table():
     table = live.manager.create()
@@ -119,7 +125,8 @@ async def live_ws(websocket: WebSocket, code: str, client_id: str):
         return
     await websocket.accept()
     table.loop = asyncio.get_running_loop()
-    table.clients[client_id] = websocket
+    conn_key = uuid.uuid4().hex
+    table.clients[conn_key] = (websocket, client_id)
     await websocket.send_json(table.snapshot_for(client_id))
 
     async def err(msg: str):
@@ -132,7 +139,8 @@ async def live_ws(websocket: WebSocket, code: str, client_id: str):
             if action == "add_human":
                 e = table.add_human(msg["seat_id"], msg.get("name", ""), client_id)
             elif action == "add_ai":
-                e = table.add_ai(msg["seat_id"], msg.get("ai_type", "random"), msg.get("name", ""))
+                e = table.add_ai(msg["seat_id"], msg.get("ai_type") or live.default_ai_type(),
+                                 msg.get("name", ""), client_id)
             elif action == "clear_seat":
                 e = table.clear_seat(msg["seat_id"])
             elif action == "start":
@@ -147,7 +155,7 @@ async def live_ws(websocket: WebSocket, code: str, client_id: str):
     except WebSocketDisconnect:
         pass
     finally:
-        table.clients.pop(client_id, None)
+        table.clients.pop(conn_key, None)
 
 
 # Serve the built frontend (web/frontend/dist) when present, so prod is a single process.

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -1,13 +1,16 @@
 from pathlib import Path
 from typing import Optional
 
-from fastapi import FastAPI, Header, HTTPException
+import asyncio
+
+from fastapi import FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 import auth
+import live
 import results
 
 app = FastAPI(title="Hearts Web UI")
@@ -87,8 +90,64 @@ def lobby_game(game_id: str):
 
 
 @app.get("/api/live")
-def live():
+def live_stats():
     return results.get_live_stats()
+
+
+# --- Live lobby play ---------------------------------------------------------
+
+
+@app.post("/api/live/tables")
+def create_live_table():
+    table = live.manager.create()
+    return {"code": table.code}
+
+
+@app.get("/api/live/tables/{code}")
+def get_live_table(code: str):
+    table = live.manager.get(code)
+    if table is None:
+        raise HTTPException(status_code=404, detail="table not found")
+    return {"code": table.code, "status": table.status}
+
+
+@app.websocket("/api/live/ws/{code}")
+async def live_ws(websocket: WebSocket, code: str, client_id: str):
+    table = live.manager.get(code)
+    if table is None:
+        await websocket.close(code=4404)
+        return
+    await websocket.accept()
+    table.loop = asyncio.get_running_loop()
+    table.clients[client_id] = websocket
+    await websocket.send_json(table.snapshot_for(client_id))
+
+    async def err(msg: str):
+        await websocket.send_json({"type": "error", "message": msg})
+
+    try:
+        while True:
+            msg = await websocket.receive_json()
+            action = msg.get("action")
+            if action == "add_human":
+                e = table.add_human(msg["seat_id"], msg.get("name", ""), client_id)
+            elif action == "add_ai":
+                e = table.add_ai(msg["seat_id"], msg.get("ai_type", "random"), msg.get("name", ""))
+            elif action == "clear_seat":
+                e = table.clear_seat(msg["seat_id"])
+            elif action == "start":
+                e = await asyncio.get_running_loop().run_in_executor(None, table.start)
+            elif action == "decide":
+                e = table.submit_decision(msg["seat_id"], client_id, msg.get("value"))
+            else:
+                e = f"Unknown action '{action}'"
+            if e:
+                await err(e)
+            await table._broadcast()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        table.clients.pop(client_id, None)
 
 
 # Serve the built frontend (web/frontend/dist) when present, so prod is a single process.

--- a/web/backend/results.py
+++ b/web/backend/results.py
@@ -30,13 +30,19 @@ from typing import Any, Optional
 LEGACY_COMPETITION_ID = "legacy"
 
 
-def results_dir() -> Path:
-    return Path(os.environ.get("RESULTS_DIR", "./results")).resolve()
-
-
 def repo_root() -> Path:
     # web/backend/results.py -> repo root is two levels up.
     return Path(__file__).resolve().parents[2]
+
+
+def results_dir() -> Path:
+    # Default to the repo's results/ dir (where the C++ server writes), so the
+    # backend finds tournaments/lobby games regardless of its launch cwd. The
+    # RESULTS_DIR env var still overrides for non-standard layouts.
+    env = os.environ.get("RESULTS_DIR")
+    if env:
+        return Path(env).resolve()
+    return repo_root() / "results"
 
 
 def _read_json(path: Path) -> Optional[Any]:

--- a/web/frontend/.gitignore
+++ b/web/frontend/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.vite
 *.local
 
 # Editor directories and files

--- a/web/frontend/src/App.css
+++ b/web/frontend/src/App.css
@@ -1,5 +1,8 @@
 .app {
   min-height: 100vh;
+  /* Guard against accidental horizontal overflow (clip doesn't break the
+     sticky header the way overflow:hidden/auto would). */
+  overflow-x: clip;
 }
 
 .app-header {
@@ -19,6 +22,7 @@
   font-weight: 700;
   color: #fff;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .app-nav {
@@ -36,10 +40,110 @@
   color: #fff;
 }
 
+/* Auth control + hamburger pinned to the right of the header. */
+.app-header__right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-left: auto;
+}
+
+/* Hamburger button — hidden on wide screens, shown on small ones. */
+.app-menu-btn {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  width: 38px;
+  height: 38px;
+  padding: 9px 8px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+}
+.app-menu-btn span {
+  display: block;
+  height: 2px;
+  width: 100%;
+  background: currentColor;
+  border-radius: 2px;
+}
+
+/* Side drawer — only rendered visibly on small screens. */
+.app-drawer {
+  display: none;
+}
+
 .app-main {
   max-width: 1100px;
   margin: 0 auto;
   padding: 24px;
+}
+
+@media (max-width: 760px) {
+  /* Collapse the inline nav into the hamburger-triggered drawer. */
+  .app-nav--inline {
+    display: none;
+  }
+  .app-menu-btn {
+    display: inline-flex;
+  }
+
+  .app-drawer {
+    display: block;
+  }
+  .app-drawer__backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 40;
+  }
+  .app-drawer__panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 72%;
+    max-width: 280px;
+    background: #1f2d3d;
+    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    transform: translateX(100%);
+    transition: transform 0.22s ease;
+    z-index: 50;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+    padding: 64px 26px 26px;
+  }
+  .app-drawer__panel a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 16px;
+  }
+  .app-drawer__close {
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 30px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+  }
+  .app-drawer--open .app-drawer__backdrop {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .app-drawer--open .app-drawer__panel {
+    transform: translateX(0);
+  }
 }
 
 @media (max-width: 600px) {
@@ -50,10 +154,6 @@
 
   .app-brand {
     font-size: 16px;
-  }
-
-  .app-nav {
-    gap: 12px;
   }
 
   .app-main {

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1,22 +1,73 @@
-import { Link, Outlet } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, Outlet, useLocation } from 'react-router-dom'
 import { AuthControl } from './components/AuthControl'
 import './App.css'
 import './theme-spacex.css'
 
+const NAV_LINKS = [
+  { to: '/', label: 'Competitions' },
+  { to: '/lobby', label: 'Lobby games' },
+  { to: '/play', label: 'Live play' },
+]
+
 export function App() {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const location = useLocation()
+
+  // Close the drawer on navigation and on Escape.
+  useEffect(() => setMenuOpen(false), [location.pathname])
+  useEffect(() => {
+    if (!menuOpen) return
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setMenuOpen(false)
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [menuOpen])
+
   return (
     <div className="app theme-spacex">
       <header className="app-header">
         <Link to="/" className="app-brand">
           ♥ Hearts
         </Link>
-        <nav className="app-nav">
-          <Link to="/">Competitions</Link>
-          <Link to="/lobby">Lobby games</Link>
-          <Link to="/play">Live play</Link>
+        <nav className="app-nav app-nav--inline">
+          {NAV_LINKS.map((l) => (
+            <Link key={l.to} to={l.to}>{l.label}</Link>
+          ))}
         </nav>
-        <AuthControl />
+        <div className="app-header__right">
+          <AuthControl />
+          <button
+            type="button"
+            className="app-menu-btn"
+            aria-label="Menu"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((v) => !v)}
+          >
+            <span /><span /><span />
+          </button>
+        </div>
       </header>
+
+      {/* Mobile slide-in side menu (hidden on wider screens via CSS). */}
+      <div className={`app-drawer ${menuOpen ? 'app-drawer--open' : ''}`}>
+        <div className="app-drawer__backdrop" onClick={() => setMenuOpen(false)} />
+        <nav className="app-drawer__panel" aria-label="Main menu">
+          <button
+            type="button"
+            className="app-drawer__close"
+            aria-label="Close menu"
+            onClick={() => setMenuOpen(false)}
+          >
+            ×
+          </button>
+          {NAV_LINKS.map((l) => (
+            <Link key={l.to} to={l.to} onClick={() => setMenuOpen(false)}>
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+
       <main className="app-main">
         <Outlet />
       </main>

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -13,6 +13,7 @@ export function App() {
         <nav className="app-nav">
           <Link to="/">Competitions</Link>
           <Link to="/lobby">Lobby games</Link>
+          <Link to="/play">Live play</Link>
         </nav>
         <AuthControl />
       </header>

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -182,11 +182,28 @@ export interface LiveMySeat {
   received?: string[]  // cards passed to me this round
 }
 
+// One entry in an AI seat's activity log (so the browser running the bot can
+// watch what it's doing / whether it's hung).
+export interface LiveLogEntry {
+  t: number          // unix seconds
+  kind: 'game' | 'round' | 'think' | 'move' | 'pass' | 'error'
+  text: string
+  pending: boolean   // open-ended action still in progress (render a live timer)
+}
+
+export interface LiveAiSeat {
+  seat_id: string
+  ai_type: string | null
+  name: string
+  pid: string | null
+  log: LiveLogEntry[]
+}
+
 export interface LiveSnapshot {
   type: 'state'
   table: { code: string; status: LiveStatus; seats: LiveSeat[] }
   public: LivePublic | null
-  you: { client_id: string; seats: LiveMySeat[] }
+  you: { client_id: string; seats: LiveMySeat[]; ai?: LiveAiSeat[] }
 }
 
 export interface LiveStats {
@@ -219,6 +236,11 @@ export interface LoginResult {
   is_admin: boolean
 }
 
+export interface AiTypeOption {
+  value: string
+  label: string
+}
+
 const tBase = (cid: string, index: string) =>
   `/api/competitions/${encodeURIComponent(cid)}/tournaments/${encodeURIComponent(index)}`
 
@@ -239,6 +261,7 @@ export const api = {
   },
   liveTable: (code: string) =>
     getJSON<{ code: string; status: LiveStatus }>(`/api/live/tables/${encodeURIComponent(code)}`),
+  aiTypes: () => getJSON<{ ai_types: AiTypeOption[] }>('/api/live/ai-types'),
   login: async (team: string | null, password: string): Promise<LoginResult> => {
     const res = await fetch('/api/login', {
       method: 'POST',

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -123,6 +123,63 @@ export interface LobbyGameListEntry {
   rounds_played: number | null
 }
 
+// --- Live lobby play ---------------------------------------------------------
+
+export type LiveStatus = 'lobby' | 'playing' | 'finished'
+
+export interface LiveSeat {
+  index: number
+  seat_id: string
+  kind: 'empty' | 'human' | 'ai'
+  name: string
+  ai_type: string | null
+  mine: boolean
+}
+
+export interface LiveMove {
+  player: string
+  card: string
+}
+
+export interface LivePublic {
+  status: LiveStatus
+  player_order: string[]
+  players: Record<string, { name: string; seat_id: string | null; kind: string }>
+  round_idx: number | null
+  pass_direction: string | null
+  scores: Record<string, number>
+  round_points: Record<string, number>
+  current_trick: { trick_idx: number | null; leader: string | null; moves: LiveMove[] }
+  completed_trick_count: number
+  turn: string | null
+  winner: string | null
+  final_points: Record<string, number>
+}
+
+export interface LivePending {
+  kind: 'move' | 'pass'
+  hand: string[]
+  legal_moves?: string[]
+  trick_idx?: number
+  pass_direction?: string
+  receiving_player?: string
+}
+
+export interface LiveMySeat {
+  seat_id: string
+  player_tag: string
+  pid: string
+  name: string
+  pending: LivePending | null
+}
+
+export interface LiveSnapshot {
+  type: 'state'
+  table: { code: string; status: LiveStatus; seats: LiveSeat[] }
+  public: LivePublic | null
+  you: { client_id: string; seats: LiveMySeat[] }
+}
+
 export interface LiveStats {
   competition_id: string | null
   tournament_index: string | null
@@ -166,6 +223,13 @@ export const api = {
   lobbyGames: () => getJSON<LobbyGameListEntry[]>('/api/lobby/games'),
   lobbyGame: (gameId: string) => getJSON<GameDetail>(`/api/lobby/games/${encodeURIComponent(gameId)}`),
   live: () => getJSON<LiveStats>('/api/live'),
+  createLiveTable: async (): Promise<{ code: string }> => {
+    const res = await fetch('/api/live/tables', { method: 'POST' })
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return res.json() as Promise<{ code: string }>
+  },
+  liveTable: (code: string) =>
+    getJSON<{ code: string; status: LiveStatus }>(`/api/live/tables/${encodeURIComponent(code)}`),
   login: async (team: string | null, password: string): Promise<LoginResult> => {
     const res = await fetch('/api/login', {
       method: 'POST',

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -141,6 +141,12 @@ export interface LiveMove {
   card: string
 }
 
+// A completed trick this round — same shape as TrickRecord, so the tournament
+// TrickRow component renders it unchanged.
+export interface LiveTrick extends TrickRecord {
+  trick_idx: number
+}
+
 export interface LivePublic {
   status: LiveStatus
   player_order: string[]
@@ -151,6 +157,7 @@ export interface LivePublic {
   round_points: Record<string, number>
   current_trick: { trick_idx: number | null; leader: string | null; moves: LiveMove[] }
   completed_trick_count: number
+  completed_tricks: LiveTrick[]
   turn: string | null
   winner: string | null
   final_points: Record<string, number>
@@ -171,6 +178,8 @@ export interface LiveMySeat {
   pid: string
   name: string
   pending: LivePending | null
+  passed?: string[]    // cards I passed this round
+  received?: string[]  // cards passed to me this round
 }
 
 export interface LiveSnapshot {

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -147,6 +147,17 @@ export interface LiveTrick extends TrickRecord {
   trick_idx: number
 }
 
+// A full round's worth of public history (pass direction + completed tricks +
+// per-player round scores), so the live view can render an expandable table per
+// round rather than only the current round.
+export interface LiveRound {
+  round_idx: number
+  pass_direction: string | null
+  tricks: LiveTrick[]
+  scores: Record<string, number>
+  complete: boolean
+}
+
 export interface LivePublic {
   status: LiveStatus
   player_order: string[]
@@ -158,6 +169,7 @@ export interface LivePublic {
   current_trick: { trick_idx: number | null; leader: string | null; moves: LiveMove[] }
   completed_trick_count: number
   completed_tricks: LiveTrick[]
+  rounds: LiveRound[]
   turn: string | null
   winner: string | null
   final_points: Record<string, number>
@@ -170,6 +182,8 @@ export interface LivePending {
   trick_idx?: number
   pass_direction?: string
   receiving_player?: string
+  deadline?: number    // server epoch seconds when the server will auto-decide
+  timeout_s?: number   // total budget, for sizing the countdown bar
 }
 
 export interface LiveMySeat {
@@ -180,13 +194,15 @@ export interface LiveMySeat {
   pending: LivePending | null
   passed?: string[]    // cards I passed this round
   received?: string[]  // cards passed to me this round
+  passed_by_round?: Record<string, string[]>    // round_idx -> cards I passed
+  received_by_round?: Record<string, string[]>  // round_idx -> cards passed to me
 }
 
 // One entry in an AI seat's activity log (so the browser running the bot can
 // watch what it's doing / whether it's hung).
 export interface LiveLogEntry {
   t: number          // unix seconds
-  kind: 'game' | 'round' | 'think' | 'move' | 'pass' | 'error'
+  kind: 'game' | 'round' | 'think' | 'move' | 'pass' | 'error' | 'print'
   text: string
   pending: boolean   // open-ended action still in progress (render a live timer)
 }
@@ -201,6 +217,7 @@ export interface LiveAiSeat {
 
 export interface LiveSnapshot {
   type: 'state'
+  server_now?: number  // server epoch seconds at send time (for clock-skew-free timers)
   table: { code: string; status: LiveStatus; seats: LiveSeat[] }
   public: LivePublic | null
   you: { client_id: string; seats: LiveMySeat[]; ai?: LiveAiSeat[] }

--- a/web/frontend/src/components/Card.css
+++ b/web/frontend/src/components/Card.css
@@ -56,6 +56,19 @@
   filter: grayscale(1);
 }
 
+/* Chosen card (e.g. picked to pass): blue ring + raised, distinct from the
+   gold winner ring. */
+.card--selected {
+  border-color: #2f7df6;
+  box-shadow: 0 0 0 2px #2f7df6, 0 4px 8px rgba(0, 0, 0, 0.3);
+  transform: translateY(-8px);
+}
+
+/* Keep the lift on hover instead of dropping back to the generic -3px. */
+.card--selected.card--clickable:hover {
+  transform: translateY(-8px);
+}
+
 .card--clickable {
   cursor: pointer;
   transition: transform 0.08s ease;

--- a/web/frontend/src/components/Card.tsx
+++ b/web/frontend/src/components/Card.tsx
@@ -6,12 +6,13 @@ interface CardProps {
   highlight?: boolean // winning card
   legal?: boolean // legal to play in this context (green outline)
   dim?: boolean // illegal in this context (faded)
+  selected?: boolean // chosen (e.g. picked to pass): raised + ringed
   onClick?: () => void
   size?: 'sm' | 'md'
   title?: string // tooltip override for clickable cards
 }
 
-export function Card({ code, highlight, legal, dim, onClick, size = 'md', title }: CardProps) {
+export function Card({ code, highlight, legal, dim, selected, onClick, size = 'md', title }: CardProps) {
   const { rank, suit } = parseCard(code)
   const red = isRedSuit(suit)
   const pts = cardPoints(code)
@@ -22,6 +23,7 @@ export function Card({ code, highlight, legal, dim, onClick, size = 'md', title 
     highlight ? 'card--win' : '',
     legal ? 'card--legal' : '',
     dim ? 'card--dim' : '',
+    selected ? 'card--selected' : '',
     onClick ? 'card--clickable' : '',
   ]
     .filter(Boolean)

--- a/web/frontend/src/components/TrickRow.css
+++ b/web/frontend/src/components/TrickRow.css
@@ -19,7 +19,13 @@
   grid-template-columns: repeat(7, 1fr);
   gap: 4px;
   flex: 1;
+  overflow: hidden; /* clip cards sliding in from offscreen during a recenter */
 }
+
+/* The recenter slide-in is driven imperatively via the Web Animations API (see
+   useColumnSlide.ts): each grid is animated from its old column offset back to
+   center. The resting layout is already centered, so no CSS animation state is
+   needed here. */
 
 .trick-col {
   display: flex;
@@ -29,10 +35,11 @@
   min-width: 0;
 }
 
+/* Subtle center-column cue: a faint tint with thin vertical guide lines marking
+   the center line — replaces the old bright "white box" highlight. */
 .trick-col--center {
-  background: #f3f7ff;
-  border-radius: 8px;
-  padding: 2px 0;
+  background: rgba(90, 140, 255, 0.08);
+  box-shadow: inset 1px 0 0 rgba(90, 140, 255, 0.3), inset -1px 0 0 rgba(90, 140, 255, 0.3);
 }
 
 .trick-col__seat {
@@ -47,6 +54,16 @@
 .trick-col--center .trick-col__seat {
   color: #2a5bd7;
   font-weight: 700;
+}
+
+/* Clickable header columns: pick the player to center on. */
+.trick-col--clickable {
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background-color 0.12s ease;
+}
+.trick-col--clickable:hover {
+  background: rgba(90, 140, 255, 0.14);
 }
 
 .trick-col__card {

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -262,4 +262,24 @@ button.btn.btn--active:hover {
   table.data td {
     padding: 6px 7px;
   }
+
+  /* Passing flow: keep both Left/Right and Across layouts compact on phones so
+     the cards, arrow, and player name stay legible without horizontal scroll. */
+  .passing-flow {
+    gap: 8px;
+  }
+  .passing-flow__cards {
+    flex-wrap: wrap;
+    min-height: 0;
+  }
+  .passing-flow__player,
+  .passing-across__player {
+    font-size: 14px;
+  }
+  .passing-flow__arrow-line {
+    font-size: 18px;
+  }
+  .passing-across__cols {
+    gap: 18px;
+  }
 }

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -1,13 +1,21 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { LiveSnapshot } from '../api/client'
 
-/** Stable per-browser id so the backend can tie human seats to this client. */
+/**
+ * Per-tab id so the backend can tie human seats to this client.
+ *
+ * Uses sessionStorage (not localStorage) so each tab/window is a *distinct*
+ * participant — otherwise two windows of the same browser share one id, collide
+ * on seat ownership, and the server keeps only the last socket per id. It stays
+ * stable across reloads within the same tab, so seat ownership survives the
+ * socket's auto-reconnect.
+ */
 export function clientId(): string {
   const KEY = 'hearts-live-client-id'
-  let id = localStorage.getItem(KEY)
+  let id = sessionStorage.getItem(KEY)
   if (!id) {
     id = (crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)) as string
-    localStorage.setItem(KEY, id)
+    sessionStorage.setItem(KEY, id)
   }
   return id
 }

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -38,6 +38,9 @@ export interface LiveConnection {
   connected: boolean
   error: string | null
   send: (a: SendAction) => void
+  /** serverEpoch - clientEpoch (seconds), measured at the last message; add to
+   *  Date.now()/1000 to get the server's clock for skew-free countdowns. */
+  serverOffset: number
 }
 
 /** Connect to a live table's WebSocket and track its latest snapshot. */
@@ -45,6 +48,7 @@ export function useLiveTable(code: string | undefined): LiveConnection {
   const [snapshot, setSnapshot] = useState<LiveSnapshot | null>(null)
   const [connected, setConnected] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [serverOffset, setServerOffset] = useState(0)
   const wsRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
@@ -66,6 +70,9 @@ export function useLiveTable(code: string | undefined): LiveConnection {
         try {
           const msg = JSON.parse(ev.data)
           if (msg.type === 'state') {
+            if (typeof msg.server_now === 'number') {
+              setServerOffset(msg.server_now - Date.now() / 1000)
+            }
             setSnapshot(msg as LiveSnapshot)
             setError(null)
           } else if (msg.type === 'error') {
@@ -90,5 +97,5 @@ export function useLiveTable(code: string | undefined): LiveConnection {
     if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(a))
   }, [])
 
-  return { snapshot, connected, error, send }
+  return { snapshot, connected, error, send, serverOffset }
 }

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { LiveSnapshot } from '../api/client'
+
+/** Stable per-browser id so the backend can tie human seats to this client. */
+export function clientId(): string {
+  const KEY = 'hearts-live-client-id'
+  let id = localStorage.getItem(KEY)
+  if (!id) {
+    id = (crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)) as string
+    localStorage.setItem(KEY, id)
+  }
+  return id
+}
+
+function wsUrl(code: string): string {
+  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
+  const cid = encodeURIComponent(clientId())
+  return `${proto}://${window.location.host}/api/live/ws/${encodeURIComponent(code)}?client_id=${cid}`
+}
+
+export type SendAction =
+  | { action: 'add_human'; seat_id: string; name: string }
+  | { action: 'add_ai'; seat_id: string; ai_type: string; name?: string }
+  | { action: 'clear_seat'; seat_id: string }
+  | { action: 'start' }
+  | { action: 'decide'; seat_id: string; value: string | string[] }
+
+export interface LiveConnection {
+  snapshot: LiveSnapshot | null
+  connected: boolean
+  error: string | null
+  send: (a: SendAction) => void
+}
+
+/** Connect to a live table's WebSocket and track its latest snapshot. */
+export function useLiveTable(code: string | undefined): LiveConnection {
+  const [snapshot, setSnapshot] = useState<LiveSnapshot | null>(null)
+  const [connected, setConnected] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    if (!code) return
+    let closed = false
+    let retry: ReturnType<typeof setTimeout> | undefined
+
+    const connect = () => {
+      if (closed) return
+      const ws = new WebSocket(wsUrl(code))
+      wsRef.current = ws
+      ws.onopen = () => setConnected(true)
+      ws.onclose = () => {
+        setConnected(false)
+        if (!closed) retry = setTimeout(connect, 1000) // simple reconnect
+      }
+      ws.onerror = () => ws.close()
+      ws.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data)
+          if (msg.type === 'state') {
+            setSnapshot(msg as LiveSnapshot)
+            setError(null)
+          } else if (msg.type === 'error') {
+            setError(String(msg.message))
+          }
+        } catch {
+          /* ignore malformed frames */
+        }
+      }
+    }
+    connect()
+
+    return () => {
+      closed = true
+      if (retry) clearTimeout(retry)
+      wsRef.current?.close()
+    }
+  }, [code])
+
+  const send = useCallback((a: SendAction) => {
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(a))
+  }, [])
+
+  return { snapshot, connected, error, send }
+}

--- a/web/frontend/src/lib/useColumnSlide.ts
+++ b/web/frontend/src/lib/useColumnSlide.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { CENTER, columnSeats } from './seating'
+
+/**
+ * Click-a-column player selection for the 7-column trick view, with a brief
+ * horizontal "scroll" animation as the columns recenter on the newly selected
+ * player.
+ *
+ * Returns:
+ *  - `selectColumn(col)`: select the player shown in column `col` (no-op for the
+ *    already-centered column). Records how many columns the view moved.
+ *  - `containerRef`: attach to the element that wraps the trick grids (the
+ *    `.trick-row__grid`s live inside it). After React commits the recentered
+ *    layout, the hook finds those grids and runs a one-shot slide-in on each.
+ *
+ * Implementation note: the recenter uses the Web Animations API rather than a
+ * CSS class + keyframes. The newly centered layout renders immediately; then, in
+ * a post-commit effect, each grid is animated from its old column offset back to
+ * center. WAAPI runs off the main React render cycle, so re-renders (e.g. live
+ * WebSocket updates) can't restart or short-circuit it, and every click triggers
+ * a fresh, independent animation with no shared state to race on. Correctness
+ * never depends on the animation finishing: the resting layout is already
+ * centered, so the animation only adds slide-in motion.
+ */
+const SLIDE_MS = 340
+const SLIDE_EASING = 'cubic-bezier(0.22, 0.61, 0.36, 1)'
+
+export function useColumnSlide(
+  playerOrder: string[],
+  selected: string,
+  setSelected: (p: string) => void,
+) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  // Columns the view moved on the latest selection (+ = clicked right of
+  // center). Consumed once by the post-commit effect, then cleared.
+  const pendingOffset = useRef(0)
+
+  const selectColumn = useCallback(
+    (col: number) => {
+      const seats = columnSeats(playerOrder, selected)
+      const target = seats[col]
+      if (!target || target === selected) return
+      pendingOffset.current = col - CENTER
+      setSelected(target)
+    },
+    [playerOrder, selected, setSelected],
+  )
+
+  // Runs after the recentered layout is committed/painted. Slide each grid in
+  // from where it used to sit (offset columns away) back to its resting center.
+  useEffect(() => {
+    const offset = pendingOffset.current
+    if (!offset) return
+    pendingOffset.current = 0
+    const grids = containerRef.current?.querySelectorAll<HTMLElement>('.trick-row__grid')
+    grids?.forEach((grid) => {
+      grid.animate(
+        [
+          { transform: `translateX(calc(${offset} * (100% / 7)))` },
+          { transform: 'translateX(0)' },
+        ],
+        { duration: SLIDE_MS, easing: SLIDE_EASING },
+      )
+    })
+  }, [selected])
+
+  return { selectColumn, containerRef }
+}

--- a/web/frontend/src/main.tsx
+++ b/web/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import { TournamentDetail } from './pages/TournamentDetail'
 import { GameDetail } from './pages/GameDetail'
 import { RoundDetail } from './pages/RoundDetail'
 import { LobbyGamesList } from './pages/LobbyGamesList'
+import { LivePlayHome, LiveTable } from './pages/LivePlay'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -23,6 +24,8 @@ createRoot(document.getElementById('root')!).render(
           <Route path="lobby" element={<LobbyGamesList />} />
           <Route path="lobby/g/:gameId" element={<GameDetail lobby />} />
           <Route path="lobby/g/:gameId/r/:roundIdx" element={<RoundDetail lobby />} />
+          <Route path="play" element={<LivePlayHome />} />
+          <Route path="play/:code" element={<LiveTable />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -1,0 +1,119 @@
+/* Live play layout */
+
+.live-home {
+  display: flex;
+  gap: 28px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+.live-home__divider {
+  width: 1px;
+  background: var(--sx-hairline, #333);
+  align-self: stretch;
+}
+
+.live-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.live-status--lobby { opacity: 0.85; }
+.live-status--playing { border-color: #4caf50; color: #4caf50; }
+.live-status--finished { border-color: #888; }
+
+.live-error {
+  color: #e57373;
+  font-size: 13px;
+}
+
+/* --- Lobby seat grid --- */
+.seat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+  margin-top: 8px;
+}
+.seat-card {
+  padding: 16px;
+  min-height: 150px;
+}
+.seat-card--filled { border-color: var(--sx-on-primary, #aaa); }
+.seat-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.seat-card__controls { display: flex; flex-direction: column; gap: 8px; }
+.seat-card__name { font-size: 18px; font-weight: 700; }
+.seat-kind--human { border-color: #64b5f6; color: #64b5f6; }
+.seat-kind--ai { border-color: #ba9; color: #cba; }
+
+/* --- Play view --- */
+.live-table-info {
+  display: flex;
+  gap: 36px;
+  margin: 12px 0 18px;
+  padding: 14px 22px;
+}
+.live-stat { font-size: 20px; font-weight: 700; }
+
+.live-seats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 14px;
+  margin-bottom: 18px;
+}
+.live-seat {
+  border: 1px solid var(--sx-hairline, #333);
+  border-radius: 6px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.live-seat--turn {
+  border-color: #4caf50;
+  box-shadow: 0 0 0 1px #4caf50 inset;
+}
+.live-seat__name {
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.live-seat__turn { border-color: #4caf50; color: #4caf50; }
+.live-seat__card {
+  min-height: 96px;
+  display: flex;
+  align-items: center;
+}
+.live-seat__empty {
+  width: 64px;
+  height: 90px;
+  border: 1px dashed var(--sx-hairline, #444);
+  border-radius: 6px;
+  opacity: 0.4;
+}
+.live-seat__score { font-size: 12px; text-align: center; }
+
+.live-winner { margin-bottom: 18px; }
+
+/* --- My hand panels --- */
+.my-seat { margin-top: 14px; }
+.my-seat__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.my-seat__prompt { border-color: #4caf50; color: #4caf50; }
+.hand-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -151,6 +151,67 @@
   overflow-x: auto;
 }
 
+/* --- AI activity log ------------------------------------------------------ */
+.ai-activity {
+  margin-top: 18px;
+}
+.ai-activity__title {
+  font-size: 12px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--muted, #888);
+  margin-bottom: 10px;
+}
+.ai-seat-log + .ai-seat-log {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(128, 128, 128, 0.2);
+}
+.ai-seat-log__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.ai-seat-log__state {
+  font-size: 11px;
+}
+.ai-seat-log__state--busy {
+  background: #f5b301;
+  color: #1a1a1a;
+}
+.ai-seat-log__state--idle {
+  background: rgba(128, 128, 128, 0.25);
+}
+.ai-log {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  font-family: 'SF Mono', 'Menlo', monospace;
+  font-size: 12.5px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.ai-log__line {
+  padding: 2px 0;
+  color: #444;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.08);
+}
+.ai-log__line--error {
+  color: #d11a2a;
+  font-weight: 600;
+}
+.ai-log__line--move,
+.ai-log__line--pass {
+  color: #1a7a3a;
+}
+.ai-log__line--think {
+  color: #2f7df6;
+}
+.ai-log__timer {
+  font-weight: 700;
+}
+
 @media (max-width: 600px) {
   .live-table-info {
     gap: 20px;

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -63,17 +63,17 @@
    marker. Fixed 3x3 grid + max-width so it looks identical on any screen. */
 .live-table {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: auto auto auto;
+  grid-template-columns: 1fr minmax(96px, 1.1fr) 1fr;
+  grid-template-rows: auto 1fr auto;
   grid-template-areas:
     ".    top    ."
     "left center right"
     ".    bottom .";
-  gap: 12px;
+  gap: 10px;
   align-items: center;
   justify-items: center;
   width: 100%;
-  max-width: 520px;
+  max-width: 460px;
   margin: 0 auto 18px;
 }
 .live-seat-slot {
@@ -87,12 +87,43 @@
 .live-seat-slot--bottom { grid-area: bottom; }
 .live-table__center {
   grid-area: center;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  justify-self: stretch;
+  min-height: 116px;
+}
+/* Clockwise direction ring fills the center cell behind the trick/pass text. */
+.live-table__ring {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 100%;
+  height: 100%;
+  max-width: 132px;
+  max-height: 132px;
+}
+.live-table__ring-track {
+  fill: none;
+  stroke: var(--sx-hairline, #3a3a3a);
+  stroke-width: 1.5;
+  opacity: 0.5;
+}
+.live-table__ring-head {
+  fill: #4caf50;
+  opacity: 0.85;
+}
+.live-table__center-text {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   font-size: 12px;
-  opacity: 0.7;
+  opacity: 0.85;
   text-align: center;
 }
 .live-table__center-trick { font-weight: 700; }
@@ -100,6 +131,7 @@
   text-transform: uppercase;
   letter-spacing: 1px;
   font-size: 10px;
+  opacity: 0.8;
 }
 .live-seat {
   border: 1px solid var(--sx-hairline, #333);
@@ -411,5 +443,33 @@
   }
   .hand-row {
     gap: 12px;
+  }
+  /* Keep the table a compact square on phones: tighter gaps, smaller seat
+     boxes, and a smaller direction ring so left/center/right fit one row. */
+  .live-table {
+    gap: 6px;
+    max-width: 360px;
+  }
+  .live-seat {
+    padding: 8px 6px;
+    gap: 6px;
+    border-radius: 8px;
+  }
+  .live-seat__name {
+    font-size: 13px;
+    gap: 5px;
+  }
+  .live-seat__card {
+    min-height: 74px;
+  }
+  .live-seat__score {
+    font-size: 11px;
+  }
+  .live-table__center {
+    min-height: 96px;
+  }
+  .live-table__ring {
+    max-width: 104px;
+    max-height: 104px;
   }
 }

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -59,11 +59,47 @@
 }
 .live-stat { font-size: 20px; font-weight: 700; }
 
-.live-seats {
+/* Square "table": 4 seats arranged N/E/S/W in seating order, with a center
+   marker. Fixed 3x3 grid + max-width so it looks identical on any screen. */
+.live-table {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 14px;
-  margin-bottom: 18px;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: auto auto auto;
+  grid-template-areas:
+    ".    top    ."
+    "left center right"
+    ".    bottom .";
+  gap: 12px;
+  align-items: center;
+  justify-items: center;
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto 18px;
+}
+.live-seat-slot {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+.live-seat-slot--top { grid-area: top; }
+.live-seat-slot--left { grid-area: left; }
+.live-seat-slot--right { grid-area: right; }
+.live-seat-slot--bottom { grid-area: bottom; }
+.live-table__center {
+  grid-area: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  opacity: 0.7;
+  text-align: center;
+}
+.live-table__center-trick { font-weight: 700; }
+.live-table__center-pass {
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 10px;
 }
 .live-seat {
   border: 1px solid var(--sx-hairline, #333);
@@ -73,6 +109,8 @@
   flex-direction: column;
   align-items: center;
   gap: 10px;
+  width: 100%;
+  max-width: 150px;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .live-seat--turn {
@@ -124,6 +162,63 @@
   gap: 8px; /* gap between cards within a suit */
 }
 
+/* --- Round history: an expandable table per round --- */
+.live-rounds {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+.live-round {
+  padding: 0;
+  overflow: hidden;
+}
+.live-round__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.live-round__head:hover {
+  background: rgba(128, 128, 128, 0.06);
+}
+.live-round__chevron {
+  display: inline-block;
+  transition: transform 0.15s ease;
+  opacity: 0.6;
+  font-size: 12px;
+}
+.live-round__chevron.is-open {
+  transform: rotate(90deg);
+}
+.live-round__title {
+  font-weight: 700;
+  font-size: 15px;
+}
+.live-round__pass {
+  opacity: 0.85;
+}
+.live-round__live {
+  border-color: #4caf50;
+  color: #4caf50;
+}
+.live-round__summary {
+  margin-left: auto;
+  font-size: 12px;
+  opacity: 0.7;
+  text-align: right;
+}
+.live-round__body {
+  padding: 0 16px 16px;
+}
+
 /* --- Round history (passing + completed tricks) --- */
 .live-history {
   margin-bottom: 18px;
@@ -149,6 +244,49 @@
 }
 .live-tricks {
   overflow-x: auto;
+}
+
+/* --- Decision countdown --------------------------------------------------- */
+.decision-timer {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+.decision-timer__bar {
+  width: 120px;
+  height: 6px;
+  background: rgba(128, 128, 128, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.decision-timer__fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.2s linear, background-color 0.3s ease;
+}
+.decision-timer__fill--ok {
+  background: #1a7a3a;
+}
+.decision-timer__fill--warn {
+  background: #f5b301;
+}
+.decision-timer__fill--danger {
+  background: #d11a2a;
+}
+.decision-timer__secs {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: #555;
+  min-width: 30px;
+  text-align: right;
+}
+.decision-timer__secs--warn {
+  color: #b07d00;
+}
+.decision-timer__secs--danger {
+  color: #d11a2a;
 }
 
 /* --- AI activity log ------------------------------------------------------ */
@@ -207,6 +345,14 @@
 }
 .ai-log__line--think {
   color: #2f7df6;
+}
+/* Real stdout from the bot — set apart with a left rule and dimmer ink. */
+.ai-log__line--print {
+  color: #555;
+  padding-left: 8px;
+  border-left: 2px solid #b9c6e0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .ai-log__timer {
   font-weight: 700;

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -162,32 +162,86 @@
   gap: 8px; /* gap between cards within a suit */
 }
 
-/* --- Round history: an expandable table per round --- */
-.live-rounds {
+/* --- Round history: a compact scoreboard with expandable rows --- */
+.live-scores {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  padding: 6px 8px;
   margin-bottom: 18px;
-}
-.live-round {
-  padding: 0;
   overflow: hidden;
 }
-.live-round__head {
-  display: flex;
+/* Shared column grid: round | pass | one fractional column per player. */
+.live-scores__row {
+  display: grid;
+  grid-template-columns: minmax(3.4em, auto) 2.4em repeat(var(--player-cols, 4), minmax(0, 1fr));
   align-items: center;
-  gap: 10px;
+  gap: 4px;
   width: 100%;
-  padding: 12px 16px;
-  background: none;
-  border: none;
-  cursor: pointer;
+  padding: 7px 8px;
   text-align: left;
   color: inherit;
   font: inherit;
 }
-.live-round__head:hover {
-  background: rgba(128, 128, 128, 0.06);
+.live-scores__row--head {
+  font-size: 11px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.22);
+}
+.live-scores__row--round {
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: 8px;
+}
+.live-scores__row--round:hover {
+  background: rgba(128, 128, 128, 0.07);
+}
+.live-scores__row--round.is-live {
+  background: rgba(76, 175, 80, 0.08);
+}
+.live-scores__row--total {
+  font-weight: 700;
+  border-top: 1px solid rgba(128, 128, 128, 0.22);
+  margin-top: 2px;
+}
+.live-scores__round {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.live-scores__rnum {
+  font-variant-numeric: tabular-nums;
+}
+.live-scores__pass {
+  text-align: center;
+  opacity: 0.8;
+  font-size: 12px;
+}
+.live-scores__pts {
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.live-scores__pts.is-pending {
+  opacity: 0.45;
+}
+.live-scores__name {
+  font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.live-scores__livedot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #4caf50;
+  box-shadow: 0 0 0 3px rgba(76, 175, 80, 0.2);
+}
+.live-scores__detail {
+  padding: 6px 8px 14px;
 }
 .live-round__chevron {
   display: inline-block;
@@ -197,26 +251,6 @@
 }
 .live-round__chevron.is-open {
   transform: rotate(90deg);
-}
-.live-round__title {
-  font-weight: 700;
-  font-size: 15px;
-}
-.live-round__pass {
-  opacity: 0.85;
-}
-.live-round__live {
-  border-color: #4caf50;
-  color: #4caf50;
-}
-.live-round__summary {
-  margin-left: auto;
-  font-size: 12px;
-  opacity: 0.7;
-  text-align: right;
-}
-.live-round__body {
-  padding: 0 16px 16px;
 }
 
 /* --- Round history (passing + completed tricks) --- */

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -115,5 +115,60 @@
 .hand-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 18px; /* gap between suit groups */
+  align-items: flex-start;
+}
+.hand-suit-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px; /* gap between cards within a suit */
+}
+
+/* --- Round history (passing + completed tricks) --- */
+.live-history {
+  margin-bottom: 18px;
+}
+.live-history__title {
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  opacity: 0.65;
+  margin-bottom: 12px;
+}
+.live-pass-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  margin-bottom: 14px;
+}
+.live-pass-summary__leg {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.live-tricks {
+  overflow-x: auto;
+}
+
+@media (max-width: 600px) {
+  .live-table-info {
+    gap: 20px;
+    padding: 12px 14px;
+  }
+  .live-stat {
+    font-size: 17px;
+  }
+  .live-home {
+    gap: 18px;
+  }
+  .live-home__divider {
+    display: none;
+  }
+  .live-pass-summary {
+    gap: 16px;
+  }
+  .hand-row {
+    gap: 12px;
+  }
 }

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -59,21 +59,22 @@
 }
 .live-stat { font-size: 20px; font-weight: 700; }
 
-/* Square "table": 4 seats arranged N/E/S/W in seating order, with a center
-   marker. Fixed 3x3 grid + max-width so it looks identical on any screen. */
+/* Square "table": 4 seats in the quadrants of a 2x2 grid in seating order,
+   with a central column holding the direction ring. Two seats per row keeps
+   the table compact on narrow screens. Fixed proportions + max-width so it
+   looks the same on mobile and desktop. */
 .live-table {
   display: grid;
-  grid-template-columns: 1fr minmax(96px, 1.1fr) 1fr;
-  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 1fr minmax(84px, 0.9fr) 1fr;
+  grid-template-rows: 1fr 1fr;
   grid-template-areas:
-    ".    top    ."
-    "left center right"
-    ".    bottom .";
+    "tl center tr"
+    "bl center br";
   gap: 10px;
   align-items: center;
   justify-items: center;
   width: 100%;
-  max-width: 460px;
+  max-width: 420px;
   margin: 0 auto 18px;
 }
 .live-seat-slot {
@@ -81,10 +82,10 @@
   display: flex;
   justify-content: center;
 }
-.live-seat-slot--top { grid-area: top; }
-.live-seat-slot--left { grid-area: left; }
-.live-seat-slot--right { grid-area: right; }
-.live-seat-slot--bottom { grid-area: bottom; }
+.live-seat-slot--tl { grid-area: tl; }
+.live-seat-slot--tr { grid-area: tr; }
+.live-seat-slot--bl { grid-area: bl; }
+.live-seat-slot--br { grid-area: br; }
 .live-table__center {
   grid-area: center;
   position: relative;
@@ -506,9 +507,10 @@
   .hand-row {
     gap: 12px;
   }
-  /* Keep the table a compact square on phones: tighter gaps, smaller seat
-     boxes, and a smaller direction ring so left/center/right fit one row. */
+  /* Keep the table a compact square on phones: tighter gaps, a narrower center
+     column, and a smaller direction ring so two seats fit per row. */
   .live-table {
+    grid-template-columns: 1fr minmax(58px, 0.6fr) 1fr;
     gap: 6px;
     max-width: 360px;
   }

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -194,6 +194,68 @@
   gap: 8px; /* gap between cards within a suit */
 }
 
+/* --- Pass action bar -----------------------------------------------------
+   A live preview of the 3 picked cards plus a prominent confirm button.
+   On phones it sticks to the bottom of the viewport so it stays in reach
+   while the player scrolls a 13-card hand. */
+.pass-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+.pass-bar__preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 50px;
+}
+.pass-bar__hint {
+  font-size: 13px;
+}
+.pass-bar__slot {
+  width: 36px;
+  height: 50px;
+  border: 1px dashed var(--sx-hairline, #444);
+  border-radius: 6px;
+  opacity: 0.4;
+}
+.pass-bar__btn {
+  background: #4caf50;
+  border-color: #4caf50;
+  color: #0c2912;
+  font-weight: 700;
+  padding: 10px 20px;
+}
+.pass-bar__btn:disabled {
+  background: transparent;
+  color: inherit;
+  opacity: 0.6;
+}
+
+@media (max-width: 600px) {
+  .pass-bar {
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    margin: 18px -16px 0;
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
+    gap: 12px;
+    background: var(--sx-canvas-night, #000);
+    border-top: 1px solid var(--sx-hairline, #333);
+    box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.35);
+  }
+  .pass-bar__preview {
+    flex: 0 0 auto;
+  }
+  .pass-bar__btn {
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: center;
+  }
+}
+
 /* --- Round history: a compact scoreboard with expandable rows --- */
 .live-scores {
   display: flex;

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -1,0 +1,356 @@
+import { useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { api } from '../api/client'
+import type { LiveSeat, LiveMySeat, LivePublic } from '../api/client'
+import { useLiveTable, type SendAction } from '../lib/liveSocket'
+import { Card } from '../components/Card'
+import './LivePlay.css'
+
+const AI_OPTIONS = [
+  { value: 'random', label: 'Random' },
+  { value: 'rob', label: 'Rob' },
+  { value: 'claude', label: 'Claude' },
+]
+
+// --- Landing: create or join -------------------------------------------------
+
+export function LivePlayHome() {
+  const navigate = useNavigate()
+  const [code, setCode] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const create = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const { code } = await api.createLiveTable()
+      navigate(`/play/${code}`)
+    } catch (e) {
+      setError(String(e))
+      setBusy(false)
+    }
+  }
+
+  const join = (e: React.FormEvent) => {
+    e.preventDefault()
+    const c = code.trim().toUpperCase()
+    if (c) navigate(`/play/${c}`)
+  }
+
+  return (
+    <div>
+      <h1>Live play</h1>
+      <p className="muted" style={{ marginTop: -8 }}>
+        Create a table, add human seats (controlled from your browser) and AI opponents, then play a
+        real game on the server. Finished games show up under Lobby games.
+      </p>
+      <div className="card-surface live-home">
+        <div>
+          <h2 style={{ marginTop: 0 }}>New table</h2>
+          <button className="btn" onClick={create} disabled={busy}>
+            {busy ? 'Creating…' : 'Create table'}
+          </button>
+        </div>
+        <div className="live-home__divider" />
+        <div>
+          <h2 style={{ marginTop: 0 }}>Join a table</h2>
+          <form onSubmit={join} className="row-actions" style={{ gap: 10 }}>
+            <input
+              type="text"
+              placeholder="CODE"
+              value={code}
+              maxLength={6}
+              onChange={(e) => setCode(e.target.value.toUpperCase())}
+              style={{ width: 120, textTransform: 'uppercase', letterSpacing: 2 }}
+            />
+            <button className="btn" type="submit">Join</button>
+          </form>
+        </div>
+      </div>
+      {error && <p className="muted">Error: {error}</p>}
+    </div>
+  )
+}
+
+// --- Table (lobby + play) ----------------------------------------------------
+
+export function LiveTable() {
+  const { code = '' } = useParams()
+  const { snapshot, connected, error, send } = useLiveTable(code)
+
+  if (!snapshot) {
+    return (
+      <div>
+        <div className="crumbs"><Link to="/play">Live play</Link> / {code}</div>
+        <p className="muted">{connected ? 'Loading table…' : 'Connecting…'}</p>
+        {error && <p className="muted">Error: {error}</p>}
+      </div>
+    )
+  }
+
+  const { table, public: pub, you } = snapshot
+  const status = table.status
+
+  return (
+    <div>
+      <div className="crumbs"><Link to="/play">Live play</Link> / {code}</div>
+      <h1 className="live-title">
+        Table {table.code}
+        <span className={`pill live-status live-status--${status}`}>{status}</span>
+        {!connected && <span className="pill" style={{ marginLeft: 8 }}>reconnecting…</span>}
+      </h1>
+      <p className="muted" style={{ marginTop: -6, fontSize: 13 }}>
+        Share code <strong>{table.code}</strong> so others can join this table.
+      </p>
+
+      {error && <p className="live-error">{error}</p>}
+
+      {status === 'lobby' ? (
+        <Lobby seats={table.seats} send={send} />
+      ) : (
+        <PlayView pub={pub} mySeats={you.seats} send={send} />
+      )}
+    </div>
+  )
+}
+
+// --- Lobby: seat management --------------------------------------------------
+
+function Lobby({ seats, send }: { seats: LiveSeat[]; send: (a: SendAction) => void }) {
+  const allFilled = seats.every((s) => s.kind !== 'empty')
+  return (
+    <>
+      <div className="seat-grid">
+        {seats.map((seat) => (
+          <SeatCard key={seat.seat_id} seat={seat} send={send} />
+        ))}
+      </div>
+      <div className="row-actions" style={{ marginTop: 16 }}>
+        <button className="btn" disabled={!allFilled} onClick={() => send({ action: 'start' })}>
+          Start game
+        </button>
+        {!allFilled && <span className="muted" style={{ fontSize: 13 }}>Fill all four seats to start.</span>}
+      </div>
+    </>
+  )
+}
+
+function SeatCard({ seat, send }: { seat: LiveSeat; send: (a: SendAction) => void }) {
+  const [name, setName] = useState('')
+  const [ai, setAi] = useState('random')
+
+  return (
+    <div className={`card-surface seat-card ${seat.kind !== 'empty' ? 'seat-card--filled' : ''}`}>
+      <div className="seat-card__head">
+        <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>SEAT {seat.index + 1}</span>
+        {seat.kind !== 'empty' && (
+          <span className={`pill seat-kind seat-kind--${seat.kind}`}>
+            {seat.kind === 'human' ? (seat.mine ? 'you' : 'human') : 'ai'}
+          </span>
+        )}
+      </div>
+
+      {seat.kind === 'empty' ? (
+        <div className="seat-card__controls">
+          <div className="row-actions" style={{ gap: 6 }}>
+            <input
+              type="text"
+              placeholder="Your name"
+              value={name}
+              maxLength={20}
+              onChange={(e) => setName(e.target.value)}
+              style={{ width: 130 }}
+            />
+            <button
+              className="btn"
+              onClick={() => send({ action: 'add_human', seat_id: seat.seat_id, name })}
+            >
+              Sit here
+            </button>
+          </div>
+          <div className="row-actions" style={{ gap: 6 }}>
+            <select className="btn" value={ai} onChange={(e) => setAi(e.target.value)}>
+              {AI_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+            <button
+              className="btn"
+              onClick={() => send({ action: 'add_ai', seat_id: seat.seat_id, ai_type: ai })}
+            >
+              Add AI
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="seat-card__filled">
+          <div className="seat-card__name">{seat.name}</div>
+          {seat.kind === 'ai' && <div className="muted" style={{ fontSize: 12 }}>{seat.ai_type} bot</div>}
+          <button
+            className="btn"
+            style={{ marginTop: 10 }}
+            onClick={() => send({ action: 'clear_seat', seat_id: seat.seat_id })}
+          >
+            Clear
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Play view ---------------------------------------------------------------
+
+function PlayView({
+  pub,
+  mySeats,
+  send,
+}: {
+  pub: LivePublic | null
+  mySeats: LiveMySeat[]
+  send: (a: SendAction) => void
+}) {
+  if (!pub) return <p className="muted">Waiting for the game to begin…</p>
+  const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
+  const trickCard: Record<string, string> = {}
+  for (const m of pub.current_trick.moves) trickCard[m.player] = m.card
+
+  return (
+    <>
+      <div className="card-surface live-table-info">
+        <div>
+          <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>ROUND</span>
+          <div className="live-stat">{pub.round_idx != null ? pub.round_idx + 1 : '—'}</div>
+        </div>
+        <div>
+          <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>PASS</span>
+          <div className="live-stat">{pub.pass_direction ?? '—'}</div>
+        </div>
+        <div>
+          <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>TRICK</span>
+          <div className="live-stat">{pub.completed_trick_count + 1} / 13</div>
+        </div>
+      </div>
+
+      {/* Table: players with the card they've played this trick. */}
+      <div className="live-seats">
+        {pub.player_order.map((pid) => {
+          const isTurn = pub.turn === pid
+          return (
+            <div key={pid} className={`live-seat ${isTurn ? 'live-seat--turn' : ''}`}>
+              <div className="live-seat__name">
+                {nameOf(pid)}
+                {isTurn && <span className="pill live-seat__turn">to play</span>}
+              </div>
+              <div className="live-seat__card">
+                {trickCard[pid] ? <Card code={trickCard[pid]} size="md" /> : <div className="live-seat__empty" />}
+              </div>
+              <div className="muted live-seat__score">
+                {pub.scores[pid] ?? 0} pts
+                {(pub.round_points[pid] ?? 0) > 0 && <span> · +{pub.round_points[pid]} this round</span>}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {pub.winner && (
+        <div className="card-surface live-winner">
+          <h2 style={{ margin: 0 }}>Game over — {nameOf(pub.winner)} wins</h2>
+          <div className="muted" style={{ marginTop: 6 }}>
+            Final: {pub.player_order.map((pid) => `${nameOf(pid)} ${pub.final_points[pid] ?? 0}`).join(' · ')}
+          </div>
+          <p style={{ marginTop: 10 }}>
+            <Link to="/lobby" className="btn">View in lobby games</Link>
+          </p>
+        </div>
+      )}
+
+      {/* My private seats: hand + pass/move controls. */}
+      {mySeats.map((seat) => (
+        <MySeatPanel key={seat.seat_id} seat={seat} send={send} />
+      ))}
+    </>
+  )
+}
+
+function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) => void }) {
+  const [picked, setPicked] = useState<string[]>([])
+  const pending = seat.pending
+
+  // Reset pass selection whenever the pending prompt changes.
+  const promptKey = pending ? `${pending.kind}-${pending.trick_idx ?? ''}-${pending.hand.join(',')}` : 'idle'
+
+  const hand = pending?.hand ?? []
+  const legal = new Set(pending?.legal_moves ?? [])
+
+  const togglePass = (card: string) => {
+    setPicked((prev) =>
+      prev.includes(card) ? prev.filter((c) => c !== card) : prev.length < 3 ? [...prev, card] : prev,
+    )
+  }
+
+  return (
+    <div className="card-surface my-seat" key={promptKey}>
+      <div className="my-seat__head">
+        <strong>{seat.name}</strong>
+        <span className="muted" style={{ fontSize: 12 }}> — your hand</span>
+        {pending?.kind === 'move' && <span className="pill my-seat__prompt">Choose a card to play</span>}
+        {pending?.kind === 'pass' && (
+          <span className="pill my-seat__prompt">
+            Pick 3 to pass {pending.pass_direction} ({picked.length}/3)
+          </span>
+        )}
+      </div>
+
+      {hand.length === 0 ? (
+        <p className="muted" style={{ fontSize: 13 }}>Waiting…</p>
+      ) : pending?.kind === 'pass' ? (
+        <>
+          <div className="hand-row">
+            {hand.map((c) => (
+              <Card
+                key={c}
+                code={c}
+                size="md"
+                legal={picked.includes(c)}
+                onClick={() => togglePass(c)}
+                title="Click to select for passing"
+              />
+            ))}
+          </div>
+          <button
+            className="btn"
+            style={{ marginTop: 12 }}
+            disabled={picked.length !== 3}
+            onClick={() => send({ action: 'decide', seat_id: seat.seat_id, value: picked })}
+          >
+            Pass selected
+          </button>
+        </>
+      ) : pending?.kind === 'move' ? (
+        <div className="hand-row">
+          {hand.map((c) => {
+            const ok = legal.has(c)
+            return (
+              <Card
+                key={c}
+                code={c}
+                size="md"
+                legal={ok}
+                dim={!ok}
+                onClick={ok ? () => send({ action: 'decide', seat_id: seat.seat_id, value: c }) : undefined}
+                title={ok ? 'Click to play' : 'Not legal to play now'}
+              />
+            )
+          })}
+        </div>
+      ) : (
+        <div className="hand-row">
+          {hand.map((c) => <Card key={c} code={c} size="md" />)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api } from '../api/client'
-import type { LiveSeat, LiveMySeat, LivePublic, AiTypeOption, LiveAiSeat, LiveLogEntry } from '../api/client'
+import type { LiveSeat, LiveMySeat, LivePublic, LiveRound, AiTypeOption, LiveAiSeat, LiveLogEntry } from '../api/client'
 import { useLiveTable, type SendAction } from '../lib/liveSocket'
 import { Card } from '../components/Card'
 import { TrickRow } from '../components/TrickRow'
 import { SUIT_ORDER, sortBySuitThenRank, type Suit } from '../lib/cards'
 import { columnSeats, CENTER, passRecipient, passSource } from '../lib/seating'
+import { useColumnSlide } from '../lib/useColumnSlide'
 import './LivePlay.css'
 
 /** Split a hand into suit groups (suit-then-rank sorted) for gapped rendering. */
@@ -103,7 +104,7 @@ export function LivePlayHome() {
 
 export function LiveTable() {
   const { code = '' } = useParams()
-  const { snapshot, connected, error, send } = useLiveTable(code)
+  const { snapshot, connected, error, send, serverOffset } = useLiveTable(code)
 
   if (!snapshot) {
     return (
@@ -135,7 +136,7 @@ export function LiveTable() {
       {status === 'lobby' ? (
         <Lobby seats={table.seats} send={send} />
       ) : (
-        <PlayView pub={pub} mySeats={you.seats} aiSeats={you.ai ?? []} send={send} />
+        <PlayView pub={pub} mySeats={you.seats} aiSeats={you.ai ?? []} send={send} serverOffset={serverOffset} />
       )}
     </div>
   )
@@ -251,16 +252,29 @@ function PlayView({
   mySeats,
   aiSeats,
   send,
+  serverOffset,
 }: {
   pub: LivePublic | null
   mySeats: LiveMySeat[]
   aiSeats: LiveAiSeat[]
   send: (a: SendAction) => void
+  serverOffset: number
 }) {
   if (!pub) return <p className="muted">Waiting for the game to begin…</p>
   const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
   const trickCard: Record<string, string> = {}
   for (const m of pub.current_trick.moves) trickCard[m.player] = m.card
+
+  // Arrange the 4 players around a square table in game (seating) order, with
+  // "me" (or the first seat) at the bottom and the rest clockwise from there.
+  const center = mySeats.find((s) => pub.player_order.includes(s.pid))?.pid ?? pub.player_order[0]
+  const startIdx = Math.max(0, pub.player_order.indexOf(center))
+  const tablePos = ['bottom', 'left', 'top', 'right'] as const
+  const seatAt: Record<string, string> = {}
+  pub.player_order.forEach((_, i) => {
+    const pid = pub.player_order[(startIdx + i) % pub.player_order.length]
+    seatAt[tablePos[i] ?? 'bottom'] = pid
+  })
 
   return (
     <>
@@ -282,26 +296,36 @@ function PlayView({
       {/* This round so far: passing + completed tricks, same UI as tournaments. */}
       <RoundHistory pub={pub} mySeats={mySeats} />
 
-      {/* Table: players with the card they've played this trick. */}
-      <div className="live-seats">
-        {pub.player_order.map((pid) => {
+      {/* Table: the 4 players arranged around a square in seating order, each
+          showing the card they've played this trick. Fixed proportions so the
+          layout reads the same on mobile and desktop. */}
+      <div className="live-table">
+        {tablePos.map((pos) => {
+          const pid = seatAt[pos]
+          if (!pid) return <div key={pos} className={`live-seat-slot live-seat-slot--${pos}`} />
           const isTurn = pub.turn === pid
           return (
-            <div key={pid} className={`live-seat ${isTurn ? 'live-seat--turn' : ''}`}>
-              <div className="live-seat__name">
-                {nameOf(pid)}
-                {isTurn && <span className="pill live-seat__turn">to play</span>}
-              </div>
-              <div className="live-seat__card">
-                {trickCard[pid] ? <Card code={trickCard[pid]} size="md" /> : <div className="live-seat__empty" />}
-              </div>
-              <div className="muted live-seat__score">
-                {pub.scores[pid] ?? 0} pts
-                {(pub.round_points[pid] ?? 0) > 0 && <span> · +{pub.round_points[pid]} this round</span>}
+            <div key={pos} className={`live-seat-slot live-seat-slot--${pos}`}>
+              <div className={`live-seat ${isTurn ? 'live-seat--turn' : ''}`}>
+                <div className="live-seat__name">
+                  {nameOf(pid)}
+                  {isTurn && <span className="pill live-seat__turn">to play</span>}
+                </div>
+                <div className="live-seat__card">
+                  {trickCard[pid] ? <Card code={trickCard[pid]} size="md" /> : <div className="live-seat__empty" />}
+                </div>
+                <div className="muted live-seat__score">
+                  {pub.scores[pid] ?? 0} pts
+                  {(pub.round_points[pid] ?? 0) > 0 && <span> · +{pub.round_points[pid]} this round</span>}
+                </div>
               </div>
             </div>
           )
         })}
+        <div className="live-table__center">
+          <span className="live-table__center-trick">Trick {pub.completed_trick_count + 1}/13</span>
+          {pub.pass_direction && <span className="live-table__center-pass">{pub.pass_direction}</span>}
+        </div>
       </div>
 
       {pub.winner && (
@@ -318,7 +342,7 @@ function PlayView({
 
       {/* My private seats: hand + pass/move controls. */}
       {mySeats.map((seat) => (
-        <MySeatPanel key={seat.seat_id} seat={seat} send={send} />
+        <MySeatPanel key={seat.seat_id} seat={seat} send={send} serverOffset={serverOffset} />
       ))}
 
       {/* AI players I'm running: live activity so I can see a slow/hung bot. */}
@@ -379,75 +403,198 @@ function AiSeatLog({ seat }: { seat: LiveAiSeat }) {
   )
 }
 
-// --- Round history: passing + completed tricks (tournament-style) ------------
+// --- Round history: an expandable table per round ----------------------------
+// Each round shows its passing info followed by its tricks (same TrickRow UI as
+// tournaments). A round auto-collapses once it has finished AND the *next* round
+// has begun play (i.e. its passing stage is complete), so attention stays on the
+// live round while finished rounds fold away — manually toggleable either way.
 
 function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[] }) {
-  const tricks = pub.completed_tricks ?? []
+  const rounds = pub.rounds ?? []
   // Center the trick rows on my seat if I'm in this game, else the first seat.
   const me = mySeats.find((s) => pub.player_order.includes(s.pid))
-  const selected = me?.pid ?? pub.player_order[0]
+  const defaultSel = me?.pid ?? pub.player_order[0]
+  // Manual column-click selection overrides the default (my-seat) centering.
+  const [selOverride, setSelOverride] = useState<string | null>(null)
+  const selected = selOverride ?? defaultSel
+  // Per-round manual expand override (round_idx -> expanded?), else auto rule.
+  const [overrides, setOverrides] = useState<Record<number, boolean>>({})
+  const { selectColumn, containerRef } = useColumnSlide(pub.player_order, selected, setSelOverride)
+
+  if (!selected || rounds.length === 0) return null
+
   const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
-  const dir = pub.pass_direction
 
-  const passed = me?.passed ?? []
-  const received = me?.received ?? []
-  const showPass = !!me && !!dir && dir !== 'Keeper' && (passed.length > 0 || received.length > 0)
+  const byIdx = (idx: number) => rounds.find((r) => r.round_idx === idx)
+  const playStarted = (r: LiveRound) =>
+    r.tricks.length > 0 || (pub.round_idx === r.round_idx && pub.current_trick.trick_idx != null)
+  // Auto-collapse: round finished AND the next round's passing stage is done
+  // (its play has started). The latest/live round never auto-collapses.
+  const autoCollapsed = (r: LiveRound) => {
+    if (!r.complete) return false
+    const next = byIdx(r.round_idx + 1)
+    return !!next && playStarted(next)
+  }
 
-  if (!selected || (tricks.length === 0 && !showPass)) return null
+  return (
+    <div className="live-rounds" ref={containerRef}>
+      {rounds.map((r) => {
+        const expanded = overrides[r.round_idx] ?? !autoCollapsed(r)
+        const toggle = () =>
+          setOverrides((prev) => ({ ...prev, [r.round_idx]: !expanded }))
+        return (
+          <RoundPanel
+            key={r.round_idx}
+            round={r}
+            expanded={expanded}
+            onToggle={toggle}
+            pub={pub}
+            me={me}
+            selected={selected}
+            nameOf={nameOf}
+            selectColumn={selectColumn}
+          />
+        )
+      })}
+    </div>
+  )
+}
 
+function RoundPanel({
+  round,
+  expanded,
+  onToggle,
+  pub,
+  me,
+  selected,
+  nameOf,
+  selectColumn,
+}: {
+  round: LiveRound
+  expanded: boolean
+  onToggle: () => void
+  pub: LivePublic
+  me: LiveMySeat | undefined
+  selected: string
+  nameOf: (pid: string) => string
+  selectColumn: (col: number) => void
+}) {
+  const dir = round.pass_direction
   const seats = columnSeats(pub.player_order, selected)
+  const tricks = round.tricks ?? []
+
+  // My passing for this specific round (fall back to the live current-round
+  // fields, which the backend fills the moment a pass resolves).
+  const ridStr = String(round.round_idx)
+  const passed =
+    me?.passed_by_round?.[ridStr] ?? (pub.round_idx === round.round_idx ? me?.passed : undefined) ?? []
+  const received =
+    me?.received_by_round?.[ridStr] ??
+    (pub.round_idx === round.round_idx ? me?.received : undefined) ??
+    []
+  const showPass = !!me && !!dir && dir !== 'Keeper' && (passed.length > 0 || received.length > 0)
   const recipient = me && dir ? passRecipient(selected, pub.player_order, dir) : selected
   const source = me && dir ? passSource(selected, pub.player_order, dir) : selected
 
+  const isLive = pub.round_idx === round.round_idx && !round.complete
+
   return (
-    <div className="card-surface live-history">
-      <div className="live-history__title">This round so far</div>
+    <div className="card-surface live-round">
+      <button className="live-round__head" onClick={onToggle} aria-expanded={expanded}>
+        <span className={`live-round__chevron ${expanded ? 'is-open' : ''}`}>▸</span>
+        <span className="live-round__title">Round {round.round_idx + 1}</span>
+        {dir && <span className="pill live-round__pass">{dir}</span>}
+        {isLive && <span className="pill live-round__live">live</span>}
+        <span className="live-round__summary">
+          {round.complete
+            ? pub.player_order
+                .map((pid) => `${nameOf(pid)} +${round.scores[pid] ?? 0}`)
+                .join(' · ')
+            : `${tricks.length} / 13 tricks`}
+        </span>
+      </button>
 
-      {showPass && (
-        <div className="live-pass-summary">
-          <div className="live-pass-summary__leg">
-            <span className="muted">You passed</span>
-            <div className="hand-suit-group">{passed.map((c) => <Card key={c} code={c} size="sm" />)}</div>
-            <span className="muted">to {nameOf(recipient)}</span>
-          </div>
-          <div className="live-pass-summary__leg">
-            <span className="muted">Received</span>
-            <div className="hand-suit-group">{received.map((c) => <Card key={c} code={c} size="sm" />)}</div>
-            <span className="muted">from {nameOf(source)}</span>
-          </div>
-        </div>
-      )}
+      {expanded && (
+        <div className="live-round__body">
+          {showPass && (
+            <div className="live-pass-summary">
+              <div className="live-pass-summary__leg">
+                <span className="muted">You passed</span>
+                <div className="hand-suit-group">{passed.map((c) => <Card key={c} code={c} size="sm" />)}</div>
+                <span className="muted">to {nameOf(recipient)}</span>
+              </div>
+              <div className="live-pass-summary__leg">
+                <span className="muted">Received</span>
+                <div className="hand-suit-group">{received.map((c) => <Card key={c} code={c} size="sm" />)}</div>
+                <span className="muted">from {nameOf(source)}</span>
+              </div>
+            </div>
+          )}
 
-      {tricks.length > 0 && (
-        <div className="live-tricks">
-          {/* Column header aligned with the trick rows below (selected centered). */}
-          <div className="trick-row">
-            <div className="trick-row__label" />
-            <div className="trick-row__grid">
-              {seats.map((pid, col) => (
-                <div key={col} className={`trick-col ${col === CENTER ? 'trick-col--center' : ''}`}>
-                  <div className="trick-col__seat">{nameOf(pid)}</div>
+          {tricks.length > 0 ? (
+            <div className="live-tricks">
+              {/* Column header aligned with the trick rows; click to recenter. */}
+              <div className="trick-row">
+                <div className="trick-row__label" />
+                <div className="trick-row__grid">
+                  {seats.map((pid, col) => {
+                    const isCenter = col === CENTER
+                    return (
+                      <div
+                        key={col}
+                        className={`trick-col ${isCenter ? 'trick-col--center' : 'trick-col--clickable'}`}
+                        onClick={isCenter ? undefined : () => selectColumn(col)}
+                        title={isCenter ? undefined : `Center on ${nameOf(pid)}`}
+                      >
+                        <div className="trick-col__seat">{nameOf(pid)}</div>
+                      </div>
+                    )
+                  })}
                 </div>
+                <div className="trick-row__pts" />
+              </div>
+              {tricks.map((t) => (
+                <TrickRow
+                  key={t.trick_idx}
+                  trick={t}
+                  trickIndex={t.trick_idx}
+                  playerOrder={pub.player_order}
+                  selected={selected}
+                />
               ))}
             </div>
-            <div className="trick-row__pts" />
-          </div>
-          {tricks.map((t) => (
-            <TrickRow
-              key={t.trick_idx}
-              trick={t}
-              trickIndex={t.trick_idx}
-              playerOrder={pub.player_order}
-              selected={selected}
-            />
-          ))}
+          ) : (
+            !showPass && <p className="muted" style={{ fontSize: 13, margin: 0 }}>No tricks yet…</p>
+          )}
         </div>
       )}
     </div>
   )
 }
 
-function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) => void }) {
+/** Shrinking countdown bar for a pending human decision; turns amber then red
+ *  as the server's auto-decide deadline approaches. Skew-free via serverOffset. */
+function DecisionTimer({ deadline, timeoutS, serverOffset }: { deadline: number; timeoutS: number; serverOffset: number }) {
+  const [, tick] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => tick((n) => n + 1), 200)
+    return () => clearInterval(id)
+  }, [])
+  const serverNow = Date.now() / 1000 + serverOffset
+  const remaining = Math.max(0, deadline - serverNow)
+  const frac = timeoutS > 0 ? Math.max(0, Math.min(1, remaining / timeoutS)) : 0
+  const level = remaining <= 10 ? 'danger' : remaining <= 30 ? 'warn' : 'ok'
+  return (
+    <div className="decision-timer" title="Time left before the server auto-plays for you">
+      <div className="decision-timer__bar">
+        <div className={`decision-timer__fill decision-timer__fill--${level}`} style={{ width: `${frac * 100}%` }} />
+      </div>
+      <span className={`decision-timer__secs decision-timer__secs--${level}`}>{Math.ceil(remaining)}s</span>
+    </div>
+  )
+}
+
+function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a: SendAction) => void; serverOffset: number }) {
   const [picked, setPicked] = useState<string[]>([])
   const pending = seat.pending
 
@@ -485,6 +632,9 @@ function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) =
           <span className="pill my-seat__prompt">
             Pick 3 to pass {pending.pass_direction} ({picked.length}/3)
           </span>
+        )}
+        {pending && pending.deadline != null && (
+          <DecisionTimer deadline={pending.deadline} timeoutS={pending.timeout_s ?? 0} serverOffset={serverOffset} />
         )}
       </div>
 

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -287,15 +287,18 @@ function PlayView({
   const trickCard: Record<string, string> = {}
   for (const m of pub.current_trick.moves) trickCard[m.player] = m.card
 
-  // Arrange the 4 players around a square table in game (seating) order, with
-  // "me" (or the first seat) at the bottom and the rest clockwise from there.
+  // Arrange the 4 players in the quadrants of a 2x2 grid in game (seating)
+  // order, with "me" (or the first seat) bottom-left and the rest going
+  // clockwise from there (bl → tl → tr → br). A central column holds the
+  // direction ring. Packing two seats per row keeps the table compact on
+  // narrow mobile screens.
   const center = mySeats.find((s) => pub.player_order.includes(s.pid))?.pid ?? pub.player_order[0]
   const startIdx = Math.max(0, pub.player_order.indexOf(center))
-  const tablePos = ['bottom', 'left', 'top', 'right'] as const
+  const tablePos = ['bl', 'tl', 'tr', 'br'] as const
   const seatAt: Record<string, string> = {}
   pub.player_order.forEach((_, i) => {
     const pid = pub.player_order[(startIdx + i) % pub.player_order.length]
-    seatAt[tablePos[i] ?? 'bottom'] = pid
+    seatAt[tablePos[i] ?? 'bl'] = pid
   })
 
   return (
@@ -662,8 +665,16 @@ function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a:
   const [picked, setPicked] = useState<string[]>([])
   const pending = seat.pending
 
-  // Reset pass selection whenever the pending prompt changes.
+  // Clear the pass selection whenever the prompt changes (e.g. a new round's
+  // pass, or moving on to play). Resetting during render — rather than via the
+  // component key, which is pinned to seat_id and never changes between rounds —
+  // avoids carrying stale picks the player no longer holds.
   const promptKey = pending ? `${pending.kind}-${pending.trick_idx ?? ''}-${pending.hand.join(',')}` : 'idle'
+  const [lastPromptKey, setLastPromptKey] = useState(promptKey)
+  if (promptKey !== lastPromptKey) {
+    setLastPromptKey(promptKey)
+    setPicked([])
+  }
 
   const hand = pending?.hand ?? []
   const legal = new Set(pending?.legal_moves ?? [])
@@ -687,7 +698,7 @@ function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a:
   )
 
   return (
-    <div className="card-surface my-seat" key={promptKey}>
+    <div className="card-surface my-seat">
       <div className="my-seat__head">
         <strong>{seat.name}</strong>
         <span className="muted" style={{ fontSize: 12 }}> — your hand</span>

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -403,11 +403,15 @@ function AiSeatLog({ seat }: { seat: LiveAiSeat }) {
   )
 }
 
-// --- Round history: an expandable table per round ----------------------------
-// Each round shows its passing info followed by its tricks (same TrickRow UI as
-// tournaments). A round auto-collapses once it has finished AND the *next* round
-// has begun play (i.e. its passing stage is complete), so attention stays on the
-// live round while finished rounds fold away — manually toggleable either way.
+// --- Round history: a compact scoreboard with expandable rows ----------------
+// One shared header names each player as a column; every round is a single row
+// of the points each player took that round (so names aren't repeated per
+// round), and a Total row carries the running game score. Clicking a round row
+// expands its passing + tricks (same TrickRow UI as tournaments) inline below.
+// A round auto-collapses once it has finished AND the *next* round has begun
+// play, so attention stays on the live round — manually toggleable either way.
+
+const PASS_ABBR: Record<string, string> = { Left: 'L', Right: 'R', Across: 'A', Keeper: '—' }
 
 function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[] }) {
   const rounds = pub.rounds ?? []
@@ -436,14 +440,27 @@ function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[]
     return !!next && playStarted(next)
   }
 
+  // Shared grid: round | pass | one fractional column per player.
+  const gridStyle = { ['--player-cols' as string]: String(pub.player_order.length) } as React.CSSProperties
+
   return (
-    <div className="live-rounds" ref={containerRef}>
+    <div className="card-surface live-scores" ref={containerRef}>
+      <div className="live-scores__row live-scores__row--head" style={gridStyle}>
+        <div className="live-scores__round muted">Round</div>
+        <div className="live-scores__pass muted">Pass</div>
+        {pub.player_order.map((pid) => (
+          <div key={pid} className="live-scores__pts live-scores__name" title={nameOf(pid)}>
+            {nameOf(pid)}
+          </div>
+        ))}
+      </div>
+
       {rounds.map((r) => {
         const expanded = overrides[r.round_idx] ?? !autoCollapsed(r)
         const toggle = () =>
           setOverrides((prev) => ({ ...prev, [r.round_idx]: !expanded }))
         return (
-          <RoundPanel
+          <RoundRow
             key={r.round_idx}
             round={r}
             expanded={expanded}
@@ -453,14 +470,23 @@ function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[]
             selected={selected}
             nameOf={nameOf}
             selectColumn={selectColumn}
+            gridStyle={gridStyle}
           />
         )
       })}
+
+      <div className="live-scores__row live-scores__row--total" style={gridStyle}>
+        <div className="live-scores__round">Total</div>
+        <div className="live-scores__pass" />
+        {pub.player_order.map((pid) => (
+          <div key={pid} className="live-scores__pts">{pub.scores[pid] ?? 0}</div>
+        ))}
+      </div>
     </div>
   )
 }
 
-function RoundPanel({
+function RoundRow({
   round,
   expanded,
   onToggle,
@@ -469,6 +495,7 @@ function RoundPanel({
   selected,
   nameOf,
   selectColumn,
+  gridStyle,
 }: {
   round: LiveRound
   expanded: boolean
@@ -478,6 +505,7 @@ function RoundPanel({
   selected: string
   nameOf: (pid: string) => string
   selectColumn: (col: number) => void
+  gridStyle: React.CSSProperties
 }) {
   const dir = round.pass_direction
   const seats = columnSeats(pub.player_order, selected)
@@ -499,23 +527,34 @@ function RoundPanel({
   const isLive = pub.round_idx === round.round_idx && !round.complete
 
   return (
-    <div className="card-surface live-round">
-      <button className="live-round__head" onClick={onToggle} aria-expanded={expanded}>
-        <span className={`live-round__chevron ${expanded ? 'is-open' : ''}`}>▸</span>
-        <span className="live-round__title">Round {round.round_idx + 1}</span>
-        {dir && <span className="pill live-round__pass">{dir}</span>}
-        {isLive && <span className="pill live-round__live">live</span>}
-        <span className="live-round__summary">
-          {round.complete
-            ? pub.player_order
-                .map((pid) => `${nameOf(pid)} +${round.scores[pid] ?? 0}`)
-                .join(' · ')
-            : `${tricks.length} / 13 tricks`}
-        </span>
+    <>
+      <button
+        className={`live-scores__row live-scores__row--round ${isLive ? 'is-live' : ''}`}
+        style={gridStyle}
+        onClick={onToggle}
+        aria-expanded={expanded}
+      >
+        <div className="live-scores__round">
+          <span className={`live-round__chevron ${expanded ? 'is-open' : ''}`}>▸</span>
+          <span className="live-scores__rnum">{round.round_idx + 1}</span>
+          {isLive && <span className="live-scores__livedot" title="Live round" />}
+        </div>
+        <div className="live-scores__pass">{dir ? PASS_ABBR[dir] ?? dir[0] : '—'}</div>
+        {pub.player_order.map((pid) => {
+          // Completed rounds show the final delta; the live round shows running
+          // points so far; not-yet-played rounds show a placeholder dot.
+          const done = round.complete
+          const val = done ? round.scores[pid] ?? 0 : isLive ? pub.round_points[pid] ?? 0 : null
+          return (
+            <div key={pid} className={`live-scores__pts ${done ? '' : 'is-pending'}`}>
+              {val == null ? '·' : val}
+            </div>
+          )
+        })}
       </button>
 
-      {expanded && (
-        <div className="live-round__body">
+      {expanded && (showPass || tricks.length > 0) && (
+        <div className="live-scores__detail">
           {showPass && (
             <div className="live-pass-summary">
               <div className="live-pass-summary__leg">
@@ -568,7 +607,7 @@ function RoundPanel({
           )}
         </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -4,7 +4,16 @@ import { api } from '../api/client'
 import type { LiveSeat, LiveMySeat, LivePublic } from '../api/client'
 import { useLiveTable, type SendAction } from '../lib/liveSocket'
 import { Card } from '../components/Card'
+import { TrickRow } from '../components/TrickRow'
+import { SUIT_ORDER, sortBySuitThenRank, type Suit } from '../lib/cards'
+import { columnSeats, CENTER, passRecipient, passSource } from '../lib/seating'
 import './LivePlay.css'
+
+/** Split a hand into suit groups (suit-then-rank sorted) for gapped rendering. */
+function suitGroups(hand: string[]): string[][] {
+  const sorted = sortBySuitThenRank(hand)
+  return SUIT_ORDER.map((s) => sorted.filter((c) => (c[1] as Suit) === s)).filter((g) => g.length > 0)
+}
 
 const AI_OPTIONS = [
   { value: 'random', label: 'Random' },
@@ -233,6 +242,9 @@ function PlayView({
         </div>
       </div>
 
+      {/* This round so far: passing + completed tricks, same UI as tournaments. */}
+      <RoundHistory pub={pub} mySeats={mySeats} />
+
       {/* Table: players with the card they've played this trick. */}
       <div className="live-seats">
         {pub.player_order.map((pid) => {
@@ -275,6 +287,74 @@ function PlayView({
   )
 }
 
+// --- Round history: passing + completed tricks (tournament-style) ------------
+
+function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[] }) {
+  const tricks = pub.completed_tricks ?? []
+  // Center the trick rows on my seat if I'm in this game, else the first seat.
+  const me = mySeats.find((s) => pub.player_order.includes(s.pid))
+  const selected = me?.pid ?? pub.player_order[0]
+  const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
+  const dir = pub.pass_direction
+
+  const passed = me?.passed ?? []
+  const received = me?.received ?? []
+  const showPass = !!me && !!dir && dir !== 'Keeper' && (passed.length > 0 || received.length > 0)
+
+  if (!selected || (tricks.length === 0 && !showPass)) return null
+
+  const seats = columnSeats(pub.player_order, selected)
+  const recipient = me && dir ? passRecipient(selected, pub.player_order, dir) : selected
+  const source = me && dir ? passSource(selected, pub.player_order, dir) : selected
+
+  return (
+    <div className="card-surface live-history">
+      <div className="live-history__title">This round so far</div>
+
+      {showPass && (
+        <div className="live-pass-summary">
+          <div className="live-pass-summary__leg">
+            <span className="muted">You passed</span>
+            <div className="hand-suit-group">{passed.map((c) => <Card key={c} code={c} size="sm" />)}</div>
+            <span className="muted">to {nameOf(recipient)}</span>
+          </div>
+          <div className="live-pass-summary__leg">
+            <span className="muted">Received</span>
+            <div className="hand-suit-group">{received.map((c) => <Card key={c} code={c} size="sm" />)}</div>
+            <span className="muted">from {nameOf(source)}</span>
+          </div>
+        </div>
+      )}
+
+      {tricks.length > 0 && (
+        <div className="live-tricks">
+          {/* Column header aligned with the trick rows below (selected centered). */}
+          <div className="trick-row">
+            <div className="trick-row__label" />
+            <div className="trick-row__grid">
+              {seats.map((pid, col) => (
+                <div key={col} className={`trick-col ${col === CENTER ? 'trick-col--center' : ''}`}>
+                  <div className="trick-col__seat">{nameOf(pid)}</div>
+                </div>
+              ))}
+            </div>
+            <div className="trick-row__pts" />
+          </div>
+          {tricks.map((t) => (
+            <TrickRow
+              key={t.trick_idx}
+              trick={t}
+              trickIndex={t.trick_idx}
+              playerOrder={pub.player_order}
+              selected={selected}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) => void }) {
   const [picked, setPicked] = useState<string[]>([])
   const pending = seat.pending
@@ -290,6 +370,18 @@ function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) =
       prev.includes(card) ? prev.filter((c) => c !== card) : prev.length < 3 ? [...prev, card] : prev,
     )
   }
+
+  // Render the hand grouped by suit (suit-then-rank sorted) with a gap between
+  // suits, matching the tournament hand layout.
+  const groupedHand = (renderCard: (c: string) => React.ReactNode) => (
+    <div className="hand-row">
+      {suitGroups(hand).map((g, i) => (
+        <div className="hand-suit-group" key={i}>
+          {g.map(renderCard)}
+        </div>
+      ))}
+    </div>
+  )
 
   return (
     <div className="card-surface my-seat" key={promptKey}>
@@ -308,18 +400,16 @@ function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) =
         <p className="muted" style={{ fontSize: 13 }}>Waiting…</p>
       ) : pending?.kind === 'pass' ? (
         <>
-          <div className="hand-row">
-            {hand.map((c) => (
-              <Card
-                key={c}
-                code={c}
-                size="md"
-                legal={picked.includes(c)}
-                onClick={() => togglePass(c)}
-                title="Click to select for passing"
-              />
-            ))}
-          </div>
+          {groupedHand((c) => (
+            <Card
+              key={c}
+              code={c}
+              size="md"
+              legal={picked.includes(c)}
+              onClick={() => togglePass(c)}
+              title="Click to select for passing"
+            />
+          ))}
           <button
             className="btn"
             style={{ marginTop: 12 }}
@@ -330,26 +420,22 @@ function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) =
           </button>
         </>
       ) : pending?.kind === 'move' ? (
-        <div className="hand-row">
-          {hand.map((c) => {
-            const ok = legal.has(c)
-            return (
-              <Card
-                key={c}
-                code={c}
-                size="md"
-                legal={ok}
-                dim={!ok}
-                onClick={ok ? () => send({ action: 'decide', seat_id: seat.seat_id, value: c }) : undefined}
-                title={ok ? 'Click to play' : 'Not legal to play now'}
-              />
-            )
-          })}
-        </div>
+        groupedHand((c) => {
+          const ok = legal.has(c)
+          return (
+            <Card
+              key={c}
+              code={c}
+              size="md"
+              legal={ok}
+              dim={!ok}
+              onClick={ok ? () => send({ action: 'decide', seat_id: seat.seat_id, value: c }) : undefined}
+              title={ok ? 'Click to play' : 'Not legal to play now'}
+            />
+          )
+        })
       ) : (
-        <div className="hand-row">
-          {hand.map((c) => <Card key={c} code={c} size="md" />)}
-        </div>
+        groupedHand((c) => <Card key={c} code={c} size="md" />)
       )}
     </div>
   )

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -247,6 +247,28 @@ function SeatCard({
 
 // --- Play view ---------------------------------------------------------------
 
+/** A clockwise ring of arrowheads in the table center: play always rotates
+ *  bottom → left → top → right (clockwise), so the four tangential arrows make
+ *  the move order legible at a glance without naming seats. */
+function PlayDirectionRing() {
+  // One arrowhead at the top of the ring pointing clockwise (to the right),
+  // duplicated at 90° steps so each sits between two seats, tangent to the ring.
+  const heads = [0, 90, 180, 270]
+  return (
+    <svg className="live-table__ring" viewBox="0 0 100 100" aria-hidden="true">
+      <circle className="live-table__ring-track" cx="50" cy="50" r="36" />
+      {heads.map((deg) => (
+        <polygon
+          key={deg}
+          className="live-table__ring-head"
+          points="46,11 46,19 54,15"
+          transform={`rotate(${deg} 50 50)`}
+        />
+      ))}
+    </svg>
+  )
+}
+
 function PlayView({
   pub,
   mySeats,
@@ -323,8 +345,11 @@ function PlayView({
           )
         })}
         <div className="live-table__center">
-          <span className="live-table__center-trick">Trick {pub.completed_trick_count + 1}/13</span>
-          {pub.pass_direction && <span className="live-table__center-pass">{pub.pass_direction}</span>}
+          <PlayDirectionRing />
+          <div className="live-table__center-text">
+            <span className="live-table__center-trick">Trick {pub.completed_trick_count + 1}/13</span>
+            {pub.pass_direction && <span className="live-table__center-pass">{pub.pass_direction}</span>}
+          </div>
         </div>
       </div>
 

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -713,17 +713,43 @@ function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a:
               size="md"
               selected={picked.includes(c)}
               onClick={() => togglePass(c)}
-              title={picked.includes(c) ? 'Click to deselect' : 'Click to select for passing'}
+              title={picked.includes(c) ? 'Tap to deselect' : 'Tap to select for passing'}
             />
           ))}
-          <button
-            className="btn"
-            style={{ marginTop: 12 }}
-            disabled={picked.length !== 3}
-            onClick={() => send({ action: 'decide', seat_id: seat.seat_id, value: picked })}
-          >
-            Pass selected
-          </button>
+          {/* Action bar: a live preview of the 3 picks plus a prominent button.
+              Sticks to the bottom of the viewport on phones so it stays in reach
+              while scrolling a 13-card hand. */}
+          <div className="pass-bar">
+            <div className="pass-bar__preview" aria-hidden={picked.length === 0}>
+              {picked.length === 0 ? (
+                <span className="muted pass-bar__hint">
+                  Tap 3 cards to pass {pending.pass_direction}
+                </span>
+              ) : (
+                [0, 1, 2].map((i) =>
+                  picked[i] ? (
+                    <Card
+                      key={i}
+                      code={picked[i]}
+                      size="sm"
+                      selected
+                      onClick={() => togglePass(picked[i])}
+                      title="Tap to deselect"
+                    />
+                  ) : (
+                    <span key={i} className="pass-bar__slot" />
+                  ),
+                )
+              )}
+            </div>
+            <button
+              className="btn pass-bar__btn"
+              disabled={picked.length !== 3}
+              onClick={() => send({ action: 'decide', seat_id: seat.seat_id, value: picked })}
+            >
+              {picked.length === 3 ? 'Pass these 3 →' : `Pick ${3 - picked.length} more`}
+            </button>
+          </div>
         </>
       ) : pending?.kind === 'move' ? (
         groupedHand((c) => {

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api } from '../api/client'
-import type { LiveSeat, LiveMySeat, LivePublic } from '../api/client'
+import type { LiveSeat, LiveMySeat, LivePublic, AiTypeOption, LiveAiSeat, LiveLogEntry } from '../api/client'
 import { useLiveTable, type SendAction } from '../lib/liveSocket'
 import { Card } from '../components/Card'
 import { TrickRow } from '../components/TrickRow'
@@ -15,11 +15,28 @@ function suitGroups(hand: string[]): string[][] {
   return SUIT_ORDER.map((s) => sorted.filter((c) => (c[1] as Suit) === s)).filter((g) => g.length > 0)
 }
 
-const AI_OPTIONS = [
-  { value: 'random', label: 'Random' },
-  { value: 'rob', label: 'Rob' },
-  { value: 'claude', label: 'Claude' },
-]
+// AI seat options are discovered by the backend (every Player subclass under
+// clients/python/players), so adding a bot needs no frontend change. Cache the
+// fetch at module scope — the list is stable for the app's lifetime.
+let aiTypesCache: AiTypeOption[] | null = null
+function useAiTypes(): AiTypeOption[] {
+  const [opts, setOpts] = useState<AiTypeOption[]>(aiTypesCache ?? [])
+  useEffect(() => {
+    if (aiTypesCache) return
+    let alive = true
+    api
+      .aiTypes()
+      .then((r) => {
+        aiTypesCache = r.ai_types
+        if (alive) setOpts(r.ai_types)
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [])
+  return opts
+}
 
 // --- Landing: create or join -------------------------------------------------
 
@@ -118,7 +135,7 @@ export function LiveTable() {
       {status === 'lobby' ? (
         <Lobby seats={table.seats} send={send} />
       ) : (
-        <PlayView pub={pub} mySeats={you.seats} send={send} />
+        <PlayView pub={pub} mySeats={you.seats} aiSeats={you.ai ?? []} send={send} />
       )}
     </div>
   )
@@ -128,11 +145,12 @@ export function LiveTable() {
 
 function Lobby({ seats, send }: { seats: LiveSeat[]; send: (a: SendAction) => void }) {
   const allFilled = seats.every((s) => s.kind !== 'empty')
+  const aiOptions = useAiTypes()
   return (
     <>
       <div className="seat-grid">
         {seats.map((seat) => (
-          <SeatCard key={seat.seat_id} seat={seat} send={send} />
+          <SeatCard key={seat.seat_id} seat={seat} send={send} aiOptions={aiOptions} />
         ))}
       </div>
       <div className="row-actions" style={{ marginTop: 16 }}>
@@ -145,9 +163,20 @@ function Lobby({ seats, send }: { seats: LiveSeat[]; send: (a: SendAction) => vo
   )
 }
 
-function SeatCard({ seat, send }: { seat: LiveSeat; send: (a: SendAction) => void }) {
+function SeatCard({
+  seat,
+  send,
+  aiOptions,
+}: {
+  seat: LiveSeat
+  send: (a: SendAction) => void
+  aiOptions: AiTypeOption[]
+}) {
   const [name, setName] = useState('')
-  const [ai, setAi] = useState('random')
+  const [ai, setAi] = useState('')
+  // Until the user picks, default to Random when available, else the first option.
+  const preferred = aiOptions.find((o) => o.value === 'random_player')?.value
+  const selectedAi = ai || preferred || aiOptions[0]?.value || ''
 
   return (
     <div className={`card-surface seat-card ${seat.kind !== 'empty' ? 'seat-card--filled' : ''}`}>
@@ -179,14 +208,20 @@ function SeatCard({ seat, send }: { seat: LiveSeat; send: (a: SendAction) => voi
             </button>
           </div>
           <div className="row-actions" style={{ gap: 6 }}>
-            <select className="btn" value={ai} onChange={(e) => setAi(e.target.value)}>
-              {AI_OPTIONS.map((o) => (
+            <select
+              className="btn"
+              value={selectedAi}
+              disabled={aiOptions.length === 0}
+              onChange={(e) => setAi(e.target.value)}
+            >
+              {aiOptions.map((o) => (
                 <option key={o.value} value={o.value}>{o.label}</option>
               ))}
             </select>
             <button
               className="btn"
-              onClick={() => send({ action: 'add_ai', seat_id: seat.seat_id, ai_type: ai })}
+              disabled={!selectedAi}
+              onClick={() => send({ action: 'add_ai', seat_id: seat.seat_id, ai_type: selectedAi })}
             >
               Add AI
             </button>
@@ -214,10 +249,12 @@ function SeatCard({ seat, send }: { seat: LiveSeat; send: (a: SendAction) => voi
 function PlayView({
   pub,
   mySeats,
+  aiSeats,
   send,
 }: {
   pub: LivePublic | null
   mySeats: LiveMySeat[]
+  aiSeats: LiveAiSeat[]
   send: (a: SendAction) => void
 }) {
   if (!pub) return <p className="muted">Waiting for the game to begin…</p>
@@ -283,7 +320,62 @@ function PlayView({
       {mySeats.map((seat) => (
         <MySeatPanel key={seat.seat_id} seat={seat} send={send} />
       ))}
+
+      {/* AI players I'm running: live activity so I can see a slow/hung bot. */}
+      {aiSeats.length > 0 && (
+        <div className="card-surface ai-activity">
+          <div className="ai-activity__title">AI players you're running</div>
+          {aiSeats.map((seat) => (
+            <AiSeatLog key={seat.seat_id} seat={seat} />
+          ))}
+        </div>
+      )}
     </>
+  )
+}
+
+// --- AI activity log: shows what a bot you host is doing ----------------------
+
+/** Live "Xs" timer that ticks while a bot's action is still pending. */
+function Elapsed({ since }: { since: number }) {
+  const [now, setNow] = useState(() => Date.now() / 1000)
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now() / 1000), 250)
+    return () => clearInterval(id)
+  }, [])
+  const secs = Math.max(0, now - since)
+  return <span className="ai-log__timer"> · {secs.toFixed(1)}s</span>
+}
+
+function AiSeatLog({ seat }: { seat: LiveAiSeat }) {
+  const entries = seat.log ?? []
+  const last = entries[entries.length - 1]
+  const idle = !last || !last.pending
+  return (
+    <div className="ai-seat-log">
+      <div className="ai-seat-log__head">
+        <strong>{seat.name}</strong>
+        <span className="muted" style={{ fontSize: 12 }}> · {seat.ai_type} bot</span>
+        <span className={`pill ai-seat-log__state ai-seat-log__state--${idle ? 'idle' : 'busy'}`}>
+          {idle ? 'idle' : 'thinking'}
+        </span>
+      </div>
+      {entries.length === 0 ? (
+        <p className="muted" style={{ fontSize: 13, margin: '6px 0 0' }}>No activity yet…</p>
+      ) : (
+        <ul className="ai-log">
+          {entries
+            .slice()
+            .reverse()
+            .map((e: LiveLogEntry, i) => (
+              <li key={entries.length - 1 - i} className={`ai-log__line ai-log__line--${e.kind}`}>
+                <span className="ai-log__text">{e.text}</span>
+                {e.pending && i === 0 && <Elapsed since={e.t} />}
+              </li>
+            ))}
+        </ul>
+      )}
+    </div>
   )
 }
 
@@ -405,9 +497,9 @@ function MySeatPanel({ seat, send }: { seat: LiveMySeat; send: (a: SendAction) =
               key={c}
               code={c}
               size="md"
-              legal={picked.includes(c)}
+              selected={picked.includes(c)}
               onClick={() => togglePass(c)}
-              title="Click to select for passing"
+              title={picked.includes(c) ? 'Click to deselect' : 'Click to select for passing'}
             />
           ))}
           <button

--- a/web/frontend/src/pages/RoundDetail.tsx
+++ b/web/frontend/src/pages/RoundDetail.tsx
@@ -5,6 +5,7 @@ import { useFetch } from '../lib/useFetch'
 import { nameResolver, displayString } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
 import { columnSeats, NUM_COLS, CENTER, passRecipient, passSource } from '../lib/seating'
+import { useColumnSlide } from '../lib/useColumnSlide'
 import { handBeforePlay, handBeforePassing, legalMovesBeforePlay } from '../lib/reconstruct'
 import { TrickRow } from '../components/TrickRow'
 import { HandOverlay, type HandOverlayData } from '../components/HandOverlay'
@@ -21,6 +22,8 @@ export function RoundDetail({ lobby = false }: { lobby?: boolean }) {
   const round = data?.rounds[Number(roundIdx)]
   const [selected, setSelected] = useState<string>('')
   const [overlay, setOverlay] = useState<HandOverlayData | null>(null)
+  // Click a column header to center on that player, with a scroll animation.
+  const { selectColumn, containerRef } = useColumnSlide(data?.player_order ?? [], selected, setSelected)
 
   // Default the selected player to the first seat once data loads.
   useEffect(() => {
@@ -136,18 +139,9 @@ export function RoundDetail({ lobby = false }: { lobby?: boolean }) {
       </h1>
 
       <div className="row-actions">
-        <label className="muted" style={{ fontSize: 13 }}>
-          Selected player:{' '}
-          <select className="btn" value={selected} onChange={(e) => setSelected(e.target.value)}>
-            {data.player_order.map((p) => (
-              <option key={p} value={p}>
-                {displayString(nameOf(p))}
-              </option>
-            ))}
-          </select>
-        </label>
         <span className="muted" style={{ fontSize: 12 }}>
-          Click any card to see that player's hand just before the play.
+          Click a player's column header to center the view on them · click any card to see that
+          player's hand just before the play.
         </span>
       </div>
 
@@ -194,18 +188,29 @@ export function RoundDetail({ lobby = false }: { lobby?: boolean }) {
         )}
       </div>
 
-      <div className="card-surface">
-        {/* Column header aligned with the trick rows below. */}
+      <div
+        className="card-surface"
+        ref={containerRef as React.RefObject<HTMLDivElement>}
+      >
+        {/* Column header aligned with the trick rows below; click to recenter. */}
         <div className="trick-row" style={{ borderBottom: '2px solid #ddd' }}>
           <div className="trick-row__label" />
           <div className="trick-row__grid">
-            {Array.from({ length: NUM_COLS }, (_, col) => (
-              <div key={col} className={`trick-col ${col === CENTER ? 'trick-col--center' : ''}`}>
-                <div className="trick-col__seat">
-                  <PlayerName d={nameOf(seats[col])} />
+            {Array.from({ length: NUM_COLS }, (_, col) => {
+              const isCenter = col === CENTER
+              return (
+                <div
+                  key={col}
+                  className={`trick-col ${isCenter ? 'trick-col--center' : 'trick-col--clickable'}`}
+                  onClick={isCenter ? undefined : () => selectColumn(col)}
+                  title={isCenter ? undefined : `Center on ${displayString(nameOf(seats[col]))}`}
+                >
+                  <div className="trick-col__seat">
+                    <PlayerName d={nameOf(seats[col])} />
+                  </div>
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
           <div className="trick-row__pts" />
         </div>

--- a/web/frontend/src/theme-spacex.css
+++ b/web/frontend/src/theme-spacex.css
@@ -66,6 +66,27 @@
   opacity: 1;
 }
 
+/* ---- Mobile side drawer + hamburger (match dark theme) ---------------- */
+.theme-spacex .app-menu-btn {
+  border-color: var(--sx-hairline);
+  color: var(--sx-on-primary);
+}
+.theme-spacex .app-drawer__panel {
+  background: var(--sx-canvas-night-soft);
+  border-left-color: var(--sx-hairline);
+}
+.theme-spacex .app-drawer__panel a {
+  color: var(--sx-on-primary-mute);
+  text-transform: uppercase;
+  letter-spacing: 1.17px;
+  font-weight: 700;
+  opacity: 0.85;
+  transition: opacity 0.15s ease;
+}
+.theme-spacex .app-drawer__panel a:hover {
+  opacity: 1;
+}
+
 /* ---- Display typography ------------------------------------------------ */
 .theme-spacex h1 {
   font-family: var(--sx-display);

--- a/web/frontend/vite.config.ts
+++ b/web/frontend/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:8000',
+      // `ws: true` lets the live-play WebSocket (/api/live/ws/...) proxy through too.
+      '/api': { target: 'http://localhost:8000', ws: true },
     },
   },
 })

--- a/web/run_web.sh
+++ b/web/run_web.sh
@@ -1,64 +1,15 @@
 #!/bin/bash
 #
-# Bring up the Hearts web UI as a single process (serves /api + the built SPA).
+# DEPRECATED: use ../run.sh from the repo root instead.
 #
-# Idempotent: creates the Python venv and installs deps on first run, installs
-# node modules if missing, rebuilds the frontend, then execs uvicorn.
+# This used to bring up just the web UI. That logic now lives in the root-level
+# run.sh, which also runs the C++ lobby server and does a port pre-flight. This
+# shim keeps the old entrypoint (and CI) working by delegating to run.sh in
+# web-only mode (SKIP_SERVER defaults to 1 here so no Bazel/C++ server is
+# needed). Pass SKIP_SERVER=0 to also start the lobby server, or just call
+# ../run.sh directly.
 #
-# Usage:
-#   web/run_web.sh                 # build + serve on 0.0.0.0:8000
-#   PORT=9000 web/run_web.sh       # override port
-#   SKIP_BUILD=1 web/run_web.sh    # serve existing dist without rebuilding
-#
-# Env vars:
-#   HOST               bind address     (default 0.0.0.0)
-#   PORT               bind port        (default 8000)
-#   RESULTS_DIR        results location (default <repo>/results)
-#   SKIP_BUILD         set to 1 to skip the npm build step
-#
-# Auth (optional; controls who can see each round's private "cards passed"):
-#   WEB_ADMIN_PASSWORD admin login password — sign in with a blank team to see
-#                      every team's passed cards. If unset, admin login is off.
-#   Team login uses the TEAMS=name:password entries in tournament_server.env;
-#   a signed-in team sees only its own players' passed cards.
+# Usage / env vars are unchanged: HOST, PORT, RESULTS_DIR, SKIP_BUILD.
 
-set -e
-
-# Resolve paths relative to this script so it runs from anywhere.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BACKEND_DIR="$SCRIPT_DIR/backend"
-FRONTEND_DIR="$SCRIPT_DIR/frontend"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-HOST="${HOST:-0.0.0.0}"
-PORT="${PORT:-8000}"
-RESULTS_DIR="${RESULTS_DIR:-$REPO_ROOT/results}"
-VENV="$BACKEND_DIR/.venv"
-
-echo "==> Backend venv"
-if [ ! -d "$VENV" ]; then
-    echo "    creating venv at $VENV"
-    python3 -m venv "$VENV"
-fi
-"$VENV/bin/pip" install -q -r "$BACKEND_DIR/requirements.txt"
-
-echo "==> Frontend"
-if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
-    echo "    installing node modules"
-    npm --prefix "$FRONTEND_DIR" install
-fi
-if [ "${SKIP_BUILD:-0}" != "1" ]; then
-    echo "    building frontend"
-    npm --prefix "$FRONTEND_DIR" run build
-else
-    echo "    SKIP_BUILD=1, using existing dist/"
-fi
-
-if [ ! -d "$FRONTEND_DIR/dist" ]; then
-    echo "ERROR: $FRONTEND_DIR/dist not found; cannot serve the SPA." >&2
-    exit 1
-fi
-
-echo "==> Serving on http://$HOST:$PORT  (RESULTS_DIR=$RESULTS_DIR)"
-cd "$BACKEND_DIR"
-exec env RESULTS_DIR="$RESULTS_DIR" "$VENV/bin/uvicorn" main:app --host "$HOST" --port "$PORT"
+exec env SKIP_SERVER="${SKIP_SERVER:-1}" \
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/run.sh" "$@"


### PR DESCRIPTION
## Summary
Lands the live lobby play feature onto `main`. The JSON-logging groundwork is already on `main` (#48), so this is a clean replay of the 12 live-play commits on top of `main` — avoiding the squash/un-squash conflict that PR #49/#51 hit.

Includes:
- Browser-hosted human + AI Hearts games with per-round tables and click-column selection
- AI activity log, suit-grouped hands, mobile navigation
- Auto-move disabled for lobby play (humans get a real move budget)
- Square/quadrant mobile table with clockwise move-order ring
- Improved mobile passing UI and the stale-pass-selection fix

## Test plan
- [x] `cd web/frontend && npm run build` passes (validated at HEAD of the source branch)
- [ ] Live lobby play loads; a human+AI game plays through
- [ ] Mobile: 2x2 quadrant table renders; passing UI clears selection each round

🤖 Generated with [Claude Code](https://claude.com/claude-code)