### PR TITLE
Stop WebSocket 403 reconnect spam for missing tables

### DIFF
--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -122,7 +122,12 @@ def get_live_table(code: str):
 async def live_ws(websocket: WebSocket, code: str, client_id: str):
     table = live.manager.get(code)
     if table is None:
-        await websocket.close(code=4404)
+        # Accept first, *then* close with an application code. Closing before
+        # accept makes the ASGI layer reject the handshake with HTTP 403, which
+        # (a) spams the logs and (b) hides the reason from the client, whose
+        # onclose only sees a generic abnormal close and reconnects forever.
+        await websocket.accept()
+        await websocket.close(code=4404, reason="table not found")
         return
     await websocket.accept()
     table.loop = asyncio.get_running_loop()
@@ -185,7 +190,10 @@ def get_table_session(code: str):
 async def table_ws(websocket: WebSocket, code: str):
     session = table.manager.get(code)
     if session is None:
-        await websocket.close(code=4404)
+        # See live_ws: accept before closing so the client receives a real
+        # 4404 close code instead of a handshake-level 403 it can't interpret.
+        await websocket.accept()
+        await websocket.close(code=4404, reason="table session not found")
         return
     await websocket.accept()
     session.loop = asyncio.get_running_loop()

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -55,15 +55,26 @@ export function useLiveTable(code: string | undefined): LiveConnection {
     if (!code) return
     let closed = false
     let retry: ReturnType<typeof setTimeout> | undefined
+    let backoff = 1000
 
     const connect = () => {
       if (closed) return
       const ws = new WebSocket(wsUrl(code))
       wsRef.current = ws
-      ws.onopen = () => setConnected(true)
-      ws.onclose = () => {
+      ws.onopen = () => {
+        setConnected(true)
+        backoff = 1000 // reset backoff once a connection succeeds
+      }
+      ws.onclose = (ev) => {
         setConnected(false)
-        if (!closed) retry = setTimeout(connect, 1000) // simple reconnect
+        if (closed) return
+        if (ev.code === 4404) {
+          // Table no longer exists — retrying would just spam 403s forever.
+          setError('Table not found — it may have ended.')
+          return
+        }
+        retry = setTimeout(connect, backoff)
+        backoff = Math.min(backoff * 2, 30000) // exponential backoff, cap 30s
       }
       ws.onerror = () => ws.close()
       ws.onmessage = (ev) => {

--- a/web/frontend/src/lib/tableSocket.ts
+++ b/web/frontend/src/lib/tableSocket.ts
@@ -40,15 +40,26 @@ export function useTableSocket(code: string | undefined): TableConnection {
     if (!code) return
     let closed = false
     let retry: ReturnType<typeof setTimeout> | undefined
+    let backoff = 1000
 
     const connect = () => {
       if (closed) return
       const ws = new WebSocket(wsUrl(code))
       wsRef.current = ws
-      ws.onopen = () => setConnected(true)
-      ws.onclose = () => {
+      ws.onopen = () => {
+        setConnected(true)
+        backoff = 1000 // reset backoff once a connection succeeds
+      }
+      ws.onclose = (ev) => {
         setConnected(false)
-        if (!closed) retry = setTimeout(connect, 1000)
+        if (closed) return
+        if (ev.code === 4404) {
+          // Table session no longer exists — stop reconnecting.
+          setError('Table session not found — it may have ended.')
+          return
+        }
+        retry = setTimeout(connect, backoff)
+        backoff = Math.min(backoff * 2, 30000) // exponential backoff, cap 30s
       }
       ws.onerror = () => ws.close()
       ws.onmessage = (ev) => {


### PR DESCRIPTION
## Summary
- When a live/table WebSocket `code` didn't exist, the server closed the socket **before** `accept()`. Closing pre-accept makes the ASGI layer reject the handshake with HTTP **403**, spamming the logs (issue #50). The intended `4404` close code never reached the browser, so the client couldn't distinguish "table gone" from a transient blip and reconnected every second forever.
- **Server** (`main.py`): `accept()` first, then `close(code=4404, ...)` for both `/api/live/ws` and `/api/table/ws`, so the client receives a real, interpretable close code.
- **Frontend** (`liveSocket.ts`, `tableSocket.ts`): stop reconnecting when the close code is `4404` (surface "table not found"); back off exponentially (1s→30s) on other disconnects instead of hammering at 1Hz.

## Test plan
- [x] Frontend `npm run build` (tsc) passes
- [x] ASGI-level check: both endpoints now emit `websocket.accept` then `websocket.close` code `4404` for a nonexistent code (previously rejected pre-accept → 403)
- [ ] Manual: open a live table URL whose code has ended → UI shows "table not found" and does not reconnect-spam; server logs stay quiet

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)