### PR TITLE
Harden server against client-triggerable crashes and DoS

### DIFF
--- a/server/api/connection.h
+++ b/server/api/connection.h
@@ -1,6 +1,7 @@
 # pragma once
 
 #include <mutex>
+#include <cstdio>
 #include <netinet/in.h>
 #include <vector>
 #include <algorithm>
@@ -35,7 +36,10 @@ public:
         // Get Client IP and Port
         ip::tcp::endpoint endpoint = clientSocket->remote_endpoint();
         mClientPort = endpoint.port();
-        strcpy(mClientIP, endpoint.address().to_string().c_str());
+        // snprintf (not strcpy) so an IPv6 peer address that exceeds the buffer
+        // is truncated rather than overflowing mClientIP and smashing the stack.
+        std::snprintf(mClientIP, sizeof(mClientIP), "%s",
+                      endpoint.address().to_string().c_str());
     }
 
 protected:
@@ -52,29 +56,43 @@ protected:
     std::string readBytes()
     {
         std::vector<char> buf(1024);
-        mClientSocket->read_some(buffer(buf));
-        return std::string(buf.begin(), buf.end());
+        // read_some returns the number of bytes actually read; the rest of buf
+        // is uninitialized. Constructing the string from the full vector (the
+        // old behavior) appended up to 1024 garbage/NUL bytes onto every read,
+        // corrupting message framing. Use only the bytes we received.
+        size_t n = mClientSocket->read_some(buffer(buf));
+        return std::string(buf.data(), n);
     }
 
     Message::Message receive()
     {
-        auto msgStr = getFirstMessage(mUnprocessedData.empty() ? readBytes() : mUnprocessedData);
-        try
+        // Loop rather than recurse: a peer that dribbles bytes without ever
+        // forming a complete JSON object would otherwise recurse once per read
+        // and overflow the stack. Cap how much we'll buffer for a single
+        // message so a peer can't make us allocate unboundedly either.
+        static constexpr size_t kMaxBufferedBytes = 1u << 20;  // 1 MiB
+        std::string msgStr = getFirstMessage(mUnprocessedData.empty() ? readBytes() : mUnprocessedData);
+        while (true)
         {
-            json jsonMsg = json::parse(msgStr);
-            return {jsonMsg};
-        }
-        catch (json::parse_error &e)
-        {
-            if (mUnprocessedData.empty())
+            try
             {
-                mUnprocessedData = msgStr + readBytes();
-                return receive();
+                json jsonMsg = json::parse(msgStr);
+                return {jsonMsg};
             }
-            else
+            catch (json::parse_error &e)
             {
-                LOG("Error parsing message: %s", e.what());
-                throw e;
+                if (!mUnprocessedData.empty())
+                {
+                    LOG("Error parsing message: %s", e.what());
+                    throw e;
+                }
+                if (msgStr.size() > kMaxBufferedBytes)
+                {
+                    LOG("Discarding oversized unparseable message (%zu bytes) from %s:%d",
+                        msgStr.size(), mClientIP, mClientPort);
+                    throw e;
+                }
+                msgStr = getFirstMessage(msgStr + readBytes());
             }
         }
     }
@@ -125,7 +143,7 @@ private:
 
 protected:
     SocketPtr mClientSocket;
-    char mClientIP[INET_ADDRSTRLEN];
+    char mClientIP[INET6_ADDRSTRLEN];
     int mClientPort;
     ConnectionStatus mStatus;
 

--- a/server/api/managed_connection.h
+++ b/server/api/managed_connection.h
@@ -81,13 +81,23 @@ public:
                         playerGameSessions.emplace(sessionID, std::move(parts));
                     }
                 } else {
-                    auto sessionId = message.getJson()[Tags::SESSION_ID].get<PlayerGameSessionID>();
+                    // .at() throws (caught below) on a missing/ill-typed session id,
+                    // rather than the old const operator[] which was UB for a missing key.
+                    auto sessionId = message.getJson().at(Tags::SESSION_ID).get<PlayerGameSessionID>();
                     auto sessionMessage = Message::SessionMessage(message);
-                    SessionParts* parts;
+                    SessionParts* parts = nullptr;
                     {
                         std::lock_guard<std::mutex> mapLock(mSessionsMtx);
                         auto it = playerGameSessions.find(sessionId);
-                        ASRT(it != playerGameSessions.end(), "Session ID %lld not found", sessionId);
+                        if (it == playerGameSessions.end()) {
+                            // A client referencing an unknown session must not crash
+                            // the server. ASRT compiles to assert(), a no-op under
+                            // NDEBUG, after which the old code dereferenced an end()
+                            // iterator (UB). Skip the message and keep serving.
+                            LOG("Client at %s:%d referenced unknown session %lld; ignoring",
+                                this->mClientIP, this->mClientPort, (long long) sessionId);
+                            continue;
+                        }
                         parts = it->second.get();
                     }
                     {
@@ -114,18 +124,36 @@ public:
             else {
                 LOG("Error with client at %s:%d: %s", this->mClientIP, this->mClientPort, e.what());
             }
-            std::vector<SessionParts*> snapshot;
-            {
-                std::lock_guard<std::mutex> mapLock(mSessionsMtx);
-                for (auto& [id, p] : playerGameSessions)
-                    snapshot.push_back(p.get());
-            }
-            for (auto* p : snapshot)
-            {
-                std::lock_guard<std::mutex> lock(p->mutex);
-                p->disconnected = true;
-                p->waitCondition.notify_all();
-            }
+            disconnectAllSessions();
+        }
+        catch (const std::exception &e) {
+            // A malformed-but-valid-JSON message (e.g. missing "type", wrong
+            // value type for session_id) throws from the Message ctor / .get<>()
+            // rather than as a boost system_error. Without this clause the
+            // exception escapes the per-connection thread and calls
+            // std::terminate(), taking the whole server down — a trivial
+            // client-triggerable DoS. Tear down only this connection instead.
+            LOG("Client at %s:%d sent an unprocessable message (%s); dropping connection",
+                this->mClientIP, this->mClientPort, e.what());
+            disconnectAllSessions();
+        }
+    }
+
+    // Mark every session on this connection disconnected and wake any thread
+    // blocked in receiveOnSession so it can observe the disconnect and exit.
+    void disconnectAllSessions()
+    {
+        std::vector<SessionParts*> snapshot;
+        {
+            std::lock_guard<std::mutex> mapLock(mSessionsMtx);
+            for (auto& [id, p] : playerGameSessions)
+                snapshot.push_back(p.get());
+        }
+        for (auto* p : snapshot)
+        {
+            std::lock_guard<std::mutex> lock(p->mutex);
+            p->disconnected = true;
+            p->waitCondition.notify_all();
         }
     }
 

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -27,6 +27,7 @@ import os
 import pkgutil
 import queue
 import random
+import secrets
 import string
 import sys
 import threading
@@ -864,20 +865,37 @@ class Table:
 # --- Registry ----------------------------------------------------------------
 
 
+# Cap on concurrently-held live tables. Each table is created by an
+# unauthenticated POST and lives until process exit, so without a ceiling a
+# script could allocate unbounded memory (DoS). 500 is far above any real use.
+MAX_TABLES = 500
+
+
 class TableManager:
     def __init__(self):
         self._tables: Dict[str, Table] = {}
         self._lock = threading.Lock()
 
-    def create(self) -> Table:
+    def create(self) -> Optional[Table]:
+        """Allocate a new table, or None if at capacity / no free code."""
         with self._lock:
-            for _ in range(20):
-                code = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
-                if code not in self._tables:
-                    break
+            if len(self._tables) >= MAX_TABLES:
+                return None
+            code = self._fresh_code()
+            if code is None:
+                return None
             table = Table(code)
             self._tables[code] = table
             return table
+
+    def _fresh_code(self) -> Optional[str]:
+        # secrets (not random) so codes aren't predictable from prior ones, and
+        # never overwrite an existing table by reusing a colliding code.
+        for _ in range(100):
+            code = "".join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(4))
+            if code not in self._tables:
+                return code
+        return None
 
     def get(self, code: str) -> Optional[Table]:
         return self._tables.get(code.upper())

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -107,6 +107,8 @@ def live_ai_types():
 @app.post("/api/live/tables")
 def create_live_table():
     table = live.manager.create()
+    if table is None:
+        raise HTTPException(status_code=503, detail="server is at capacity; try again later")
     return {"code": table.code}
 
 
@@ -135,21 +137,39 @@ async def live_ws(websocket: WebSocket, code: str, client_id: str):
 
     try:
         while True:
-            msg = await websocket.receive_json()
-            action = msg.get("action")
-            if action == "add_human":
-                e = table.add_human(msg["seat_id"], msg.get("name", ""), client_id)
-            elif action == "add_ai":
-                e = table.add_ai(msg["seat_id"], msg.get("ai_type") or live.default_ai_type(),
-                                 msg.get("name", ""), client_id)
-            elif action == "clear_seat":
-                e = table.clear_seat(msg["seat_id"])
-            elif action == "start":
-                e = await asyncio.get_running_loop().run_in_executor(None, table.start)
-            elif action == "decide":
-                e = table.submit_decision(msg["seat_id"], client_id, msg.get("value"))
-            else:
-                e = f"Unknown action '{action}'"
+            # A malformed frame (non-JSON, or JSON that isn't an object) must not
+            # tear down the socket or log a traceback — answer with an error and
+            # keep going, so one buggy/hostile client can't spam or self-DoS.
+            try:
+                msg = await websocket.receive_json()
+            except WebSocketDisconnect:
+                break
+            except Exception:
+                await err("malformed message (expected a JSON object)")
+                continue
+            if not isinstance(msg, dict):
+                await err("malformed message (expected a JSON object)")
+                continue
+            try:
+                action = msg.get("action")
+                if action == "add_human":
+                    e = table.add_human(str(msg.get("seat_id", "")), str(msg.get("name", "")), client_id)
+                elif action == "add_ai":
+                    e = table.add_ai(str(msg.get("seat_id", "")),
+                                     msg.get("ai_type") or live.default_ai_type(),
+                                     str(msg.get("name", "")), client_id)
+                elif action == "clear_seat":
+                    e = table.clear_seat(str(msg.get("seat_id", "")))
+                elif action == "start":
+                    e = await asyncio.get_running_loop().run_in_executor(None, table.start)
+                elif action == "decide":
+                    e = table.submit_decision(str(msg.get("seat_id", "")), client_id, msg.get("value"))
+                else:
+                    e = f"Unknown action '{action}'"
+            except WebSocketDisconnect:
+                break
+            except Exception:
+                e = "could not process request"
             if e:
                 await err(e)
             await table._broadcast()
@@ -170,6 +190,8 @@ def table_ai_types():
 @app.post("/api/table/sessions")
 def create_table_session():
     session = table.manager.create()
+    if session is None:
+        raise HTTPException(status_code=503, detail="server is at capacity; try again later")
     return {"code": session.code}
 
 
@@ -198,16 +220,31 @@ async def table_ws(websocket: WebSocket, code: str):
 
     try:
         while True:
-            msg = await websocket.receive_json()
-            action = msg.get("action")
-            if action == "configure":
-                e = session.configure(msg.get("seats", []))
-            elif action == "start":
-                e = await asyncio.get_running_loop().run_in_executor(None, session.start)
-            elif action == "respond":
-                e = session.submit(msg.get("value"))
-            else:
-                e = f"Unknown action '{action}'"
+            # See live_ws: tolerate malformed frames without crashing the socket.
+            try:
+                msg = await websocket.receive_json()
+            except WebSocketDisconnect:
+                break
+            except Exception:
+                await err("malformed message (expected a JSON object)")
+                continue
+            if not isinstance(msg, dict):
+                await err("malformed message (expected a JSON object)")
+                continue
+            try:
+                action = msg.get("action")
+                if action == "configure":
+                    e = session.configure(msg.get("seats", []))
+                elif action == "start":
+                    e = await asyncio.get_running_loop().run_in_executor(None, session.start)
+                elif action == "respond":
+                    e = session.submit(msg.get("value"))
+                else:
+                    e = f"Unknown action '{action}'"
+            except WebSocketDisconnect:
+                break
+            except Exception:
+                e = "could not process request"
             if e:
                 await err(e)
             await session._broadcast()

--- a/web/backend/table.py
+++ b/web/backend/table.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import queue
 import random
+import secrets
 import string
 import threading
 import time
@@ -646,20 +647,36 @@ class TableSession:
 # --- Registry ----------------------------------------------------------------
 
 
+# Ceiling on concurrent table sessions (created by unauthenticated POST and
+# held until process exit) so a script can't exhaust memory. See live.MAX_TABLES.
+MAX_SESSIONS = 500
+
+
 class TableSessionManager:
     def __init__(self):
         self._sessions: Dict[str, TableSession] = {}
         self._lock = threading.Lock()
 
-    def create(self) -> TableSession:
+    def create(self) -> Optional[TableSession]:
+        """Allocate a new session, or None if at capacity / no free code."""
         with self._lock:
-            for _ in range(20):
-                code = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
-                if code not in self._sessions:
-                    break
+            if len(self._sessions) >= MAX_SESSIONS:
+                return None
+            code = self._fresh_code()
+            if code is None:
+                return None
             session = TableSession(code)
             self._sessions[code] = session
             return session
+
+    def _fresh_code(self) -> Optional[str]:
+        # secrets (not random) for unpredictable codes; never reuse a colliding
+        # code, which would silently evict the existing session.
+        for _ in range(100):
+            code = "".join(secrets.choice(string.ascii_uppercase + string.digits) for _ in range(4))
+            if code not in self._sessions:
+                return code
+        return None
 
     def get(self, code: str) -> Optional[TableSession]:
         return self._sessions.get(code.upper())


### PR DESCRIPTION
## Summary
Security audit pass (closes #53). Closes several vectors a malicious or buggy client could use to crash or exhaust the server.

**C++ server**
- `connection.h`: `strcpy` into `mClientIP` → `snprintf` + buffer widened to `INET6_ADDRSTRLEN` (stack-overflow via long IPv6 peer address).
- `connection.h`: `readBytes()` returns only the bytes actually read (was appending up to 1KB of uninitialized data onto every read, corrupting framing).
- `connection.h`: `receive()` loops with a 1 MiB cap instead of recursing per partial read (stack-overflow / unbounded buffering by a slow sender).
- `managed_connection.h`: safe session lookup (`.at()` + `find()`/skip) replacing const `operator[]` (UB) and `ASRT`+`end()` deref (UB under NDEBUG); added `catch(std::exception)` so a malformed-but-valid-JSON message drops only that connection instead of `std::terminate`-ing the whole server.

**Web backend**
- `main.py`: both WebSocket loops tolerate malformed frames (error + continue) and coerce action fields with `str()`.
- `live.py` / `table.py`: cap concurrent tables/sessions at 500, generate codes with `secrets`, never overwrite an existing code — unauthenticated POST loop can no longer exhaust memory or hijack a code.

## Test plan
- [x] `bazel build //server:server //server:tournament_server` — builds clean
- [x] `python3 -m py_compile main.py live.py table.py`
- [ ] CI: integration / competition / server-bringup exercise the real protocol
