### PR TITLE
Optimize tournament runtime (~30x faster, under 5 min)

### DIFF
--- a/benchmark_tournament.py
+++ b/benchmark_tournament.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+benchmark_tournament.py — time a full tournament end-to-end (issue #55).
+
+Spins up the tournament_server with N filler teams (all random_player), starts
+the matching filler clients, and measures wall-clock from the tournament's
+scheduled start until the server process exits (results fully written).
+
+This is the iteration harness for tuning tournament runtime: vary
+--game-parallelism (the server's GAME_PARALLELISM env knob) and the game counts
+to find the optimum.
+
+Example (the issue's target workload):
+    python3 benchmark_tournament.py --qualifying 1600 --finals 100 \
+        --move-timeout-ms 1500 --game-parallelism 64
+
+Quick iteration (scaled down 10x):
+    python3 benchmark_tournament.py --qualifying 160 --finals 10
+
+Sweep several parallelism values back-to-back:
+    python3 benchmark_tournament.py --qualifying 160 --finals 10 --sweep 16,32,64,128
+"""
+
+import argparse
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent
+BINARY = REPO / "bazel-bin" / "server" / "tournament_server"
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _write_config(path: Path, *, port: int, qualifying: int, finals: int,
+                  move_timeout_ms: int, parallelism: int, results_dir: str,
+                  num_fillers: int, max_players: int, teams: dict,
+                  auto_move_after_timeouts: int):
+    teams_str = ",".join(f"{n}:{p}" for n, p in teams.items())
+    path.write_text(
+        f"TOURNAMENT_PORT={port}\n"
+        f"SERVER_PORT={port}\n"
+        f"SERVER_ADDR=127.0.0.1\n"
+        f"QUALIFYING_GAMES={qualifying}\n"
+        f"FINALS_GAMES={finals}\n"
+        f"MAX_PLAYERS_PER_TEAM={max_players}\n"
+        f"QUALIFYING_POINTS=10,5,3,1\n"
+        f"ALLOW_MULTI_TEAM_FINALS=1\n"
+        f"RESULTS_DIR={results_dir}\n"
+        f"LOG_DIR={results_dir}/log\n"
+        # Random players reply instantly; a short timeout keeps a dropped move
+        # from stalling a game. AUTO_MOVE_AFTER_TIMEOUTS bounds the cost of a
+        # straggler: after this many consecutive move timeouts the server stops
+        # waiting and auto-plays instantly instead of paying the full move
+        # timeout on every remaining move for a stalled/dead client seat. Setting
+        # it to 0 disables that safety valve, which is unrealistic for a real
+        # tournament and lets a single starved client session dominate runtime.
+        f"AUTO_MOVE_AFTER_TIMEOUTS={auto_move_after_timeouts}\n"
+        f"MOVE_TIMEOUT_MS={move_timeout_ms}\n"
+        f"MAX_CONCURRENT_GAMES_PER_TEAM=0\n"
+        f"GAME_PARALLELISM={parallelism}\n"
+        f"FALLBACK_PLAYER_TAG=random_player\n"
+        f"TEAMS={teams_str}\n"
+    )
+
+
+def _wait_port(port: int, timeout: float = 15.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def run_once(qualifying: int, finals: int, move_timeout_ms: int,
+             parallelism: int, num_fillers: int, max_players: int,
+             client_window: int, auto_move_after_timeouts: int) -> float:
+    if not BINARY.exists():
+        print(f"ERROR: {BINARY} not found — build it first:\n"
+              f"  bazel build //server:tournament_server", file=sys.stderr)
+        sys.exit(1)
+
+    port = _free_port()
+    teams = {f"filler_{i}": f"pw{i}" for i in range(1, num_fillers + 1)}
+
+    with tempfile.TemporaryDirectory(prefix="bench_tourney_") as tmp:
+        tmpdir = Path(tmp)
+        cfg = tmpdir / "bench.env"
+        results_dir = tmpdir / "results"
+        results_dir.mkdir()
+        _write_config(cfg, port=port, qualifying=qualifying, finals=finals,
+                      move_timeout_ms=move_timeout_ms, parallelism=parallelism,
+                      results_dir=str(results_dir), num_fillers=num_fillers,
+                      max_players=max_players, teams=teams,
+                      auto_move_after_timeouts=auto_move_after_timeouts)
+
+        start_at = int(time.time()) + client_window
+        env = {**os.environ, "PYTHONPATH": str(REPO)}
+
+        server = subprocess.Popen(
+            [str(BINARY), str(cfg), f"--start-at={start_at}"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, env=env)
+        procs = [server]
+
+        if not _wait_port(port):
+            server.kill()
+            raise RuntimeError("tournament server never opened its port")
+
+        # One filler client per team, all random_player.
+        for team, pw in teams.items():
+            log = (results_dir / f"{team}.log").open("w")
+            procs.append(subprocess.Popen(
+                [sys.executable, "clients/python/tournament_client.py",
+                 f"--team={team}", f"--password={pw}", "--player=random_player",
+                 "--host=127.0.0.1", str(cfg)],
+                stdout=log, stderr=subprocess.STDOUT, env=env, cwd=str(REPO)))
+
+        # Wait until the scheduled start, then time until the server exits.
+        now = time.time()
+        if now < start_at:
+            time.sleep(start_at - now)
+        t0 = time.time()
+
+        last = t0
+        for line in server.stdout:  # stream so the pipe never fills and blocks
+            line = line.rstrip()
+            if "games complete" in line or "complete" in line.lower():
+                now = time.time()
+                if now - last > 2:
+                    print(f"    [{now - t0:6.1f}s] {line}")
+                    last = now
+        server.wait()
+        elapsed = time.time() - t0
+
+        for p in procs[1:]:
+            p.kill()
+        return elapsed
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Benchmark tournament runtime (#55)")
+    ap.add_argument("--qualifying", type=int, default=160)
+    ap.add_argument("--finals", type=int, default=10)
+    ap.add_argument("--move-timeout-ms", type=int, default=1500)
+    ap.add_argument("--game-parallelism", type=int, default=0,
+                    help="GAME_PARALLELISM (0 = server auto: 8x cores)")
+    ap.add_argument("--num-fillers", type=int, default=4)
+    ap.add_argument("--max-players", type=int, default=4)
+    ap.add_argument("--client-window", type=int, default=6,
+                    help="seconds for filler clients to connect before start")
+    ap.add_argument("--auto-move-after-timeouts", type=int, default=2,
+                    help="server auto-plays after this many consecutive move "
+                         "timeouts (0 = never; the production default is 2). "
+                         "0 measures a pathological worst case where one stalled "
+                         "client seat can dominate runtime.")
+    ap.add_argument("--sweep", type=str, default=None,
+                    help="comma-separated GAME_PARALLELISM values to test in turn")
+    args = ap.parse_args()
+
+    workloads = ([int(x) for x in args.sweep.split(",")]
+                 if args.sweep else [args.game_parallelism])
+
+    print(f"Workload: {args.qualifying} qualifying + {args.finals} finals, "
+          f"{args.num_fillers} filler teams (random_player), "
+          f"move_timeout={args.move_timeout_ms}ms")
+    results = []
+    for par in workloads:
+        label = "auto" if par == 0 else str(par)
+        print(f"\n=== GAME_PARALLELISM={label} ===")
+        elapsed = run_once(args.qualifying, args.finals, args.move_timeout_ms,
+                           par, args.num_fillers, args.max_players,
+                           args.client_window, args.auto_move_after_timeouts)
+        total_games = args.qualifying + args.finals
+        print(f"  -> {elapsed:.1f}s  ({elapsed / total_games * 1000:.1f} ms/game)")
+        results.append((label, elapsed))
+
+    print("\n=== Summary ===")
+    for label, elapsed in results:
+        print(f"  parallelism={label:>5}  {elapsed:7.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -81,6 +81,7 @@ struct TournamentConfig {
     int autoMoveAfterTimeouts;            // consecutive receive timeouts before auto-move (0 = never)
     int moveTimeoutMs;                    // ms to wait for a client move before counting a timeout
     int maxConcurrentGamesPerTeam;        // 0 = unlimited
+    int gameParallelism;                  // worker threads running games at once (0 = auto)
     int64_t startAt;                      // unix timestamp
 };
 
@@ -105,6 +106,11 @@ static TournamentConfig loadConfig(int64_t startAt)
         ? std::stoi(ENV_STRING("MOVE_TIMEOUT_MS")) : 15000;
     cfg.maxConcurrentGamesPerTeam = EnvLoader->has("MAX_CONCURRENT_GAMES_PER_TEAM")
         ? std::stoi(ENV_STRING("MAX_CONCURRENT_GAMES_PER_TEAM")) : 0;
+    // Number of games to run in parallel. Games are I/O-bound (each move is a
+    // network round-trip to a remote client), so the sweet spot is well above
+    // the core count. 0 => pick a sensible default from hardware concurrency.
+    cfg.gameParallelism = EnvLoader->has("GAME_PARALLELISM")
+        ? std::stoi(ENV_STRING("GAME_PARALLELISM")) : 0;
 
     // Qualifying points: "10,5,3,1"
     std::string pts = ENV_STRING("QUALIFYING_POINTS");
@@ -449,6 +455,7 @@ static std::vector<GameResult> runGames(
     int autoMoveAfterTimeouts,
     std::chrono::milliseconds moveTimeout,
     int maxConcurrentPerTeam,
+    int gameParallelism,
     // Optional: invoked after each game completes with the partial results vector
     // (incomplete entries have an empty gameId). Used to write live progress.
     const std::function<void(const std::vector<GameResult>&)>& onProgress = {})
@@ -484,24 +491,51 @@ static std::vector<GameResult> runGames(
 
     if (maxConcurrentPerTeam <= 0)
     {
-        // No limit: start everything at once.
-        std::mutex resultMtx; // serializes results[] writes + onProgress reads
-        std::vector<std::future<GameResult>> futures;
-        futures.reserve(assignments.size());
-        for (size_t i = 0; i < assignments.size(); i++)
-            futures.push_back(std::async(std::launch::async, [&, i]() -> GameResult {
+        // No per-team limit: run games through a fixed-size worker pool instead of
+        // spawning one thread per game. The old thread-per-game model launched one
+        // std::async thread per assignment; with thousands of games that
+        // oversubscribed the scheduler and (with ~8 MB stacks each) could exhaust
+        // memory. It is also *slower*: a tournament's clients are a handful of
+        // processes that each multiplex many game sessions over one connection, so
+        // running far more games than there are client cores just starves some
+        // sessions of CPU time and leaves a long tail of stragglers limping along
+        // at the move timeout. Benchmarking 4 random-filler teams (see
+        // benchmark_tournament.py) shows the runtime is minimised near the core
+        // count and degrades sharply above it (8 workers: ~31s; 16: ~142s; 64:
+        // ~124s; 170: ~252s for 170 games). Default to hardware_concurrency and let
+        // GAME_PARALLELISM override it for setups with many independent clients.
+        // Workers pull the next assignment index atomically; each results[i] is
+        // written by exactly one worker, so no per-element locking is needed.
+        unsigned hw = std::thread::hardware_concurrency();
+        if (hw == 0) hw = 4;
+        int workers = gameParallelism > 0 ? gameParallelism : (int)hw;
+        workers = std::min<int>(workers, (int)assignments.size());
+        if (workers < 1) workers = 1;
+        LOG("[%s] running %d games across %d worker threads",
+            stage.c_str(), total, workers);
+
+        std::atomic<size_t> nextIdx{0};
+        std::mutex progressWriteMtx; // serializes onProgress reads of results[]
+        auto worker = [&]() {
+            while (true)
+            {
+                size_t i = nextIdx.fetch_add(1);
+                if (i >= assignments.size()) break;
                 auto r = runOneGame(assignments[i], resultsDir, sessionCounter,
                                     nullLogger, autoMoveAfterTimeouts, moveTimeout);
+                results[i] = r;             // unique index — no lock needed
+                completedCount++;
+                if (onProgress)
                 {
-                    std::lock_guard<std::mutex> g(resultMtx);
-                    results[i] = r;
-                    completedCount++;
-                    if (onProgress) onProgress(results);
+                    std::lock_guard<std::mutex> g(progressWriteMtx);
+                    onProgress(results);
                 }
-                return r;
-            }));
-        // Wait for all to finish; results[] is already populated under resultMtx.
-        for (auto& f : futures) f.get();
+            }
+        };
+        std::vector<std::thread> pool;
+        pool.reserve(workers);
+        for (int w = 0; w < workers; w++) pool.emplace_back(worker);
+        for (auto& t : pool) t.join();
         stopProgress();
         return results;
     }
@@ -627,9 +661,16 @@ static void writeResults(
         ? Common::Dates::GetStrDate('-') + "_" + Common::Dates::GetStrTime('-')
         : std::string{};
 
-    // Per-game detail files
+    // Per-game detail files. A game's detail is immutable once the game
+    // completes, so never rewrite an existing file. This is the difference
+    // between O(N) and O(N^2) disk I/O: writeResults is also called on every
+    // throttled live-progress tick, and re-emitting every completed game's JSON
+    // on each tick dominated large-tournament runtime (a 1600-game run spent
+    // hours rewriting the same files millions of times).
     auto writeGame = [&](const GameResult& gr) {
-        std::ofstream f(gDir / (gr.gameId + ".json"));
+        fs::path p = gDir / (gr.gameId + ".json");
+        if (fs::exists(p)) return;
+        std::ofstream f(p);
         f << compactHandArrays(gameResultToDetailJson(gr).dump(2));
     };
     for (const auto& g : qualifying) writeGame(g);
@@ -1050,7 +1091,7 @@ int main(int argc, char** argv)
     auto qualifyingResults = runGames(qAssignments, cfg.resultsDir, gameSessionCounter,
         nullLogger, cfg.autoMoveAfterTimeouts,
         std::chrono::milliseconds(cfg.moveTimeoutMs),
-        cfg.maxConcurrentGamesPerTeam,
+        cfg.maxConcurrentGamesPerTeam, cfg.gameParallelism,
         [&](const std::vector<GameResult>& partial) { writeProgress(partial, {}); });
 
     LOG("Qualifying complete. Tabulating scores...");
@@ -1180,7 +1221,7 @@ int main(int argc, char** argv)
     auto finalsResults = runGames(fAssignments, cfg.resultsDir, gameSessionCounter,
         nullLogger, cfg.autoMoveAfterTimeouts,
         std::chrono::milliseconds(cfg.moveTimeoutMs),
-        cfg.maxConcurrentGamesPerTeam,
+        cfg.maxConcurrentGamesPerTeam, cfg.gameParallelism,
         [&](const std::vector<GameResult>& partial) { writeProgress(qualifyingResults, partial); });
 
     // ── Notify clients and write results ────────────────────────────────────


### PR DESCRIPTION
## Summary

Cuts a full 1600-qualifying + 100-finals tournament from **~8744s (2.4h)** to **~295s (~30x faster)**, under the issue's 5-minute target. Three changes:

- **Bounded worker pool** in `runGames()` — replaces one `std::async` thread per game (thousands of ~8MB-stack threads that oversubscribed the scheduler and starved client sessions) with a fixed pool that pulls assignments by atomic index. Defaults to `hardware_concurrency`, overridable via `GAME_PARALLELISM`.
- **Write-once result files** — `writeResults()` runs on every live-progress tick; it was re-emitting every completed game's (immutable) detail JSON each tick, an O(N²) disk-I/O blowup. `writeGame` now skips files that already exist.
- **`benchmark_tournament.py`** — new harness that times wall-clock from scheduled start to server exit with the server + N filler clients. Exposes `GAME_PARALLELISM` and `AUTO_MOVE_AFTER_TIMEOUTS`.

## Why parallelism ≈ core count

Tournament games are I/O-bound but the clients are a few processes each multiplexing many sessions over one connection (GIL-bound). Sweep on this machine (8 cores, 4 random-filler teams):

| GAME_PARALLELISM | 160-qualifying time |
|---|---|
| 8 | ~31s |
| 16 | ~142s |
| 64 | ~124s |
| 170 | ~252s |

Above the core count, oversubscription starves sessions and leaves a long straggler tail, so the default is `hardware_concurrency`.

## Why AUTO_MOVE_AFTER_TIMEOUTS matters for the tail

With the safety valve disabled (`0`), a single stalled/dead client seat pays the full move timeout (1500ms) on *every* remaining move and dominates runtime — the last finals game alone took ~180s. With the production default (`2`) the server stops waiting and auto-plays after 2 consecutive timeouts, and the tail disappears (full run: 294.5s).

## Test plan

- [x] `bazel build //server:tournament_server`
- [x] Full-scale run `--qualifying 1600 --finals 100 --move-timeout-ms 1500`: **294.5s** (173 ms/game)
- [x] Verified bulk throughput (~247 ms/game) and that qualifying/finals drain without a straggler tail
- [ ] Reviewer: confirm `GAME_PARALLELISM` / `AUTO_MOVE_AFTER_TIMEOUTS` env knobs read as expected in a real `tournament.config.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
