### PR TITLE
Lobby: upload a Python client, open CLI seats, open-table list (#56)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,6 +36,11 @@ jobs:
         export PYTHONPATH="$(pwd):${PYTHONPATH}"
         python3 tests/table_game_inference_test.py
 
+    - name: Run SDK resilience test
+      run: |
+        export PYTHONPATH="$(pwd):${PYTHONPATH}"
+        python3 tests/sdk_resilience_test.py
+
   competition:
     runs-on: macos-latest
 

--- a/clients/python/api/networking/Connection.py
+++ b/clients/python/api/networking/Connection.py
@@ -49,7 +49,12 @@ class Connection:
                 raise ConnectionError("Server closed connection while waiting for data")
             try:
                 json_objects = self._get_json_objects(data.decode("utf-8"))
-            except json.decoder.JSONDecodeError:
+            except (json.decoder.JSONDecodeError, UnicodeDecodeError):
+                # Either a truncated JSON object OR a multi-byte UTF-8 character
+                # split across this 1024-byte recv boundary. Stash the *whole*
+                # buffer (old partial + bytes just read) and read more — decoding
+                # `data` directly here would drop the freshly-read bytes (they live
+                # only in this local), permanently desyncing the parser.
                 self.incomplete_message = data
                 # log(f"Received incomplete message, attempting to receive more data, current data: {data}")
                 return self.receive()

--- a/clients/python/api/networking/ManagedConnection.py
+++ b/clients/python/api/networking/ManagedConnection.py
@@ -142,7 +142,24 @@ class ManagedConnection(Connection):
         with self.receiver_thread_lock:
             try:
                 while True:
-                    message = self.receive()
+                    try:
+                        message = self.receive()
+                    except ConnectionError:
+                        # Server closed the connection — handled below (wake
+                        # waiters and stop the reader).
+                        raise
+                    except Exception as e:
+                        # A single unreadable frame (e.g. a multi-byte UTF-8 char
+                        # split across a recv boundary, or a malformed buffer) must
+                        # NOT kill the receiver: this socket is shared by every
+                        # session on the connection, so a dead reader wedges ALL of
+                        # them — the game appears to hang mid-trick with all players
+                        # idle until each session hits its own multi-minute timeout.
+                        # Log and keep reading; the partial buffer is retried on the
+                        # next recv.
+                        self.logger.log(f"Receiver thread skipped an unreadable frame: {type(e).__name__}: {e}")
+                        continue
+
                     if message is None:
                         # Only exit when nobody is waiting AND the connection has been
                         # idle long enough to be considered dead.  Exiting while
@@ -159,12 +176,24 @@ class ManagedConnection(Connection):
                     else:
                         self.last_msg_time = datetime.now()
 
-                    self._handle_msg(message)
+                    try:
+                        self._handle_msg(message)
+                    except Exception as e:
+                        # An unexpected message shape (e.g. one missing a
+                        # session_id) likewise must not tear down delivery for
+                        # every session — skip it rather than killing the reader.
+                        self.logger.log(f"Receiver thread could not dispatch a message: {type(e).__name__}: {e}")
             except ConnectionError:
                 # Server closed the connection — notify any waiting sessions so they
                 # see the disconnect promptly rather than waiting for their timeout.
                 self._wake_all_sessions()
-            self.receiver_thread = None
+            finally:
+                # ALWAYS clear the handle so the reader can be restarted. If an
+                # unexpected error ever escaped above, leaving a dead thread
+                # referenced here would permanently stop message delivery for the
+                # whole connection (_start_receiver_thread refuses to start a new
+                # one while this is non-None).
+                self.receiver_thread = None
         self.logger.log("Ending receiver thread")
         if len(self.waiting_sessions) > 0:
             self._start_receiver_thread()

--- a/clients/python/lobby_client.py
+++ b/clients/python/lobby_client.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+lobby_client.py — join a lobby by code with a single AI player.
+
+Use this to drop a CLI-run bot into a lobby created in the web UI (Live play).
+Create a table in the UI, mark one or more seats "Open (CLI)", copy the table's
+lobby code, then run:
+
+    python3 clients/python/lobby_client.py --player=random_player --lobby-code=<CODE>
+
+The server matches players FIFO within a lobby code, so each CLI client you run
+fills the next open seat. When four sessions share the code (some from the web,
+some from the CLI), they play one game together.
+
+The server address is read from an env file (config.env by default, or a bare
+positional path / --env-file=PATH), the same convention as tournament_client.py.
+
+    python3 clients/python/lobby_client.py --player=rob_player --lobby-code=ABCD local.config.env
+"""
+
+import argparse
+import importlib
+import inspect
+import sys
+from pathlib import Path
+
+
+# Env.py reads sys.argv[1] as the env file path at import time, so resolve and
+# place it at position 1 before importing anything from the SDK. Mirrors
+# tournament_client.py.
+def _resolve_env_file() -> str:
+    for i, a in enumerate(sys.argv[1:], 1):
+        if a.startswith('--env-file='):
+            path = a.split('=', 1)[1]
+            del sys.argv[i]
+            return path
+        if a == '--env-file' and i + 1 < len(sys.argv):
+            path = sys.argv[i + 1]
+            del sys.argv[i + 1]
+            del sys.argv[i]
+            return path
+    non_flag = [i for i, a in enumerate(sys.argv[1:], 1) if not a.startswith('--')]
+    if non_flag:
+        return sys.argv.pop(non_flag[-1])
+    return './config.env'
+
+
+ENV_FILE = _resolve_env_file()
+sys.argv.insert(1, ENV_FILE)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from clients.python.api.Player import Player  # noqa: E402
+from clients.python.api.networking.ManagedConnection import ManagedConnection  # noqa: E402
+from clients.python.api.networking.SessionHelpers import (  # noqa: E402
+    MakeAndRunSession, WaitForAllSessionsToFinish)
+from clients.python.util.Constants import GameType  # noqa: E402
+
+
+def discover_player(module_name: str):
+    """Import clients.python.players.<module_name> and return its Player subclass."""
+    full = f"clients.python.players.{module_name}"
+    mod = importlib.import_module(full)
+    for _, obj in inspect.getmembers(mod, inspect.isclass):
+        if issubclass(obj, Player) and obj is not Player and getattr(obj, '__module__', '') == full:
+            return obj
+    raise ValueError(f"No Player subclass found in {full}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Join a lobby by code with one AI player')
+    parser.add_argument('--player', required=True, help='Player module name (e.g. random_player)')
+    parser.add_argument('--lobby-code', required=True,
+                        help="The lobby code to join (shown in the web UI table, or any shared string)")
+    parser.add_argument('--games', type=int, default=1,
+                        help='Number of games to play in this lobby (default 1)')
+    parser.add_argument('--timeout-s', type=int, default=150,
+                        help='Per-session socket timeout (seconds); keep above the move timeout')
+    # Declared so they appear in --help; consumed before argparse (Env needs the
+    # env file at import time).
+    parser.add_argument('--env-file', dest='env_file_opt', default=None,
+                        help='Env file with the server address (default: config.env)')
+    parser.add_argument('env_file', nargs='?', help='Env file (positional alias for --env-file)')
+    args = parser.parse_args()
+
+    player_cls = discover_player(args.player)
+    print(f"Joining lobby '{args.lobby_code}' as {player_cls.player_tag} for {args.games} game(s)...")
+
+    with ManagedConnection(timeout_s=args.timeout_s) as conn:
+        for n in range(args.games):
+            MakeAndRunSession(conn, GameType.ANY, player_cls,
+                              lobby_code=args.lobby_code, timeout_s=args.timeout_s)
+            WaitForAllSessionsToFinish()
+            print(f"Game {n + 1}/{args.games} finished.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/sdk_resilience_test.py
+++ b/tests/sdk_resilience_test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Resilience tests for the shared-connection SDK plumbing (no server needed).
+
+One ``ManagedConnection`` multiplexes every concurrent game session over a single
+TCP socket, read by a single background receiver thread. Two latent bugs could
+wedge *all* sessions on that connection at once — the game appears to hang
+mid-trick with every player idle until each session hits its multi-minute
+timeout:
+
+  1. ``Connection.receive`` decoded each 1024-byte ``recv`` chunk as UTF-8 and
+     only treated a ``JSONDecodeError`` as "need more bytes". A multi-byte UTF-8
+     character split across the recv boundary raised ``UnicodeDecodeError``,
+     which escaped — and worse, dropped the freshly-read bytes (they lived only
+     in a local), permanently desyncing the parser.
+
+  2. ``ManagedConnection._receive_loop`` only caught ``ConnectionError``. Any
+     other exception (e.g. a ``KeyError`` dispatching a message with no
+     ``session_id``) killed the *only* receiver thread and left
+     ``receiver_thread`` non-None, so it was never restarted.
+
+These tests reproduce both via fakes (no live server) and assert the hardened
+behaviour. Run directly: ``python3 tests/sdk_resilience_test.py``.
+"""
+
+import socket
+import sys
+import threading
+from datetime import datetime, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from clients.python.api.networking.Connection import Connection
+from clients.python.api.networking.ManagedConnection import ManagedConnection
+
+
+class _FakeLogger:
+    def log(self, *args, **kwargs):
+        pass
+
+    def log_message(self, *args, **kwargs):
+        pass
+
+
+class _FakeSocket:
+    """Hands back a preset list of byte chunks, one per recv() call."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def recv(self, _n):
+        if not self._chunks:
+            raise socket.timeout()
+        return self._chunks.pop(0)
+
+
+def _bare_connection(chunks):
+    """A Connection instance wired to a fake socket, bypassing __init__/connect."""
+    conn = object.__new__(Connection)
+    conn.client_socket = _FakeSocket(chunks)
+    conn.pending_messages = []
+    conn.incomplete_message = b""
+    conn.logger = None
+    return conn
+
+
+def test_get_json_objects_splits_concatenated():
+    objs = Connection._get_json_objects('{"a":1}{"b":2}{"c":3}')
+    assert objs == [{"a": 1}, {"b": 2}, {"c": 3}], objs
+    # A single object must come back intact.
+    assert Connection._get_json_objects('{"a":1}') == [{"a": 1}]
+    print("PASS: _get_json_objects splits concatenated frames")
+
+
+def test_multibyte_split_across_recv_boundary():
+    # '{"k":"é"}' — 'é' is two UTF-8 bytes (0xC3 0xA9). Split the buffer *between*
+    # those two bytes so the first recv() ends mid-character.
+    full = '{"k":"é"}'.encode("utf-8")
+    cut = full.index(b"\xa9")  # the second byte of 'é'
+    first, second = full[:cut], full[cut:]
+    assert first.endswith(b"\xc3") and second.startswith(b"\xa9")
+
+    conn = _bare_connection([first, second])
+    msg = conn.receive()
+    assert msg == {"k": "é"}, msg
+    print("PASS: split multi-byte char is reassembled (no dropped bytes)")
+
+
+def _bare_managed_connection():
+    mc = object.__new__(ManagedConnection)
+    mc.logger = _FakeLogger()
+    mc.receiver_thread_lock = threading.Lock()
+    mc.waiting_sessions = set()
+    mc.connection_timeout_s = 0  # idle check is immediately satisfied on a None
+    mc.last_msg_time = datetime.now() - timedelta(seconds=10)
+    mc.receiver_thread = object()  # non-None: finally must reset it to None
+    return mc
+
+
+def test_receiver_survives_bad_frames():
+    handled = []
+
+    # A fake receive() that first RAISES (unreadable frame), then returns a
+    # message that fails to dispatch, then a good message, then None (idle->stop).
+    _RAISE = object()
+    events = iter([_RAISE, {"poison": True}, {"session_id": 5, "ok": True}, None])
+
+    def fake_receive():
+        ev = next(events)
+        if ev is _RAISE:
+            raise ValueError("undecodable frame")
+        return ev
+
+    def fake_handle(message):
+        if "session_id" not in message:
+            raise KeyError("session_id")  # mimics the real dispatch KeyError
+        handled.append(message)
+
+    mc = _bare_managed_connection()
+    mc.receive = fake_receive
+    mc._handle_msg = fake_handle
+
+    # Must return (not raise) despite the bad frame and the dispatch failure.
+    mc._receive_loop()
+
+    assert handled == [{"session_id": 5, "ok": True}], handled
+    assert mc.receiver_thread is None, "receiver_thread must be cleared so it can restart"
+    print("PASS: receiver thread survives an unreadable frame and a bad dispatch")
+
+
+def run():
+    test_get_json_objects_splits_concatenated()
+    test_multibyte_split_across_recv_boundary()
+    test_receiver_survives_bad_frames()
+    print("ALL PASS: sdk resilience")
+
+
+if __name__ == "__main__":
+    run()

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -117,6 +117,57 @@ def default_ai_type() -> Optional[str]:
     opts = ai_type_options()
     return opts[0]["value"] if opts else None
 
+
+# --- Uploaded AI clients -----------------------------------------------------
+# A browser can upload a .py file holding a Player subclass to drop into a seat
+# *without merging it* — handy for trying an iteration against humans/other bots.
+# Uploaded clients are scoped to a single table (not added to the global
+# AI_TYPES registry) so one user's experiment never leaks into another's lobby.
+#
+# SECURITY: an uploaded client is arbitrary Python executed in this process. The
+# web UI is intended as a trusted local/dev tool; do not expose this endpoint to
+# untrusted users. Upload size is capped and the module must define exactly one
+# Player subclass, but there is no sandbox.
+
+UPLOAD_TAG_PREFIX = "upload:"  # ai_type values for uploaded clients start with this
+MAX_UPLOAD_BYTES = 256 * 1024
+
+
+def load_uploaded_player(source: str) -> type:
+    """Exec ``source`` in a fresh namespace and return its single Player subclass.
+
+    Raises ValueError with a human-readable reason on any problem (syntax error,
+    no Player subclass, more than one) so the caller can surface it to the UI.
+    """
+    import types as _types
+
+    module = _types.ModuleType("uploaded_player_" + uuid.uuid4().hex)
+    module.__dict__["__name__"] = module.__name__
+    # Example players bootstrap sys.path with Path(__file__).resolve().parents[3].
+    # Give the uploaded module a __file__ inside the real players package so that
+    # idiom resolves to the repo root and the SDK imports succeed.
+    module.__dict__["__file__"] = str(Path(_players_pkg.__path__[0]) / "uploaded_client.py")
+    try:
+        exec(compile(source, "<uploaded_client>", "exec"), module.__dict__)
+    except Exception as exc:  # syntax error, import error, etc.
+        raise ValueError(f"could not import client: {type(exc).__name__}: {exc}")
+
+    found = [
+        cls for _, cls in inspect.getmembers(module, inspect.isclass)
+        if issubclass(cls, Player) and cls is not Player
+        and cls.__module__ == module.__name__
+        and not inspect.isabstract(cls)
+    ]
+    if not found:
+        raise ValueError("no concrete Player subclass found in the uploaded file")
+    if len(found) > 1:
+        names = ", ".join(c.__name__ for c in found)
+        raise ValueError(f"file defines multiple Player subclasses ({names}); keep one")
+    cls = found[0]
+    if getattr(cls, "player_tag", None) is None:
+        cls.player_tag = cls.__name__.lower()
+    return cls
+
 # Timing budget for a human move. The server auto-moves after MOVE_TIMEOUT_MS
 # (configured when launching the server); we return a fallback just under that
 # so the human's decided_move stays ahead of the server's auto-move, and the SDK
@@ -523,6 +574,10 @@ class Table:
         self.connection: Optional[ManagedConnection] = None
         self.threads: List[threading.Thread] = []
 
+        # Per-table uploaded AI clients: ai_type ("upload:<id>") -> {cls, label}.
+        # Scoped here (not global) so an experiment stays inside this table.
+        self.uploaded_ais: Dict[str, dict] = {}
+
         # Public reconstructed state (guarded by _state_lock)
         self._state_lock = threading.Lock()
         self._player_order: List[str] = []
@@ -555,21 +610,67 @@ class Table:
         seat.owner_client_id = client_id
         return None
 
+    def ai_class_for(self, ai_type: str) -> Optional[type]:
+        """Resolve an ai_type to its Player class, from this table's uploaded
+        clients first, then the global discovered registry."""
+        if ai_type in self.uploaded_ais:
+            return self.uploaded_ais[ai_type]["cls"]
+        meta = AI_TYPES.get(ai_type)
+        return meta["cls"] if meta else None
+
+    def ai_label_for(self, ai_type: str) -> str:
+        if ai_type in self.uploaded_ais:
+            return self.uploaded_ais[ai_type]["label"]
+        meta = AI_TYPES.get(ai_type)
+        return meta["label"] if meta else ai_type
+
+    def register_upload(self, source: str, filename: str = "") -> dict:
+        """Validate an uploaded client and register it for this table. Returns
+        ``{value, label}`` for the seat picker. Raises ValueError on bad input."""
+        if self.status != "lobby":
+            raise ValueError("game already started")
+        if len(self.uploaded_ais) >= 16:
+            raise ValueError("too many uploaded clients for this table")
+        cls = load_uploaded_player(source)
+        ai_type = f"{UPLOAD_TAG_PREFIX}{uuid.uuid4().hex[:8]}"
+        stem = Path(filename).stem if filename else cls.__name__
+        label = f"⬆ {_label_for(stem) or cls.__name__}"
+        self.uploaded_ais[ai_type] = {"cls": cls, "label": label}
+        return {"value": ai_type, "label": label}
+
     def add_ai(self, seat_id: str, ai_type: str, name: str = "",
                client_id: Optional[str] = None) -> Optional[str]:
         if self.status != "lobby":
             return "Game already started"
-        if ai_type not in AI_TYPES:
+        if self.ai_class_for(ai_type) is None:
             return f"Unknown AI type '{ai_type}'"
         seat = self._seat(seat_id)
         if seat is None:
             return "No such seat"
         seat.kind = "ai"
         seat.ai_type = ai_type
-        seat.name = _sanitize(name) if name else f"{ai_type}-{seat.index}"
+        default = self.ai_label_for(ai_type).lstrip("⬆ ").strip() or ai_type
+        seat.name = _sanitize(name) if name else f"{default}-{seat.index}"
         # Track which browser hosted this bot so we can show *that* browser the
         # bot's activity log (it runs in this backend process either way).
         seat.owner_client_id = client_id
+        seat.log = []
+        return None
+
+    def add_open(self, seat_id: str, name: str = "") -> Optional[str]:
+        """Reserve a seat for an *external* client (e.g. a CLI player) that joins
+        this table's lobby code. The web spawns no SDK session for an open seat;
+        the C++ server's FIFO-by-lobby-code matcher fills it from whoever connects
+        with this table's ``lobby_code``."""
+        if self.status != "lobby":
+            return "Game already started"
+        seat = self._seat(seat_id)
+        if seat is None:
+            return "No such seat"
+        seat.kind = "open"
+        seat.ai_type = None
+        seat.name = _sanitize(name) if name else "Open (CLI)"
+        seat.owner_client_id = None
         seat.log = []
         return None
 
@@ -593,6 +694,13 @@ class Table:
             return "Game already started"
         if any(s.kind == "empty" for s in self.seats):
             return "All four seats must be filled before starting"
+        # Open seats are filled by external CLI clients via the shared lobby code,
+        # not by the web. We need at least one web-hosted seat to observe and
+        # narrate public state (the web reconstructs the game from its own seat
+        # threads' observer hooks).
+        local_seats = [s for s in self.seats if s.kind in ("human", "ai")]
+        if not local_seats:
+            return "At least one human or AI seat is required to start"
 
         _ensure_stdout_router()  # so bots' print() output is captured per seat
 
@@ -604,10 +712,14 @@ class Table:
         for seat in self.seats:
             seat.player_tag = f"{_sanitize(seat.name)}_{seat.index}_{self.code}"
             seat.response_queue = queue.Queue()
+            # Open seats are filled by an external client joining this lobby code;
+            # the web spawns no session for them.
+            if seat.kind == "open":
+                continue
             if seat.kind == "human":
                 player_cls = _make_human_cls(self, seat)
             else:
-                player_cls = _make_ai_cls(self, seat, AI_TYPES[seat.ai_type]["cls"])
+                player_cls = _make_ai_cls(self, seat, self.ai_class_for(seat.ai_type))
             try:
                 thread, _session = MakeSession(
                     self.connection, GameType.ANY, player_cls,
@@ -834,10 +946,33 @@ class Table:
             "table": {
                 "code": self.code,
                 "status": self.status,
+                "lobby_code": self.lobby_code,  # share with CLI clients to co-fill open seats
                 "seats": [s.public_view(client_id) for s in self.seats],
+                # Per-table AI options = uploaded clients for this table only
+                # (the global discovered list is fetched separately and cached).
+                "uploaded_ai_types": [
+                    {"value": tag, "label": meta["label"]}
+                    for tag, meta in self.uploaded_ais.items()
+                ],
             },
             "public": self._public_state() if self.status != "lobby" else None,
             "you": {"client_id": client_id, "seats": mine, "ai": ai},
+        }
+
+    def summary(self) -> dict:
+        """Compact public listing entry for the open-lobbies list."""
+        seats = [
+            {"kind": s.kind, "name": s.name if s.kind != "empty" else None}
+            for s in self.seats
+        ]
+        return {
+            "code": self.code,
+            "status": self.status,
+            "seats": seats,
+            "humans": sum(1 for s in self.seats if s.kind == "human"),
+            "ai": sum(1 for s in self.seats if s.kind == "ai"),
+            "open": sum(1 for s in self.seats if s.kind == "open"),
+            "empty": sum(1 for s in self.seats if s.kind == "empty"),
         }
 
     # -- broadcast (thread -> asyncio bridge) -------------------------------
@@ -899,6 +1034,22 @@ class TableManager:
 
     def get(self, code: str) -> Optional[Table]:
         return self._tables.get(code.upper())
+
+    def list_tables(self, include_finished: bool = False) -> List[dict]:
+        """Open/active tables for the join-or-observe list, newest activity first.
+
+        Lobby and in-progress tables are joinable/observable; finished tables are
+        omitted by default (their games live under Lobby games)."""
+        with self._lock:
+            tables = list(self._tables.values())
+        out = [
+            t.summary() for t in tables
+            if include_finished or t.status != "finished"
+        ]
+        # Lobby tables first (joinable), then in-progress (observable).
+        order = {"lobby": 0, "playing": 1, "finished": 2}
+        out.sort(key=lambda s: order.get(s["status"], 9))
+        return out
 
 
 manager = TableManager()

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -139,6 +139,10 @@ def upload_live_client(code: str, req: UploadClientRequest):
         option = table.register_upload(req.source, req.filename or "")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    # Push the updated roster to every connected client so the new option shows
+    # up in the seat picker immediately (otherwise it only appears on the next
+    # WS action, e.g. clicking Clear).
+    table.schedule_broadcast()
     return option
 
 

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -104,12 +104,42 @@ def live_ai_types():
     return {"ai_types": live.ai_type_options()}
 
 
+@app.get("/api/live/tables")
+def list_live_tables():
+    """Open/active tables, so the UI can list lobbies to join or observe."""
+    return {"tables": live.manager.list_tables()}
+
+
 @app.post("/api/live/tables")
 def create_live_table():
     table = live.manager.create()
     if table is None:
         raise HTTPException(status_code=503, detail="server is at capacity; try again later")
     return {"code": table.code}
+
+
+class UploadClientRequest(BaseModel):
+    filename: Optional[str] = None
+    source: str
+
+
+@app.post("/api/live/tables/{code}/upload-client")
+def upload_live_client(code: str, req: UploadClientRequest):
+    """Register an uploaded Python Player for one table's seat picker.
+
+    SECURITY: the uploaded file is arbitrary code executed in this process. The
+    web UI is a trusted local/dev tool; do not expose this to untrusted users.
+    """
+    table = live.manager.get(code)
+    if table is None:
+        raise HTTPException(status_code=404, detail="table not found")
+    if len(req.source.encode("utf-8")) > live.MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="uploaded client is too large")
+    try:
+        option = table.register_upload(req.source, req.filename or "")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return option
 
 
 @app.get("/api/live/tables/{code}")
@@ -170,6 +200,8 @@ async def live_ws(websocket: WebSocket, code: str, client_id: Optional[str] = No
                     e = table.add_ai(str(msg.get("seat_id", "")),
                                      msg.get("ai_type") or live.default_ai_type(),
                                      str(msg.get("name", "")), client_id)
+                elif action == "add_open":
+                    e = table.add_open(str(msg.get("seat_id", "")), str(msg.get("name", "")))
                 elif action == "clear_seat":
                     e = table.clear_seat(str(msg.get("seat_id", "")))
                 elif action == "start":

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -130,7 +130,8 @@ export type LiveStatus = 'lobby' | 'playing' | 'finished'
 export interface LiveSeat {
   index: number
   seat_id: string
-  kind: 'empty' | 'human' | 'ai'
+  // "open" = reserved for an external CLI client that joins via the lobby code.
+  kind: 'empty' | 'human' | 'ai' | 'open'
   name: string
   ai_type: string | null
   mine: boolean
@@ -218,9 +219,26 @@ export interface LiveAiSeat {
 export interface LiveSnapshot {
   type: 'state'
   server_now?: number  // server epoch seconds at send time (for clock-skew-free timers)
-  table: { code: string; status: LiveStatus; seats: LiveSeat[] }
+  table: {
+    code: string
+    status: LiveStatus
+    seats: LiveSeat[]
+    lobby_code?: string                      // share with CLI clients to fill open seats
+    uploaded_ai_types?: AiTypeOption[]       // per-table uploaded clients
+  }
   public: LivePublic | null
   you: { client_id: string; seats: LiveMySeat[]; ai?: LiveAiSeat[] }
+}
+
+// One open/active table for the join-or-observe list.
+export interface LiveTableSummary {
+  code: string
+  status: LiveStatus
+  seats: { kind: string; name: string | null }[]
+  humans: number
+  ai: number
+  open: number
+  empty: number
 }
 
 // --- Physical-table play (AI vs. real humans at a real table) ----------------
@@ -355,7 +373,26 @@ export const api = {
   },
   liveTable: (code: string) =>
     getJSON<{ code: string; status: LiveStatus }>(`/api/live/tables/${encodeURIComponent(code)}`),
+  liveTables: () => getJSON<{ tables: LiveTableSummary[] }>('/api/live/tables'),
   aiTypes: () => getJSON<{ ai_types: AiTypeOption[] }>('/api/live/ai-types'),
+  uploadLiveClient: async (code: string, filename: string, source: string): Promise<AiTypeOption> => {
+    const res = await fetch(`/api/live/tables/${encodeURIComponent(code)}/upload-client`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename, source }),
+    })
+    if (!res.ok) {
+      let detail = `${res.status} ${res.statusText}`
+      try {
+        const body = await res.json()
+        if (body?.detail) detail = body.detail
+      } catch {
+        // non-JSON error body; keep the status line
+      }
+      throw new Error(detail)
+    }
+    return res.json() as Promise<AiTypeOption>
+  },
   createTableSession: async (): Promise<{ code: string }> => {
     const res = await fetch('/api/table/sessions', { method: 'POST' })
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -29,6 +29,7 @@ function wsUrl(code: string): string {
 export type SendAction =
   | { action: 'add_human'; seat_id: string; name: string }
   | { action: 'add_ai'; seat_id: string; ai_type: string; name?: string }
+  | { action: 'add_open'; seat_id: string; name?: string }
   | { action: 'clear_seat'; seat_id: string }
   | { action: 'start' }
   | { action: 'decide'; seat_id: string; value: string | string[] }

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -49,6 +49,21 @@
 .seat-card__name { font-size: 18px; font-weight: 700; }
 .seat-kind--human { border-color: #64b5f6; color: #64b5f6; }
 .seat-kind--ai { border-color: #ba9; color: #cba; }
+.seat-kind--open { border-color: #8d9; color: #9eb; }
+
+/* Copy-pasteable CLI invocation for joining a table by lobby code. */
+.cli-hint {
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+}
 
 /* --- Play view --- */
 .live-table-info {

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api } from '../api/client'
-import type { LiveSeat, LiveMySeat, LivePublic, LiveRound, AiTypeOption, LiveAiSeat, LiveLogEntry } from '../api/client'
+import type { LiveSeat, LiveMySeat, LivePublic, LiveRound, AiTypeOption, LiveAiSeat, LiveLogEntry, LiveTableSummary, LiveSnapshot } from '../api/client'
 import { useLiveTable, type SendAction } from '../lib/liveSocket'
 import { Card } from '../components/Card'
 import { TrickRow } from '../components/TrickRow'
@@ -101,6 +101,76 @@ export function LivePlayHome() {
       <div style={{ marginTop: 32 }}>
         <LobbyGamesSection />
       </div>
+
+      <OpenLobbies />
+    </div>
+  )
+}
+
+// --- Open lobbies: discover tables to join or observe -------------------------
+
+function OpenLobbies() {
+  const navigate = useNavigate()
+  const [tables, setTables] = useState<LiveTableSummary[] | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    const load = () =>
+      api
+        .liveTables()
+        .then((r) => alive && setTables(r.tables))
+        .catch(() => alive && setTables([]))
+    load()
+    const id = setInterval(load, 3000) // keep the list fresh while people open/fill tables
+    return () => {
+      alive = false
+      clearInterval(id)
+    }
+  }, [])
+
+  if (!tables || tables.length === 0) {
+    return (
+      <div style={{ marginTop: 24 }}>
+        <h2>Open tables</h2>
+        <p className="muted" style={{ fontSize: 13 }}>
+          {tables == null ? 'Loading…' : 'No open tables right now — create one above.'}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <h2>Open tables</h2>
+      <div className="seat-grid">
+        {tables.map((t) => {
+          const joinable = t.status === 'lobby' && t.empty > 0
+          const parts = [
+            t.humans ? `${t.humans} human` : null,
+            t.ai ? `${t.ai} AI` : null,
+            t.open ? `${t.open} open` : null,
+            t.empty ? `${t.empty} empty` : null,
+          ].filter(Boolean)
+          return (
+            <div key={t.code} className="card-surface seat-card seat-card--filled">
+              <div className="seat-card__head">
+                <strong style={{ letterSpacing: 2 }}>{t.code}</strong>
+                <span className={`pill live-status live-status--${t.status}`}>{t.status}</span>
+              </div>
+              <div className="muted" style={{ fontSize: 12, marginTop: 4 }}>
+                {parts.join(' · ') || 'empty table'}
+              </div>
+              <button
+                className="btn"
+                style={{ marginTop: 10 }}
+                onClick={() => navigate(`/play/${t.code}`)}
+              >
+                {joinable ? 'Join' : 'Observe'}
+              </button>
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -139,7 +209,7 @@ export function LiveTable() {
       {error && <p className="live-error">{error}</p>}
 
       {status === 'lobby' ? (
-        <Lobby seats={table.seats} send={send} />
+        <Lobby table={table} send={send} />
       ) : (
         <PlayView pub={pub} mySeats={you.seats} aiSeats={you.ai ?? []} send={send} serverOffset={serverOffset} />
       )}
@@ -149,14 +219,21 @@ export function LiveTable() {
 
 // --- Lobby: seat management --------------------------------------------------
 
-function Lobby({ seats, send }: { seats: LiveSeat[]; send: (a: SendAction) => void }) {
+type LobbyTable = LiveSnapshot['table']
+
+function Lobby({ table, send }: { table: LobbyTable; send: (a: SendAction) => void }) {
+  const seats = table.seats
   const allFilled = seats.every((s) => s.kind !== 'empty')
-  const aiOptions = useAiTypes()
+  const builtInAi = useAiTypes()
+  // Per-table uploaded clients extend the built-in roster in the seat picker.
+  const aiOptions = [...builtInAi, ...(table.uploaded_ai_types ?? [])]
+  const hasOpen = seats.some((s) => s.kind === 'open')
+
   return (
     <>
       <div className="seat-grid">
         {seats.map((seat) => (
-          <SeatCard key={seat.seat_id} seat={seat} send={send} aiOptions={aiOptions} />
+          <SeatCard key={seat.seat_id} seat={seat} send={send} aiOptions={aiOptions} code={table.code} />
         ))}
       </div>
       <div className="row-actions" style={{ marginTop: 16 }}>
@@ -165,6 +242,23 @@ function Lobby({ seats, send }: { seats: LiveSeat[]; send: (a: SendAction) => vo
         </button>
         {!allFilled && <span className="muted" style={{ fontSize: 13 }}>Fill all four seats to start.</span>}
       </div>
+
+      {(hasOpen || table.lobby_code) && (
+        <div className="card-surface" style={{ marginTop: 16 }}>
+          <h3 style={{ margin: '0 0 6px' }}>Join from the command line</h3>
+          <p className="muted" style={{ fontSize: 13, marginTop: 0 }}>
+            Mark a seat <strong>Open (CLI)</strong>, then drop a bot from your terminal into the next
+            open seat with the table's lobby code:
+          </p>
+          <pre className="cli-hint">
+            python3 clients/python/lobby_client.py --player=random_player --lobby-code={table.lobby_code ?? table.code}
+          </pre>
+          <p className="muted" style={{ fontSize: 12, marginTop: 6 }}>
+            Players fill open seats FIFO. Start the game once every seat is filled (open seats wait
+            for their CLI client to connect).
+          </p>
+        </div>
+      )}
     </>
   )
 }
@@ -173,16 +267,38 @@ function SeatCard({
   seat,
   send,
   aiOptions,
+  code,
 }: {
   seat: LiveSeat
   send: (a: SendAction) => void
   aiOptions: AiTypeOption[]
+  code: string
 }) {
   const [name, setName] = useState('')
   const [ai, setAi] = useState('')
+  const [uploadErr, setUploadErr] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
   // Until the user picks, default to Random when available, else the first option.
   const preferred = aiOptions.find((o) => o.value === 'random_player')?.value
   const selectedAi = ai || preferred || aiOptions[0]?.value || ''
+
+  const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = '' // allow re-selecting the same file after an edit
+    if (!file) return
+    setUploadErr(null)
+    setUploading(true)
+    try {
+      const source = await file.text()
+      const opt = await api.uploadLiveClient(code, file.name, source)
+      // Auto-select the freshly uploaded client so "Add AI" uses it immediately.
+      setAi(opt.value)
+    } catch (err) {
+      setUploadErr(err instanceof Error ? err.message : String(err))
+    } finally {
+      setUploading(false)
+    }
+  }
 
   return (
     <div className={`card-surface seat-card ${seat.kind !== 'empty' ? 'seat-card--filled' : ''}`}>
@@ -190,7 +306,7 @@ function SeatCard({
         <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>SEAT {seat.index + 1}</span>
         {seat.kind !== 'empty' && (
           <span className={`pill seat-kind seat-kind--${seat.kind}`}>
-            {seat.kind === 'human' ? (seat.mine ? 'you' : 'human') : 'ai'}
+            {seat.kind === 'human' ? (seat.mine ? 'you' : 'human') : seat.kind === 'open' ? 'open' : 'ai'}
           </span>
         )}
       </div>
@@ -232,11 +348,34 @@ function SeatCard({
               Add AI
             </button>
           </div>
+          <div className="row-actions" style={{ gap: 6 }}>
+            <label className="btn" style={{ cursor: 'pointer' }}>
+              {uploading ? 'Uploading…' : 'Upload .py client'}
+              <input
+                type="file"
+                accept=".py,text/x-python,text/plain"
+                onChange={onUpload}
+                disabled={uploading}
+                style={{ display: 'none' }}
+              />
+            </label>
+            <button
+              className="btn"
+              onClick={() => send({ action: 'add_open', seat_id: seat.seat_id })}
+              title="Reserve this seat for a CLI client joining via the lobby code"
+            >
+              Open (CLI)
+            </button>
+          </div>
+          {uploadErr && <div className="live-error" style={{ fontSize: 12 }}>{uploadErr}</div>}
         </div>
       ) : (
         <div className="seat-card__filled">
           <div className="seat-card__name">{seat.name}</div>
           {seat.kind === 'ai' && <div className="muted" style={{ fontSize: 12 }}>{seat.ai_type} bot</div>}
+          {seat.kind === 'open' && (
+            <div className="muted" style={{ fontSize: 12 }}>waiting for a CLI client…</div>
+          )}
           <button
             className="btn"
             style={{ marginTop: 10 }}


### PR DESCRIPTION
## Summary

Closes #56. Three additions to live lobby play:

- **Upload a Python client.** Each empty seat's picker gains an *Upload .py client* control. The file's single `Player` subclass is registered as a per-table AI option (value prefixed `upload:`, label `⬆ <name>`) and can be seated like any built-in bot — handy for trying an AI iteration against humans or other bots without merging it. Scoped to one table, size-capped (256 KB), max 16 uploads/table.
- **Open (CLI) seats + a CLI helper.** A seat can be marked *Open (CLI)*, reserving it for an external client that joins via the table's lobby code. New `clients/python/lobby_client.py` drops a chosen player into the next open seat (the server matches FIFO within a lobby code). The lobby renders a copy-pasteable invocation. Starting still requires at least one human/AI seat; open seats are skipped when spawning local sessions and wait for their CLI client.
- **Open-tables list.** The Live-play home polls `GET /api/live/tables` and lists open/active tables with their seat composition and a **Join** (a lobby with an empty seat) or **Observe** button.

## Interop notes / limitation

CLI→UI works: CLI clients fill UI-created open seats via the shared lobby code, and the UI renders the live game. The reverse — the UI **listing/joining a table created directly on the C++ server from a CLI client** — is not supported here: the web backend only tracks tables it created and cannot enumerate C++-server lobbies. That would need a new server-side lobby-listing API.

## Security

The upload endpoint **execs arbitrary Python in the server process** (no sandbox). The web UI is intended as a trusted local/dev tool; the endpoint is size-capped and requires exactly one concrete `Player` subclass, but it must not be exposed to untrusted users. Warnings are in the backend code and API docstring.

## Test plan

- [x] Frontend `npm run build` (tsc + vite) passes
- [x] Backend imports under the venv; smoke-tested `add_open`, `register_upload`, `ai_class_for`, `add_ai` with an uploaded client, `start()` guards, `summary()`, `list_tables()`, and `snapshot_for()` `uploaded_ai_types`
- [ ] Manual: create a table, upload a client, mark a seat Open (CLI), join from `lobby_client.py`, start, play a full game
- [ ] Manual: open-tables list shows Join/Observe correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
