### PR TITLE
Add "games won" column to player aggregate views (closes #64)

### DIFF
--- a/web/backend/results.py
+++ b/web/backend/results.py
@@ -414,6 +414,7 @@ def get_live_stats() -> dict:
     qualifying_executed = 0
     finals_executed = 0
     standings: dict[str, int] = {}
+    games_won: dict[str, int] = {}
     began_at = None
     competition_id = None
     tournament_index = None
@@ -424,6 +425,16 @@ def get_live_stats() -> dict:
         qualifying_executed = len(summary.get("qualifying", []))
         finals_executed = len(summary.get("finals", []))
         standings = summary.get("finals_totals") or summary.get("qualifying_totals") or {}
+        # Count game wins over the same stage the standings reflect (finals once
+        # they begin, otherwise qualifying), so wins line up with the points shown.
+        # The winner id carries a per-game session suffix; the standings totals are
+        # keyed by slot id (team/tag/index), so collapse to that to match.
+        stage_games = summary.get("finals") if summary.get("finals_totals") else summary.get("qualifying")
+        for entry in stage_games or []:
+            winner = entry.get("winner") if isinstance(entry, dict) else None
+            if winner:
+                slot = "/".join(winner.split("/")[:3])
+                games_won[slot] = games_won.get(slot, 0) + 1
 
     executed = qualifying_executed + finals_executed
     planned_total = planned_qualifying + planned_finals
@@ -442,5 +453,6 @@ def get_live_stats() -> dict:
         "games_executed": executed,
         "games_waiting": waiting,
         "standings": standings,
+        "games_won": games_won,
         "note": "in-progress/waiting counts are approximated from completed result files vs configured totals; the game server does not expose live per-game state.",
     }

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -312,6 +312,7 @@ export interface LiveStats {
   games_executed: number
   games_waiting: number
   standings: Record<string, number>
+  games_won: Record<string, number>
   note: string
 }
 

--- a/web/frontend/src/lib/aggregate.ts
+++ b/web/frontend/src/lib/aggregate.ts
@@ -12,6 +12,7 @@ export interface Aggregate {
   numGames: number
   // slotId -> total across the matching games
   gamesByPlayer: Record<string, number>
+  gamesWonByPlayer: Record<string, number>
   gamePointsByPlayer: Record<string, number>
   tournamentPointsByPlayer: Record<string, number>
   moonShotsByPlayer: Record<string, number>
@@ -40,6 +41,7 @@ function add(target: Record<string, number>, key: string, v: number) {
 
 export function aggregate(games: GameSummary[]): Aggregate {
   const gamesByPlayer: Record<string, number> = {}
+  const gamesWonByPlayer: Record<string, number> = {}
   const gamePointsByPlayer: Record<string, number> = {}
   const tournamentPointsByPlayer: Record<string, number> = {}
   const moonShotsByPlayer: Record<string, number> = {}
@@ -50,9 +52,17 @@ export function aggregate(games: GameSummary[]): Aggregate {
       add(gamePointsByPlayer, key, p.game_score)
       add(tournamentPointsByPlayer, key, p.tournament_points)
     }
+    if (g.winner) add(gamesWonByPlayer, slotId(g.winner), 1)
     for (const [id, v] of Object.entries(g.moon_shots ?? {})) add(moonShotsByPlayer, slotId(id), v)
   }
-  return { numGames: games.length, gamesByPlayer, gamePointsByPlayer, tournamentPointsByPlayer, moonShotsByPlayer }
+  return {
+    numGames: games.length,
+    gamesByPlayer,
+    gamesWonByPlayer,
+    gamePointsByPlayer,
+    tournamentPointsByPlayer,
+    moonShotsByPlayer,
+  }
 }
 
 /** All distinct slot ids appearing across a set of games (for filter dropdowns). */

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -80,6 +80,7 @@ export function LiveStatsPanel() {
               <th>#</th>
               <th>Player</th>
               <th>Tournament points</th>
+              <th>Games won</th>
             </tr>
           </thead>
           <tbody>
@@ -88,6 +89,7 @@ export function LiveStatsPanel() {
                 <td>{i + 1}</td>
                 <td><PlayerName d={nameOf(player)} /></td>
                 <td>{pts}</td>
+                <td>{data.games_won?.[player] ?? 0}</td>
               </tr>
             ))}
           </tbody>

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -8,7 +8,7 @@ import { aggregate, allPlayers, filterGames } from '../lib/aggregate'
 
 const PAGE_SIZE = 50
 
-type SortKey = 'team' | 'player' | 'gamesCount' | 'game' | 'tournament' | 'moon'
+type SortKey = 'team' | 'player' | 'gamesCount' | 'gamesWon' | 'game' | 'tournament' | 'moon'
 const TEXT_SORTS: SortKey[] = ['team', 'player']
 
 export function TournamentDetail() {
@@ -89,6 +89,7 @@ export function TournamentDetail() {
       if (sortKey === 'team') cmp = (nameOf(a).team ?? '').localeCompare(nameOf(b).team ?? '')
       else if (sortKey === 'player') cmp = playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
       else if (sortKey === 'gamesCount') cmp = (agg.gamesByPlayer[a] ?? 0) - (agg.gamesByPlayer[b] ?? 0)
+      else if (sortKey === 'gamesWon') cmp = (agg.gamesWonByPlayer[a] ?? 0) - (agg.gamesWonByPlayer[b] ?? 0)
       else if (sortKey === 'game') cmp = (agg.gamePointsByPlayer[a] ?? 0) - (agg.gamePointsByPlayer[b] ?? 0)
       else if (sortKey === 'tournament')
         cmp = (agg.tournamentPointsByPlayer[a] ?? 0) - (agg.tournamentPointsByPlayer[b] ?? 0)
@@ -160,6 +161,7 @@ export function TournamentDetail() {
               <SortTh label="Team" col="team" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Player" col="player" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Total games" col="gamesCount" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
+              <SortTh label="Games won" col="gamesWon" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Total game points" col="game" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh
                 label="Total tournament points"
@@ -179,6 +181,7 @@ export function TournamentDetail() {
                   <td style={{ color: d.color, fontWeight: 600 }}>{d.team ?? '—'}</td>
                   <td><PlayerName d={d} /></td>
                   <td>{agg.gamesByPlayer[p] ?? 0}</td>
+                  <td>{agg.gamesWonByPlayer[p] ?? 0}</td>
                   <td>{agg.gamePointsByPlayer[p] ?? 0}</td>
                   <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
                   <td>{agg.moonShotsByPlayer[p] ?? 0}</td>


### PR DESCRIPTION
## Summary
Adds a **Games won** column to the player aggregate views so it's easy to see how many games each player actually won, next to their points.

- **Tournament detail** aggregate table: new sortable **Games won** column, counted per player slot from each game's `winner`.
- **Live tournament stats** standings: backend `get_live_stats` now returns a `games_won` map (counted over the same stage the standings reflect, and collapsed from the winner's per-game session id down to the slot id so the keys line up with the points standings); the panel renders it as a **Games won** column.

## Test plan
- [x] `npm run build` (tsc + vite) — clean
- [x] `get_live_stats()` returns `games_won` keyed by slot id, matching `standings` keys on a real summary
- [ ] Eyeball both tables in the running UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
