### PR TITLE
Move "lobby games" under live play (closes #65)

### DIFF
--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import './theme-spacex.css'
 
 const NAV_LINKS = [
   { to: '/', label: 'Competitions' },
-  { to: '/lobby', label: 'Lobby games' },
   { to: '/play', label: 'Live play' },
   { to: '/table', label: 'Table game' },
 ]

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -8,6 +8,7 @@ import { TrickRow } from '../components/TrickRow'
 import { SUIT_ORDER, sortBySuitThenRank, type Suit } from '../lib/cards'
 import { columnSeats, CENTER, passRecipient, passSource } from '../lib/seating'
 import { useColumnSlide } from '../lib/useColumnSlide'
+import { LobbyGamesSection } from './LobbyGamesList'
 import './LivePlay.css'
 
 /** Split a hand into suit groups (suit-then-rank sorted) for gapped rendering. */
@@ -70,7 +71,7 @@ export function LivePlayHome() {
       <h1>Live play</h1>
       <p className="muted" style={{ marginTop: -8 }}>
         Create a table, add human seats (controlled from your browser) and AI opponents, then play a
-        real game on the server. Finished games show up under Lobby games.
+        real game on the server. Finished games show up under Lobby games below.
       </p>
       <div className="card-surface live-home">
         <div>
@@ -96,6 +97,10 @@ export function LivePlayHome() {
         </div>
       </div>
       {error && <p className="muted">Error: {error}</p>}
+
+      <div style={{ marginTop: 32 }}>
+        <LobbyGamesSection />
+      </div>
     </div>
   )
 }

--- a/web/frontend/src/pages/LobbyGamesList.tsx
+++ b/web/frontend/src/pages/LobbyGamesList.tsx
@@ -10,13 +10,27 @@ function formatTime(iso: string | null): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
 }
 
+// Standalone page (kept for direct /lobby links); the list itself lives in
+// LobbyGamesSection so it can also be embedded under Live play.
 export function LobbyGamesList() {
+  return (
+    <div>
+      <LobbyGamesSection headingLevel="h1" />
+    </div>
+  )
+}
+
+// The lobby-games list, reusable as its own page or embedded (e.g. under the
+// Live play landing). `headingLevel` controls whether the title is an <h1>
+// (standalone page) or an <h2> (embedded under another page's <h1>).
+export function LobbyGamesSection({ headingLevel = 'h2' }: { headingLevel?: 'h1' | 'h2' }) {
   const { data, loading, error } = useFetch(() => api.lobbyGames(), [])
   const navigate = useNavigate()
+  const Heading = headingLevel
 
   return (
     <div>
-      <h1>Lobby games</h1>
+      <Heading>Lobby games</Heading>
       <p className="muted" style={{ marginTop: -8 }}>
         Practice games played on the regular server (outside any tournament).
       </p>


### PR DESCRIPTION
## Summary
Moves the **Lobby games** tab under **Live play** so the practice-game history sits next to where you create/join a table.

- Removed the top-level **Lobby games** nav link.
- The lobby-games list now renders on the **Live play** landing page, **below** the create/join-a-table card.
- Refactored the list into a reusable `LobbyGamesSection` (configurable heading level). The standalone `/lobby` route is kept (wrapping the same section) so existing links and the lobby game-detail routes still work.

## Test plan
- [x] `npm run build` (tsc + vite) — clean
- [ ] Visit `/play`: lobby games list appears below the create/join card; nav no longer shows a separate "Lobby games" tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
