### PR TITLE
Stop residual WebSocket 403 reconnect spam (closes #50)

### DIFF
--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -121,15 +121,22 @@ def get_live_table(code: str):
 
 
 @app.websocket("/api/live/ws/{code}")
-async def live_ws(websocket: WebSocket, code: str, client_id: str):
+async def live_ws(websocket: WebSocket, code: str, client_id: Optional[str] = None):
+    # `client_id` is Optional (not a required str) on purpose: a *missing*
+    # required query param makes FastAPI reject the handshake before we can
+    # accept it, which the ASGI layer logs as a bare "403 Forbidden" and the
+    # client only sees as a generic abnormal close it then reconnects to
+    # forever. Accept first and close with an application code instead, so the
+    # logs stay quiet and the client gets a reason it can stop on.
     table = live.manager.get(code)
-    if table is None:
+    if table is None or not client_id:
         # Accept first, *then* close with an application code. Closing before
         # accept makes the ASGI layer reject the handshake with HTTP 403, which
         # (a) spams the logs and (b) hides the reason from the client, whose
         # onclose only sees a generic abnormal close and reconnects forever.
         await websocket.accept()
-        await websocket.close(code=4404, reason="table not found")
+        reason = "table not found" if table is None else "missing client_id"
+        await websocket.close(code=4404, reason=reason)
         return
     await websocket.accept()
     table.loop = asyncio.get_running_loop()

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -56,6 +56,15 @@ export function useLiveTable(code: string | undefined): LiveConnection {
     let closed = false
     let retry: ReturnType<typeof setTimeout> | undefined
     let backoff = 1000
+    let everOpened = false
+    let handshakeFailures = 0
+    // If the socket never finishes its handshake (e.g. the backend was restarted
+    // and rejects the upgrade with a bare 403, surfaced here as a generic 1006
+    // close), retrying forever just spams the server logs. Cap consecutive
+    // never-opened attempts and surface an error instead. Reconnects after a
+    // *successful* open stay unbounded, so a brief network blip mid-game still
+    // recovers.
+    const MAX_HANDSHAKE_FAILURES = 6
 
     const connect = () => {
       if (closed) return
@@ -63,6 +72,8 @@ export function useLiveTable(code: string | undefined): LiveConnection {
       wsRef.current = ws
       ws.onopen = () => {
         setConnected(true)
+        everOpened = true
+        handshakeFailures = 0
         backoff = 1000 // reset backoff once a connection succeeds
       }
       ws.onclose = (ev) => {
@@ -72,6 +83,15 @@ export function useLiveTable(code: string | undefined): LiveConnection {
           // Table no longer exists — retrying would just spam 403s forever.
           setError('Table not found — it may have ended.')
           return
+        }
+        if (!everOpened) {
+          // Never got past the handshake — likely a 403 from a missing/old
+          // table. Give up after a bounded number of tries instead of looping.
+          handshakeFailures += 1
+          if (handshakeFailures >= MAX_HANDSHAKE_FAILURES) {
+            setError('Unable to reach the table — it may have ended. Refresh to retry.')
+            return
+          }
         }
         retry = setTimeout(connect, backoff)
         backoff = Math.min(backoff * 2, 30000) // exponential backoff, cap 30s


### PR DESCRIPTION
## Summary
Closes #50. The prior fix (#57) handled the *missing-table* path, but two routes to a bare handshake-level **403 Forbidden** remained — and a stale browser tab reconnected through them forever, spamming the backend logs.

- **Backend** (`web/backend/main.py`): `client_id` was a *required* query param, so a request without it was rejected by FastAPI **before** the endpoint could `accept()` — uvicorn logs that as a bare `403` and the client only sees a generic `1006` close it reconnects to forever. It's now `Optional` and closed cleanly with application code `4404` inside the handler (alongside the existing missing-table case).
- **Frontend** (`web/frontend/src/lib/liveSocket.ts`): the reconnect loop retried **every** non-4404 close indefinitely (1s→30s backoff). Against an old/restarting backend that still 403s the upgrade, one tab spammed forever. Reconnects for a socket that **never finished its handshake** are now capped at 6 attempts and surface an error; reconnects **after** a successful open stay unbounded, so a brief mid-game network blip still recovers.

## Why uvicorn logs 403
uvicorn logs `"WebSocket ..." 403` only when the app's first ASGI message is `websocket.close` *before* `accept`. Accepting first (then closing with 4404) avoids the log line and gives the client an interpretable close code it can stop on.

## Test plan
- [x] `TestClient`: missing table, missing `client_id`, and empty `client_id` all return a clean `4404` close (verified reasons: "table not found" / "missing client_id")
- [x] Real table + valid `client_id` still returns the normal state snapshot
- [x] `npm run build` (tsc + vite) passes
- [ ] Manual: open `/play/<code>`, restart backend, confirm the tab stops reconnecting (shows an error) instead of looping