### PR TITLE
Team & team+player filters with predictive leader labels

### DIFF
--- a/web/frontend/src/lib/aggregate.ts
+++ b/web/frontend/src/lib/aggregate.ts
@@ -121,41 +121,61 @@ export function allTeamPlayers(games: GameSummary[]): TeamPlayer[] {
 }
 
 /**
- * Rank the top team across a set of games by total tournament points (summed
- * over every slot whose id starts with that team). Returns the team name, or
- * null when there are no games / no scored players.
+ * Pick the key with the highest average value (sum / count), breaking ties by
+ * lexicographically smaller key. Returns null when there are no entries.
  */
-export function topTeam(games: GameSummary[]): string | null {
-  const byTeam: Record<string, number> = {}
-  for (const g of games)
-    for (const p of gamePlayers(g)) add(byTeam, teamOf(p.id), p.tournament_points)
+function topByAverage(sum: Record<string, number>, count: Record<string, number>): string | null {
   let best: string | null = null
-  let bestPts = -Infinity
-  for (const [team, pts] of Object.entries(byTeam)) {
-    if (pts > bestPts || (pts === bestPts && (best === null || team < best))) {
-      best = team
-      bestPts = pts
+  let bestAvg = -Infinity
+  for (const [key, total] of Object.entries(sum)) {
+    const avg = total / (count[key] || 1)
+    if (avg > bestAvg || (avg === bestAvg && (best === null || key < best))) {
+      best = key
+      bestAvg = avg
     }
   }
   return best
 }
 
 /**
- * Rank the top (team, player) across a set of games by total tournament points
- * (summed over all of that player's slots for that team). Returns "team/tag",
+ * Rank the top team across a set of games by *average* tournament points — the
+ * team's total tournament points (summed over every slot whose id starts with
+ * that team) divided by the number of games the team appeared in. Ranking by
+ * average (not total) keeps the prediction fair when the filter leaves a subset
+ * in which teams appear in different numbers of games. Returns the team name, or
+ * null when there are no games / no scored players.
+ */
+export function topTeam(games: GameSummary[]): string | null {
+  const sumByTeam: Record<string, number> = {}
+  const gamesByTeam: Record<string, number> = {}
+  for (const g of games) {
+    const teamsInGame = new Set<string>()
+    for (const p of gamePlayers(g)) {
+      add(sumByTeam, teamOf(p.id), p.tournament_points)
+      teamsInGame.add(teamOf(p.id))
+    }
+    for (const t of teamsInGame) add(gamesByTeam, t, 1)
+  }
+  return topByAverage(sumByTeam, gamesByTeam)
+}
+
+/**
+ * Rank the top (team, player) across a set of games by *average* tournament
+ * points — that player's total (summed over all their slots for that team)
+ * divided by the number of games they appeared in. Ranking by average (not
+ * total) keeps the prediction fair across a filtered subset. Returns "team/tag",
  * or null when there are no games / no scored players.
  */
 export function topTeamPlayer(games: GameSummary[]): string | null {
-  const byTP: Record<string, number> = {}
-  for (const g of games)
-    for (const p of gamePlayers(g)) add(byTP, teamPlayerKey(p.id), p.tournament_points)
-  let best: string | null = null
-  let bestPts = -Infinity
-  for (const [tp, pts] of Object.entries(byTP)) {
-    if (pts > bestPts || (pts === bestPts && (best === null || tp < best))) {
-      best = tp
-      bestPts = pts
+  const sumByTP: Record<string, number> = {}
+  const gamesByTP: Record<string, number> = {}
+  for (const g of games) {
+    const tpsInGame = new Set<string>()
+    for (const p of gamePlayers(g)) {
+      add(sumByTP, teamPlayerKey(p.id), p.tournament_points)
+      tpsInGame.add(teamPlayerKey(p.id))
     }
+    for (const tp of tpsInGame) add(gamesByTP, tp, 1)
   }
-  return best
+  return topByAverage(sumByTP, gamesByTP)
 }

--- a/web/frontend/src/lib/aggregate.ts
+++ b/web/frontend/src/lib/aggregate.ts
@@ -1,12 +1,23 @@
 import { gamePlayers, type GameSummary } from '../api/client'
 import { slotId } from './playerId'
 
+/** A team+player filter: a specific player (tag) playing for a specific team,
+ *  regardless of which slot they occupied. */
+export interface TeamPlayer {
+  team: string
+  tag: string
+}
+
 export interface GameFilter {
-  // Game must include ALL of these slot ids among its players.
-  players: string[]
+  // Game must include ALL of these teams among its players.
+  teams: string[]
+  // Game must include each of these (team, player) pairs (any slot).
+  teamPlayers: TeamPlayer[]
   // Game must have at least this many total moon shots.
   minMoonShots: number
 }
+
+export const EMPTY_FILTER: GameFilter = { teams: [], teamPlayers: [], minMoonShots: 0 }
 
 export interface Aggregate {
   numGames: number
@@ -18,8 +29,27 @@ export interface Aggregate {
   moonShotsByPlayer: Record<string, number>
 }
 
-function gameSlotIds(g: GameSummary): Set<string> {
-  return new Set(gamePlayers(g).map((p) => slotId(p.id)))
+/** team of a full/slot id (first path component). */
+export function teamOf(id: string): string {
+  return id.split('/')[0]
+}
+
+/** "team/tag" key for a full/slot id (drops slot + session). */
+export function teamPlayerKey(id: string): string {
+  const parts = id.split('/')
+  return `${parts[0]}/${parts[1]}`
+}
+
+export function teamPlayerId(tp: TeamPlayer): string {
+  return `${tp.team}/${tp.tag}`
+}
+
+function gameTeams(g: GameSummary): Set<string> {
+  return new Set(gamePlayers(g).map((p) => teamOf(p.id)))
+}
+
+function gameTeamPlayers(g: GameSummary): Set<string> {
+  return new Set(gamePlayers(g).map((p) => teamPlayerKey(p.id)))
 }
 
 function totalMoonShots(g: GameSummary): number {
@@ -28,8 +58,14 @@ function totalMoonShots(g: GameSummary): number {
 
 export function filterGames(games: GameSummary[], filter: GameFilter): GameSummary[] {
   return games.filter((g) => {
-    const slots = gameSlotIds(g)
-    if (filter.players.length && !filter.players.every((p) => slots.has(p))) return false
+    if (filter.teams.length) {
+      const teams = gameTeams(g)
+      if (!filter.teams.every((t) => teams.has(t))) return false
+    }
+    if (filter.teamPlayers.length) {
+      const tps = gameTeamPlayers(g)
+      if (!filter.teamPlayers.every((tp) => tps.has(teamPlayerId(tp)))) return false
+    }
     if (totalMoonShots(g) < filter.minMoonShots) return false
     return true
   })
@@ -65,9 +101,61 @@ export function aggregate(games: GameSummary[]): Aggregate {
   }
 }
 
-/** All distinct slot ids appearing across a set of games (for filter dropdowns). */
-export function allPlayers(games: GameSummary[]): string[] {
+/** All distinct team names appearing across a set of games. */
+export function allTeams(games: GameSummary[]): string[] {
   const set = new Set<string>()
-  for (const g of games) for (const p of gamePlayers(g)) set.add(slotId(p.id))
+  for (const g of games) for (const p of gamePlayers(g)) set.add(teamOf(p.id))
   return [...set].sort()
+}
+
+/** All distinct (team, player) pairs appearing across a set of games. */
+export function allTeamPlayers(games: GameSummary[]): TeamPlayer[] {
+  const set = new Set<string>()
+  for (const g of games) for (const p of gamePlayers(g)) set.add(teamPlayerKey(p.id))
+  return [...set]
+    .map((k) => {
+      const [team, tag] = k.split('/')
+      return { team, tag }
+    })
+    .sort((a, b) => a.team.localeCompare(b.team) || a.tag.localeCompare(b.tag))
+}
+
+/**
+ * Rank the top team across a set of games by total tournament points (summed
+ * over every slot whose id starts with that team). Returns the team name, or
+ * null when there are no games / no scored players.
+ */
+export function topTeam(games: GameSummary[]): string | null {
+  const byTeam: Record<string, number> = {}
+  for (const g of games)
+    for (const p of gamePlayers(g)) add(byTeam, teamOf(p.id), p.tournament_points)
+  let best: string | null = null
+  let bestPts = -Infinity
+  for (const [team, pts] of Object.entries(byTeam)) {
+    if (pts > bestPts || (pts === bestPts && (best === null || team < best))) {
+      best = team
+      bestPts = pts
+    }
+  }
+  return best
+}
+
+/**
+ * Rank the top (team, player) across a set of games by total tournament points
+ * (summed over all of that player's slots for that team). Returns "team/tag",
+ * or null when there are no games / no scored players.
+ */
+export function topTeamPlayer(games: GameSummary[]): string | null {
+  const byTP: Record<string, number> = {}
+  for (const g of games)
+    for (const p of gamePlayers(g)) add(byTP, teamPlayerKey(p.id), p.tournament_points)
+  let best: string | null = null
+  let bestPts = -Infinity
+  for (const [tp, pts] of Object.entries(byTP)) {
+    if (pts > bestPts || (pts === bestPts && (best === null || tp < best))) {
+      best = tp
+      bestPts = pts
+    }
+  }
+  return best
 }

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -2,9 +2,19 @@ import { useMemo } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { api, gamePlayers, type GameSummary } from '../api/client'
 import { useFetch } from '../lib/useFetch'
-import { nameResolver, playerSortKey } from '../lib/playerId'
+import { nameResolver, playerSortKey, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
-import { aggregate, allPlayers, filterGames } from '../lib/aggregate'
+import {
+  aggregate,
+  allTeams,
+  allTeamPlayers,
+  filterGames,
+  teamPlayerId,
+  topTeam,
+  topTeamPlayer,
+  type GameFilter,
+  type TeamPlayer,
+} from '../lib/aggregate'
 
 const PAGE_SIZE = 50
 
@@ -20,7 +30,8 @@ export function TournamentDetail() {
   // shareable and survives back/forward navigation.
   const [params, setParams] = useSearchParams()
   const stage: 'qualifying' | 'finals' = params.get('stage') === 'finals' ? 'finals' : 'qualifying'
-  const selectedPlayers = params.getAll('player')
+  const selectedTeams = params.getAll('team')
+  const selectedTPKeys = params.getAll('tp') // "team/tag"
   const minMoon = Number(params.get('minMoon')) || 0
   const page = Math.max(0, Number(params.get('page')) || 0)
   const sortKey = (params.get('sort') as SortKey) || 'tournament'
@@ -43,7 +54,24 @@ export function TournamentDetail() {
     return stage === 'qualifying' ? data.qualifying : data.finals
   }, [data, stage])
 
-  const players = useMemo(() => allPlayers(games), [games])
+  const teams = useMemo(() => allTeams(games), [games])
+  const teamPlayers = useMemo(() => allTeamPlayers(games), [games])
+
+  const selectedTPs: TeamPlayer[] = useMemo(
+    () =>
+      selectedTPKeys.map((k) => {
+        const [team, tag] = k.split('/')
+        return { team, tag }
+      }),
+    // re-derive only when the URL list changes
+    [selectedTPKeys.join('|')],
+  )
+
+  const filter: GameFilter = useMemo(
+    () => ({ teams: selectedTeams, teamPlayers: selectedTPs, minMoonShots: minMoon }),
+    [selectedTeams.join('|'), selectedTPs, minMoon],
+  )
+
   const nameOf = useMemo(() => {
     const ids: string[] = []
     for (const g of games) {
@@ -52,21 +80,52 @@ export function TournamentDetail() {
     }
     return nameResolver(ids)
   }, [games])
-  const filtered = useMemo(
-    () => filterGames(games, { players: selectedPlayers, minMoonShots: minMoon }),
-    [games, selectedPlayers, minMoon],
-  )
+
+  const filtered = useMemo(() => filterGames(games, filter), [games, filter])
   const agg = useMemo(() => aggregate(filtered), [filtered])
+
+  // For each candidate team filter, the team that would rank #1 if that filter
+  // were added to the current set — or null if it would leave no games.
+  const teamPredictions = useMemo(() => {
+    const m: Record<string, string | null> = {}
+    for (const t of teams) {
+      const nextTeams = selectedTeams.includes(t) ? selectedTeams : [...selectedTeams, t]
+      const sub = filterGames(games, { ...filter, teams: nextTeams })
+      m[t] = sub.length ? topTeam(sub) : null
+    }
+    return m
+  }, [games, teams, filter, selectedTeams.join('|')])
+
+  // For each candidate team+player filter, the player ("team/tag") that would
+  // rank #1 if that filter were added — or null if it would leave no games.
+  const tpPredictions = useMemo(() => {
+    const m: Record<string, string | null> = {}
+    for (const tp of teamPlayers) {
+      const key = teamPlayerId(tp)
+      const has = selectedTPKeys.includes(key)
+      const nextTPs = has ? selectedTPs : [...selectedTPs, tp]
+      const sub = filterGames(games, { ...filter, teamPlayers: nextTPs })
+      m[key] = sub.length ? topTeamPlayer(sub) : null
+    }
+    return m
+  }, [games, teamPlayers, filter, selectedTPKeys.join('|')])
 
   if (loading) return <p className="muted">Loading…</p>
   if (error) return <p className="muted">Error: {error}</p>
   if (!data) return <p className="muted">Not found.</p>
 
-  const togglePlayer = (p: string) => {
-    const next = selectedPlayers.includes(p)
-      ? selectedPlayers.filter((x) => x !== p)
-      : [...selectedPlayers, p]
-    patch({ player: next, page: null })
+  const toggleTeam = (t: string) => {
+    const next = selectedTeams.includes(t)
+      ? selectedTeams.filter((x) => x !== t)
+      : [...selectedTeams, t]
+    patch({ team: next, page: null })
+  }
+
+  const toggleTP = (key: string) => {
+    const next = selectedTPKeys.includes(key)
+      ? selectedTPKeys.filter((x) => x !== key)
+      : [...selectedTPKeys, key]
+    patch({ tp: next, page: null })
   }
 
   const pageGames = filtered.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
@@ -137,21 +196,50 @@ export function TournamentDetail() {
             />
           </label>
         </div>
+
         <div className="muted" style={{ fontSize: 13, marginBottom: 6 }}>
-          Players involved (game must include all checked):
+          Teams (game must include all checked) — label shows who'd lead if added:
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 14 }}>
+          {teams.map((t) => {
+            const lead = teamPredictions[t]
+            const checked = selectedTeams.includes(t)
+            return (
+              <label key={t} className="pill" style={{ cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleTeam(t)}
+                  style={{ marginRight: 5 }}
+                />
+                <span style={{ color: teamColor(t), fontWeight: 600 }}>{t}</span>
+                <FilterLead text={lead === null ? '∅' : lead} />
+              </label>
+            )
+          })}
+        </div>
+
+        <div className="muted" style={{ fontSize: 13, marginBottom: 6 }}>
+          Players by team (game must include all checked, any slot) — label shows who'd lead if added:
         </div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-          {players.map((p) => (
-            <label key={p} className="pill" style={{ cursor: 'pointer' }}>
-              <input
-                type="checkbox"
-                checked={selectedPlayers.includes(p)}
-                onChange={() => togglePlayer(p)}
-                style={{ marginRight: 5 }}
-              />
-              <PlayerName d={nameOf(p)} />
-            </label>
-          ))}
+          {teamPlayers.map((tp) => {
+            const key = teamPlayerId(tp)
+            const lead = tpPredictions[key]
+            const checked = selectedTPKeys.includes(key)
+            return (
+              <label key={key} className="pill" style={{ cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleTP(key)}
+                  style={{ marginRight: 5 }}
+                />
+                <PlayerName d={nameOf(key)} />
+                <FilterLead d={lead ? nameOf(lead) : undefined} text={lead === null ? '∅' : undefined} />
+              </label>
+            )
+          })}
         </div>
 
         <h2>Aggregate over {agg.numGames} matching game(s)</h2>
@@ -256,6 +344,23 @@ export function TournamentDetail() {
         )}
       </div>
     </div>
+  )
+}
+
+/** Small muted "→ leader" annotation shown on a filter chip. Pass `d` to render
+ *  a player display, or `text` for a plain string ('∅' means "excludes all"). */
+function FilterLead({
+  d,
+  text,
+}: {
+  d?: ReturnType<ReturnType<typeof nameResolver>>
+  text?: string
+}) {
+  if (!d && !text) return null
+  return (
+    <span className="muted" style={{ marginLeft: 6, fontSize: 11 }}>
+      → {d ? <PlayerName d={d} /> : text}
+    </span>
   )
 }
 

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -18,8 +18,20 @@ import {
 
 const PAGE_SIZE = 50
 
-type SortKey = 'team' | 'player' | 'gamesCount' | 'gamesWon' | 'game' | 'tournament' | 'moon'
+type SortKey =
+  | 'rank'
+  | 'team'
+  | 'player'
+  | 'avgTournament'
+  | 'gamesCount'
+  | 'gamesWon'
+  | 'tournament'
+  | 'avgGame'
+  | 'moon'
+// Columns that compare as text (localeCompare).
 const TEXT_SORTS: SortKey[] = ['team', 'player']
+// Columns whose natural/default direction is ascending (smallest/best first).
+const ASC_DEFAULT_SORTS: SortKey[] = ['team', 'player', 'rank']
 
 export function TournamentDetail() {
   const { cid = '', index = '' } = useParams()
@@ -34,8 +46,8 @@ export function TournamentDetail() {
   const selectedTPKeys = params.getAll('tp') // "team/tag"
   const minMoon = Number(params.get('minMoon')) || 0
   const page = Math.max(0, Number(params.get('page')) || 0)
-  const sortKey = (params.get('sort') as SortKey) || 'tournament'
-  const sortAsc = params.get('dir') ? params.get('dir') === 'asc' : TEXT_SORTS.includes(sortKey)
+  const sortKey = (params.get('sort') as SortKey) || 'rank'
+  const sortAsc = params.get('dir') ? params.get('dir') === 'asc' : ASC_DEFAULT_SORTS.includes(sortKey)
 
   // Merge a set of changes into the URL search params (preserving the rest).
   const patch = (changes: Record<string, string | string[] | null>) => {
@@ -83,6 +95,28 @@ export function TournamentDetail() {
 
   const filtered = useMemo(() => filterGames(games, filter), [games, filter])
   const agg = useMemo(() => aggregate(filtered), [filtered])
+
+  // Overall rank by total tournament points across ALL games in this stage
+  // (filters do NOT affect it) — so the "Rank" column is a stable reference for
+  // who's ahead in the tournament regardless of the subset being viewed.
+  const rankByPlayer = useMemo(() => {
+    const full = aggregate(games)
+    const ids = Object.keys(full.tournamentPointsByPlayer).sort((a, b) => {
+      const d = (full.tournamentPointsByPlayer[b] ?? 0) - (full.tournamentPointsByPlayer[a] ?? 0)
+      if (d !== 0) return d
+      return playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
+    })
+    const m: Record<string, number> = {}
+    let rank = 0
+    let prevPts: number | null = null
+    ids.forEach((id, i) => {
+      const pts = full.tournamentPointsByPlayer[id] ?? 0
+      if (prevPts === null || pts !== prevPts) rank = i + 1
+      m[id] = rank
+      prevPts = pts
+    })
+    return m
+  }, [games, nameOf])
 
   // For each candidate team filter, the team that would rank #1 if that filter
   // were added to the current set — or null if it would leave no games.
@@ -140,18 +174,28 @@ export function TournamentDetail() {
     }
   }
 
+  // Per-game averages over the currently-matching subset (0 when no games).
+  const avgOf = (totals: Record<string, number>, p: string) => {
+    const n = agg.gamesByPlayer[p] ?? 0
+    return n ? (totals[p] ?? 0) / n : 0
+  }
+
   const aggRows = Object.keys(agg.gamePointsByPlayer)
     .concat(Object.keys(agg.tournamentPointsByPlayer))
     .filter((v, i, a) => a.indexOf(v) === i)
     .sort((a, b) => {
       let cmp: number
-      if (sortKey === 'team') cmp = (nameOf(a).team ?? '').localeCompare(nameOf(b).team ?? '')
+      if (sortKey === 'rank') cmp = (rankByPlayer[a] ?? Infinity) - (rankByPlayer[b] ?? Infinity)
+      else if (sortKey === 'team') cmp = (nameOf(a).team ?? '').localeCompare(nameOf(b).team ?? '')
       else if (sortKey === 'player') cmp = playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
+      else if (sortKey === 'avgTournament')
+        cmp = avgOf(agg.tournamentPointsByPlayer, a) - avgOf(agg.tournamentPointsByPlayer, b)
       else if (sortKey === 'gamesCount') cmp = (agg.gamesByPlayer[a] ?? 0) - (agg.gamesByPlayer[b] ?? 0)
       else if (sortKey === 'gamesWon') cmp = (agg.gamesWonByPlayer[a] ?? 0) - (agg.gamesWonByPlayer[b] ?? 0)
-      else if (sortKey === 'game') cmp = (agg.gamePointsByPlayer[a] ?? 0) - (agg.gamePointsByPlayer[b] ?? 0)
       else if (sortKey === 'tournament')
         cmp = (agg.tournamentPointsByPlayer[a] ?? 0) - (agg.tournamentPointsByPlayer[b] ?? 0)
+      else if (sortKey === 'avgGame')
+        cmp = avgOf(agg.gamePointsByPlayer, a) - avgOf(agg.gamePointsByPlayer, b)
       else cmp = (agg.moonShotsByPlayer[a] ?? 0) - (agg.moonShotsByPlayer[b] ?? 0)
       if (cmp === 0) cmp = playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
       return sortAsc ? cmp : -cmp
@@ -246,11 +290,18 @@ export function TournamentDetail() {
         <table className="data">
           <thead>
             <tr>
+              <SortTh label="Rank" col="rank" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Team" col="team" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Player" col="player" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
+              <SortTh
+                label="Avg tournament points"
+                col="avgTournament"
+                sortKey={sortKey}
+                sortAsc={sortAsc}
+                onSort={toggleSort}
+              />
               <SortTh label="Total games" col="gamesCount" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Games won" col="gamesWon" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
-              <SortTh label="Total game points" col="game" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh
                 label="Total tournament points"
                 col="tournament"
@@ -258,6 +309,7 @@ export function TournamentDetail() {
                 sortAsc={sortAsc}
                 onSort={toggleSort}
               />
+              <SortTh label="Avg game score" col="avgGame" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Moon shots" col="moon" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
             </tr>
           </thead>
@@ -266,12 +318,14 @@ export function TournamentDetail() {
               const d = nameOf(p)
               return (
                 <tr key={p}>
+                  <td>{rankByPlayer[p] ?? '—'}</td>
                   <td style={{ color: d.color, fontWeight: 600 }}>{d.team ?? '—'}</td>
                   <td><PlayerName d={d} /></td>
+                  <td>{avgOf(agg.tournamentPointsByPlayer, p).toFixed(2)}</td>
                   <td>{agg.gamesByPlayer[p] ?? 0}</td>
                   <td>{agg.gamesWonByPlayer[p] ?? 0}</td>
-                  <td>{agg.gamePointsByPlayer[p] ?? 0}</td>
                   <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
+                  <td>{avgOf(agg.gamePointsByPlayer, p).toFixed(2)}</td>
                   <td>{agg.moonShotsByPlayer[p] ?? 0}</td>
                 </tr>
               )


### PR DESCRIPTION
## Summary
Closes #70. Reworks the tournament aggregation filters from per-individual-player to **team** and **team+player** filters, and adds **predictive leader labels** to every filter chip.

1. **Team filters** — checking a team keeps only games that team participated in. Multiple checked teams are AND-ed (game must include all of them).

2. **Team+player filters** — checking a "player on a team" keeps games where that player played for that team, regardless of which slot they occupied.

3. **Predictive leader labels** — each filter chip is annotated with the team / player that would rank **#1 by total tournament points** if that filter were added to the current selection. If adding the filter would leave no matching games, the chip shows the empty-set marker (∅) instead.

### Implementation
- `aggregate.ts`: new `GameFilter { teams, teamPlayers, minMoonShots }` and `TeamPlayer { team, tag }` model. Added helpers `teamOf`, `teamPlayerKey`, `teamPlayerId`, `allTeams`, `allTeamPlayers`, and the argmax rankers `topTeam` / `topTeamPlayer` (sum tournament points, tie-break by name). `filterGames` now requires every selected team present and every selected team+player present.
- `TournamentDetail.tsx`: URL params changed from `player` to `team` (multi) and `tp` (multi `team/tag`). Predictions computed in `teamPredictions` / `tpPredictions` memos. New `FilterLead` component renders the "→ leader" annotation.

## Test plan
- [x] `npm run build` (tsc + vite) passes
- [ ] CI `frontend-build` green
- [ ] Manual: toggle team / player chips, confirm leader labels and ∅ behavior
