### PR TITLE
Fix #50: stop WebSocket handshake-403 log spam with a catch-all route

### DIFF
--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -318,6 +318,21 @@ async def table_ws(websocket: WebSocket, code: str):
         session.clients.pop(conn_key, None)
 
 
+# Catch-all WebSocket route. MUST be declared after every specific @app.websocket
+# route above so those still win (FastAPI matches in registration order). Any WS
+# path that matches nothing else — an empty table code (/api/live/ws/), a stale
+# path from an old cached frontend, a typo — would otherwise be rejected by
+# Starlette *before* the handshake. uvicorn logs that as a bare "403 Forbidden"
+# and the browser only sees an uninterpretable 1006 close, so the client can't
+# tell it should stop and reconnects forever, spamming the logs (issue #50).
+# Accept the handshake first, then close with the application code 4404 that the
+# live/table socket clients already treat as "gone — stop reconnecting".
+@app.websocket("/{_ws_path:path}")
+async def websocket_catch_all(websocket: WebSocket, _ws_path: str):
+    await websocket.accept()
+    await websocket.close(code=4404, reason="unknown websocket endpoint")
+
+
 # Serve the built frontend (web/frontend/dist) when present, so prod is a single process.
 _dist = Path(__file__).resolve().parent.parent / "frontend" / "dist"
 if _dist.is_dir():


### PR DESCRIPTION
## Summary
- The earlier #50 fix made the live/table WS handlers accept-then-close-4404 for a *missing table*, but any WS path matching **no route at all** (empty table code `/api/live/ws/`, a stale path from an old cached frontend, a typo) was still rejected by Starlette **before** the handshake. uvicorn logs that as a bare `403 Forbidden`; the browser only sees an uninterpretable `1006` close, so the client reconnects forever and spams the logs.
- Add a catch-all `@app.websocket("/{_ws_path:path}")` declared **after** every specific WS route (FastAPI matches in registration order, so the real routes still win) that accepts the handshake first, then closes with the application code `4404` the live/table clients already treat as "gone, stop reconnecting".

## How it was found
Reproduced locally against the current backend: `/api/live/ws/EDC3` already returns a clean `4404` (the prior fix works), but `/api/live/ws/` (empty code) and any unmatched path produced the `403`. The reporter's screenshot was from a pre-fix/stale deploy; this change makes the backend incapable of emitting a handshake 403 on *any* WS path.

## Test plan
- [x] `/api/live/ws/`, `/api/live/ws`, `/api/bogus/ws/X` -> now `[accepted]` + clean `4404` close (were `403`)
- [x] `/api/live/ws/EDC3` (table not found) and `/api/table/ws/NOPE` -> still clean `4404` from their specific handlers
- [x] `GET /api/competitions` and `GET /api/live/tournament` -> still `200` (HTTP routes unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
