### PR TITLE
#78: record timed-out moves end to end (server + web UI)

### DIFF
--- a/server/api/game_session.h
+++ b/server/api/game_session.h
@@ -88,6 +88,13 @@ public:
         return mGameSessionID;
     }
 
+    // True if the last receive() returned nullopt because the connection gave up
+    // immediately (give-up mode) rather than waiting the full move timeout. Used
+    // by RemotePlayer to mark an auto-move as give-up ("#") vs. timeout ("*").
+    bool lastReceiveWasGiveUp() {
+        return mConnection.sessionLastReceiveWasGiveUp(mGameSessionID);
+    }
+
 
 private:
     uint16_t getSeqNumAndIncrement()

--- a/server/api/managed_connection.h
+++ b/server/api/managed_connection.h
@@ -32,6 +32,11 @@ struct SessionParts
     bool disconnected;
     int consecutiveTimeouts = 0;
     int autoMoveThreshold = 2;  // 0 = never auto-move
+    // Set by receiveOnSession on every return: true iff the call gave up
+    // immediately (zero wait) because consecutiveTimeouts had already reached
+    // autoMoveThreshold. Lets the move recorder distinguish a give-up auto ("#")
+    // from a single move that timed out after the full wait ("*").
+    bool lastReceiveWasGiveUp = false;
     std::optional<std::shared_ptr<Common::MessageLogger>> messageLogger;
 };
 
@@ -176,6 +181,19 @@ public:
         return false;
     }
 
+    // Whether the most recent receiveOnSession on this session gave up immediately
+    // (give-up mode) rather than waiting the full timeout. Read right after a
+    // timed-out move to tell a "#" (give-up) auto-play from a "*" (timeout) one.
+    bool sessionLastReceiveWasGiveUp(PlayerGameSessionID sessionId)
+    {
+        std::lock_guard<std::mutex> mapLock(mSessionsMtx);
+        auto it = playerGameSessions.find(sessionId);
+        if (it == playerGameSessions.end())
+            return false;
+        std::lock_guard<std::mutex> lock(it->second->mutex);
+        return it->second->lastReceiveWasGiveUp;
+    }
+
     static void CleanConnections(std::vector<std::unique_ptr<ManagedConnection>> &connections) {
         connections.erase(
                 std::remove_if(connections.begin(), connections.end(),
@@ -215,8 +233,8 @@ public:
         SessionParts& parts = *rawParts;
 
         std::unique_lock<std::mutex> lock(parts.mutex);
-        auto effectiveTimeout = (parts.autoMoveThreshold > 0 && parts.consecutiveTimeouts >= parts.autoMoveThreshold)
-            ? std::chrono::milliseconds(0) : timeout;
+        bool giveUpMode = (parts.autoMoveThreshold > 0 && parts.consecutiveTimeouts >= parts.autoMoveThreshold);
+        auto effectiveTimeout = giveUpMode ? std::chrono::milliseconds(0) : timeout;
         bool gotMessage = parts.waitCondition.wait_for(lock, effectiveTimeout, [&parts] {
             return !parts.unprocessedReceivedMessages.empty()
                    || parts.disconnected;
@@ -226,10 +244,14 @@ public:
             || parts.unprocessedReceivedMessages.empty())
         {
             parts.consecutiveTimeouts++;
+            // Remember whether this was an immediate give-up (we'd already blown
+            // the threshold) vs. a move that exhausted its full timeout.
+            parts.lastReceiveWasGiveUp = giveUpMode;
             return std::nullopt;
         }
 
         parts.consecutiveTimeouts = 0;
+        parts.lastReceiveWasGiveUp = false;
         auto message = parts.unprocessedReceivedMessages[0];
         parts.unprocessedReceivedMessages.erase(parts.unprocessedReceivedMessages.begin());
 

--- a/server/game/game_observer.h
+++ b/server/game/game_observer.h
@@ -15,8 +15,11 @@ public:
     virtual void onHandsAfterPass(const std::map<std::string, std::vector<std::string>>& hands) {}
     // passedByPlayer: playerTagSession → 3 cards they passed (empty map on Keeper rounds)
     virtual void onCardsPassed(const std::map<std::string, std::vector<std::string>>& passedByPlayer) {}
+    // moveSources[i] is how cards[i] was chosen: "player", "timeout", or "give_up"
+    // (Common::Server::MoveSource). Aligned with playerOrder/cards.
     virtual void onTrickComplete(const std::vector<std::string>& playerOrder, // play order
                                   const std::vector<std::string>& cards,       // play order
+                                  const std::vector<std::string>& moveSources, // play order
                                   const std::string& winner, int points) {}
     virtual void onRoundComplete(int roundIdx, const std::map<std::string, int>& scores) {}
     virtual void onMove(const std::string& playerTag, long latencyMs, bool autoMoved,

--- a/server/game/game_recorder.h
+++ b/server/game/game_recorder.h
@@ -19,6 +19,7 @@
 #include <nlohmann/json.hpp>
 
 #include "game_observer.h"
+#include "../util/constants.h"  // Common::Server::MoveSource
 
 namespace Common::Game {
 
@@ -30,6 +31,7 @@ struct TrickRecord {
     std::string firstPlayer;
     std::vector<std::string> playerTags; // play order (playerTags[i] played cards[i])
     std::vector<std::string> cards;
+    std::vector<std::string> moveSources; // play order: "player" | "timeout" | "give_up"
     std::string winner;
     int points;
 };
@@ -62,6 +64,15 @@ struct GameResult {
     std::map<std::string, long> maxC2SMs;         // per-player max c2s
     std::map<std::string, long> maxMoveLatencyMs; // per-player max total move time (server wall clock)
     std::map<std::string, int>  latencyCount;     // number of moves with latency data
+
+    // End-to-end move-time histogram, per player. moveTimeoutMs is divided into
+    // 100ms buckets; bucket i (0..numBuckets-2) counts moves whose total latency
+    // fell in [i*100, (i+1)*100) ms. The final bucket (index numBuckets-1) is the
+    // "timeout" bucket: every auto/timed-out move lands here (rendered red in the
+    // UI). numBuckets = moveTimeoutMs/100 + 1. Empty when moveTimeoutMs <= 0.
+    long moveTimeoutMs = 0;
+    std::map<std::string, std::vector<long>> latencyHistogram;
+
     std::vector<RoundRecord> rounds;
 
     // Placement points awarded in qualifying (tournament only)
@@ -75,10 +86,12 @@ class RecordingObserver : public GameObserver {
 public:
     GameResult result;
 
-    explicit RecordingObserver(const std::string& gameId, const std::string& stage = "lobby")
+    explicit RecordingObserver(const std::string& gameId, const std::string& stage = "lobby",
+                               long moveTimeoutMs = 0)
     {
-        result.gameId = gameId;
-        result.stage  = stage;
+        result.gameId        = gameId;
+        result.stage         = stage;
+        result.moveTimeoutMs = moveTimeoutMs;
     }
 
     void onStartRound(int roundIdx, const std::string& passDir) override
@@ -103,11 +116,13 @@ public:
 
     void onTrickComplete(const std::vector<std::string>& playerOrder,
                           const std::vector<std::string>& cards,
+                          const std::vector<std::string>& moveSources,
                           const std::string& winner, int points) override
     {
         std::string firstPlayer = playerOrder.empty() ? "" : playerOrder[0];
         if (!result.rounds.empty())
-            result.rounds.back().tricks.push_back({firstPlayer, playerOrder, cards, winner, points});
+            result.rounds.back().tricks.push_back(
+                {firstPlayer, playerOrder, cards, moveSources, winner, points});
     }
 
     void onRoundComplete(int /*roundIdx*/, const std::map<std::string, int>& scores) override
@@ -122,6 +137,28 @@ public:
     {
         result.totalMoveLatencyMs[playerTag] += latencyMs;
         result.maxMoveLatencyMs[playerTag]    = std::max(result.maxMoveLatencyMs[playerTag], latencyMs);
+
+        // Histogram: 100ms buckets across [0, moveTimeoutMs), plus a final "timeout"
+        // bucket for auto-moves (and the rare completed move at/over the timeout).
+        if (result.moveTimeoutMs > 0)
+        {
+            int numBuckets = (int)(result.moveTimeoutMs / 100) + 1; // last = timeout bucket
+            auto& hist = result.latencyHistogram[playerTag];
+            if ((int)hist.size() != numBuckets) hist.assign(numBuckets, 0);
+            int idx;
+            if (autoMoved || latencyMs >= result.moveTimeoutMs)
+            {
+                idx = numBuckets - 1; // timeout bucket
+            }
+            else
+            {
+                idx = (int)(latencyMs / 100);
+                if (idx > numBuckets - 2) idx = numBuckets - 2;
+                if (idx < 0) idx = 0;
+            }
+            hist[idx]++;
+        }
+
         if (autoMoved)
         {
             result.autoMoveCount[playerTag]++;
@@ -215,6 +252,11 @@ inline json gameResultToDetailJson(const GameResult& gr)
             json tj;
             tj["first_player"] = toFullId(t.firstPlayer, gr.playerTagToSlotId);
             tj["moves"]        = t.cards; // in play order starting from first_player
+            // Per-move provenance aligned with moves[]: "player" | "timeout" | "give_up".
+            // Omitted when every move was a normal player move, to keep typical games lean.
+            if (std::any_of(t.moveSources.begin(), t.moveSources.end(),
+                            [](const std::string& s){ return s != Common::Server::MoveSource::PLAYER; }))
+                tj["move_sources"] = t.moveSources;
             tj["winner"]       = toFullId(t.winner, gr.playerTagToSlotId);
             tj["points"]       = t.points;
             tricks.push_back(tj);

--- a/server/game/objects/player.h
+++ b/server/game/objects/player.h
@@ -24,6 +24,11 @@ public:
     virtual Card getMove(const CardCollection& legalPlays) = 0;
     virtual void notifyMove(PlayerID playerID, Card card, bool autoMoved) = 0;
     virtual bool wasLastMoveAuto() const { return false; }
+    // True only when the last move was auto-played *immediately* because the client
+    // had already exceeded the consecutive-timeout threshold (give-up mode), as
+    // opposed to a single move that simply ran out its timeout. Distinguishes the
+    // "#" (give-up) marker from the "*" (timeout) marker in the recorded game.
+    virtual bool wasLastMoveGiveUp() const { return false; }
     // Latency data from the most recent move exchange (-1 if unavailable or auto-moved).
     virtual long lastS2CLatencyMs() const { return -1; }  // server→client (move_request delivery)
     virtual long lastC2SLatencyMs() const { return -1; }  // client→server (decided_move delivery)

--- a/server/game/remote_player.h
+++ b/server/game/remote_player.h
@@ -109,6 +109,7 @@ public:
         }});
 
         mLastMoveWasAuto    = false;
+        mLastMoveWasGiveUp  = false;
         mLastS2CLatencyMs   = -1;
         mLastC2SLatencyMs   = -1;
         mLastThinkTimeMs    = -1;
@@ -147,7 +148,8 @@ public:
         }
         else { LOG("Client %s timed out or disconnected during move", mPlayerTagSession.c_str()); }
 
-        mLastMoveWasAuto = true;
+        mLastMoveWasAuto   = true;
+        mLastMoveWasGiveUp = mGameSession->lastReceiveWasGiveUp();
         return autoMoveCard(legalPlays);
     }
 
@@ -169,6 +171,7 @@ public:
     long lastThinkTimeMs()  const override { return mLastThinkTimeMs;  }
 
     bool wasLastMoveAuto() const override { return mLastMoveWasAuto; }
+    bool wasLastMoveGiveUp() const override { return mLastMoveWasGiveUp; }
 
     void notifyEndTrick(PlayerTagSession winningPlayer) override
     {
@@ -233,6 +236,7 @@ private:
     std::shared_ptr<PlayerGameSession> mGameSession;
     PlayerTagSession mPlayerTagSession;
     bool mLastMoveWasAuto;
+    bool mLastMoveWasGiveUp = false;  // auto-played immediately due to give-up mode ("#")
     long mLastS2CLatencyMs = -1;  // server→client latency of last move_request
     long mLastC2SLatencyMs = -1;  // client→server latency of last decided_move
     long mLastThinkTimeMs  = -1;  // client think time for last move

--- a/server/game/trick.h
+++ b/server/game/trick.h
@@ -22,6 +22,10 @@ public:
     void RunTrick()
     {
         notifyStartTrick();
+        // Per-move provenance in play order, aligned with mPlayedCards. Captured
+        // immediately after each getMove() because wasLastMove* is overwritten by
+        // the next player's move.
+        std::vector<std::string> moveSources;
         for (const PlayerRef& currentPlayer : mPlayers)
         {
             CardCollection legalMoves = legalMovesForPlayer(currentPlayer);
@@ -30,6 +34,10 @@ public:
             long latencyMs = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - moveStart).count();
             bool autoMoved = currentPlayer->wasLastMoveAuto();
+            moveSources.push_back(
+                !autoMoved ? Common::Server::MoveSource::PLAYER
+                           : (currentPlayer->wasLastMoveGiveUp() ? Common::Server::MoveSource::GIVE_UP
+                                                                 : Common::Server::MoveSource::TIMEOUT));
             // RemotePlayer validates and auto-substitutes on bad input, so a card
             // reaching here should always be legal. Keep as a sanity-check assertion.
             ASRT(legalMoves.contains(card), "Illegal card %s reached trick (should have been caught in RemotePlayer)",
@@ -57,7 +65,7 @@ public:
                 if (mPlayedCards[i].getSuit() == HEARTS) points++;
                 if (mPlayedCards[i] == Card(QUEEN, SPADES)) points += Constants::QUEEN_SCORE;
             }
-            mObserver->onTrickComplete(playerOrder, cards,
+            mObserver->onTrickComplete(playerOrder, cards, moveSources,
                 mPlayers[mTrickWinnerIdx]->getTagSession(), points);
         }
     }

--- a/server/matching/live_game.h
+++ b/server/matching/live_game.h
@@ -49,8 +49,13 @@ public:
             EnvLoader->has("RESULTS_DIR") ? std::filesystem::path(ENV_STRING("RESULTS_DIR"))
                                           : std::filesystem::path("results");
 
-        std::thread([players, logger, gameId, playedAt, resultsDir]() {
-            Common::Game::RecordingObserver recorder(gameId);
+        // Match the move timeout the Matcher assigns to lobby sessions, so the
+        // recorded move-time histogram buckets the right way (see matcher.h).
+        long moveTimeoutMs = (EnvLoader && EnvLoader->has("MOVE_TIMEOUT_MS"))
+            ? (long)std::stoi(ENV_STRING("MOVE_TIMEOUT_MS")) : 15000;
+
+        std::thread([players, logger, gameId, playedAt, resultsDir, moveTimeoutMs]() {
+            Common::Game::RecordingObserver recorder(gameId, "lobby", moveTimeoutMs);
             // Seating order = the order players were dealt into the game.
             for (const auto& p : players)
                 recorder.result.playerOrder.push_back(p->getTagSession());

--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -534,6 +534,7 @@ static json aggregatePlayerStats(const std::vector<GameResult>& games)
         long timeoutCount = 0;
         int  timeoutGames = 0;
         long totalS2C = 0, totalC2S = 0, totalThink = 0;
+        long totalTotal = 0; // sum of end-to-end move times, over every move
         long maxS2C = 0, maxC2S = 0, maxThink = 0, maxTotal = 0;
         int  latencySamples = 0;
     };
@@ -548,6 +549,12 @@ static json aggregatePlayerStats(const std::vector<GameResult>& games)
             auto& s = bySlot[slotId];
             if (s.hist.size() < hist.size()) s.hist.resize(hist.size(), 0);
             for (size_t i = 0; i < hist.size(); ++i) s.hist[i] += hist[i];
+        }
+        for (const auto& [tagSession, t] : gr.totalMoveLatencyMs)
+        {
+            auto it = gr.playerTagToSlotId.find(tagSession);
+            std::string slotId = (it != gr.playerTagToSlotId.end()) ? it->second : tagSession;
+            bySlot[slotId].totalTotal += t;
         }
         for (const auto& [tagSession, n] : gr.autoMoveCount)
         {
@@ -588,6 +595,7 @@ static json aggregatePlayerStats(const std::vector<GameResult>& games)
         lat["avg_s2c_ms"]   = s.latencySamples ? s.totalS2C   / s.latencySamples : -1;
         lat["avg_c2s_ms"]   = s.latencySamples ? s.totalC2S   / s.latencySamples : -1;
         lat["avg_think_ms"] = s.latencySamples ? s.totalThink / s.latencySamples : -1;
+        lat["avg_total_ms"] = moveCount ? s.totalTotal / moveCount : -1;
         lat["max_s2c_ms"]   = s.maxS2C;
         lat["max_c2s_ms"]   = s.maxC2S;
         lat["max_think_ms"] = s.maxThink;

--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -522,6 +522,83 @@ static json gameResultToSummaryJson(const GameResult& gr)
     return j;
 }
 
+// Aggregate per-player performance across a set of games, keyed by slotId. Produces
+// the tournament-view "performance" section: a summed move-time histogram, total
+// move/timeout counts, how many games the player timed out in, and a latency
+// breakdown (avg/max s2c, c2s, think). Histograms are summed element-wise; all
+// games in one tournament share the same bucket layout (moveTimeoutMs/100 + 1).
+static json aggregatePlayerStats(const std::vector<GameResult>& games)
+{
+    struct Stat {
+        std::vector<long> hist;
+        long timeoutCount = 0;
+        int  timeoutGames = 0;
+        long totalS2C = 0, totalC2S = 0, totalThink = 0;
+        long maxS2C = 0, maxC2S = 0, maxThink = 0, maxTotal = 0;
+        int  latencySamples = 0;
+    };
+    std::map<std::string, Stat> bySlot;
+
+    for (const auto& gr : games)
+    {
+        for (const auto& [tagSession, hist] : gr.latencyHistogram)
+        {
+            auto it = gr.playerTagToSlotId.find(tagSession);
+            std::string slotId = (it != gr.playerTagToSlotId.end()) ? it->second : tagSession;
+            auto& s = bySlot[slotId];
+            if (s.hist.size() < hist.size()) s.hist.resize(hist.size(), 0);
+            for (size_t i = 0; i < hist.size(); ++i) s.hist[i] += hist[i];
+        }
+        for (const auto& [tagSession, n] : gr.autoMoveCount)
+        {
+            auto it = gr.playerTagToSlotId.find(tagSession);
+            std::string slotId = (it != gr.playerTagToSlotId.end()) ? it->second : tagSession;
+            auto& s = bySlot[slotId];
+            s.timeoutCount += n;
+            if (n > 0) s.timeoutGames += 1;
+        }
+        for (const auto& [tagSession, n] : gr.latencyCount)
+        {
+            if (n == 0) continue;
+            auto it = gr.playerTagToSlotId.find(tagSession);
+            std::string slotId = (it != gr.playerTagToSlotId.end()) ? it->second : tagSession;
+            auto& s = bySlot[slotId];
+            s.latencySamples += n;
+            if (gr.totalS2CMs.count(tagSession))       s.totalS2C   += gr.totalS2CMs.at(tagSession);
+            if (gr.totalC2SMs.count(tagSession))       s.totalC2S   += gr.totalC2SMs.at(tagSession);
+            if (gr.totalThinkMs.count(tagSession))     s.totalThink += gr.totalThinkMs.at(tagSession);
+            if (gr.maxThinkMs.count(tagSession))       s.maxThink   = std::max(s.maxThink, gr.maxThinkMs.at(tagSession));
+            if (gr.maxS2CMs.count(tagSession))         s.maxS2C     = std::max(s.maxS2C,   gr.maxS2CMs.at(tagSession));
+            if (gr.maxC2SMs.count(tagSession))         s.maxC2S     = std::max(s.maxC2S,   gr.maxC2SMs.at(tagSession));
+            if (gr.maxMoveLatencyMs.count(tagSession)) s.maxTotal   = std::max(s.maxTotal, gr.maxMoveLatencyMs.at(tagSession));
+        }
+    }
+
+    json out = json::object();
+    for (const auto& [slotId, s] : bySlot)
+    {
+        long moveCount = 0;
+        for (long c : s.hist) moveCount += c;
+        json entry;
+        entry["histogram"]     = s.hist;
+        entry["move_count"]    = moveCount;
+        entry["timeout_count"] = s.timeoutCount;
+        entry["timeout_games"] = s.timeoutGames;
+        json lat;
+        lat["avg_s2c_ms"]   = s.latencySamples ? s.totalS2C   / s.latencySamples : -1;
+        lat["avg_c2s_ms"]   = s.latencySamples ? s.totalC2S   / s.latencySamples : -1;
+        lat["avg_think_ms"] = s.latencySamples ? s.totalThink / s.latencySamples : -1;
+        lat["max_s2c_ms"]   = s.maxS2C;
+        lat["max_c2s_ms"]   = s.maxC2S;
+        lat["max_think_ms"] = s.maxThink;
+        lat["max_total_ms"] = s.maxTotal;
+        lat["sample_count"] = s.latencySamples;
+        entry["latency"] = lat;
+        out[slotId] = entry;
+    }
+    return out;
+}
+
 // Forward declaration (defined after writeResults)
 static GameResult runOneGame(const GameAssignment&, const std::string&,
     std::atomic<PlayerGameSessionID>&, const std::shared_ptr<Common::GameLogger>&,
@@ -775,6 +852,17 @@ static void writeResults(
     summary["finals_totals"]    = finalTotals;
     summary["complete"]         = complete;
 
+    // Per-player performance aggregates for the tournament view: move-time
+    // histograms (100ms buckets up to the timeout, with a final red "timeout"
+    // bucket), timeout-game counts, and the latency breakdown. Bucket width and
+    // the timeout duration let the UI label the x-axis and find the timeout bucket.
+    summary["move_timeout_ms"]  = cfg.moveTimeoutMs;
+    summary["bucket_ms"]        = 100;
+    summary["player_stats"]     = {
+        {"qualifying", aggregatePlayerStats(qualifying)},
+        {"finals",     aggregatePlayerStats(finals)},
+    };
+
     std::ofstream sf(tDir / "summary.json");
     sf << summary.dump(2);
 
@@ -850,7 +938,8 @@ static GameResult runOneGame(
     int autoMoveAfterTimeouts,
     std::chrono::milliseconds moveTimeout)
 {
-    auto observer = std::make_shared<RecordingObserver>(assignment.gameId, assignment.stage);
+    auto observer = std::make_shared<RecordingObserver>(
+        assignment.gameId, assignment.stage, (long)moveTimeout.count());
 
     // Create a game session per player-slot
     std::vector<std::shared_ptr<PlayerGameSession>> sessions;

--- a/server/util/constants.h
+++ b/server/util/constants.h
@@ -92,6 +92,15 @@ namespace Common::Server::MoveSource
 {
     constexpr auto PLAYER = "player";
     constexpr auto SERVER = "server";
+
+    // Recorder-level move provenance (emitted in game detail JSON `move_sources`).
+    // PLAYER above means the client chose the card. The two below distinguish *how*
+    // a server-substituted (auto) move happened, which the web UI renders as:
+    //   TIMEOUT  → "*"  the client was given the full timeout but never answered
+    //   GIVE_UP  → "#"  the client had already timed out >= N times, so the server
+    //                   stopped waiting and auto-played immediately
+    constexpr auto TIMEOUT = "timeout";
+    constexpr auto GIVE_UP = "give_up";
 }
 
 namespace Common::Server::ServerStatus

--- a/tests/round_gtest.cpp
+++ b/tests/round_gtest.cpp
@@ -49,6 +49,7 @@ public:
     }
     void onTrickComplete(const std::vector<std::string>& playerOrder,
                          const std::vector<std::string>& cards,
+                         const std::vector<std::string>& /*moveSources*/,
                          const std::string&, int) override {
         for (size_t k = 0; k < playerOrder.size() && k < cards.size(); ++k)
             played[playerOrder[k]].insert(cards[k]);
@@ -83,6 +84,7 @@ public:
     }
     void onTrickComplete(const std::vector<std::string>& playerOrder,
                          const std::vector<std::string>& cards,
+                         const std::vector<std::string>& /*moveSources*/,
                          const std::string&, int) override {
         if (rounds.empty()) return;
         for (size_t k = 0; k < playerOrder.size() && k < cards.size(); ++k)

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -102,6 +102,7 @@ export interface PlayerLatencyBreakdown {
   avg_s2c_ms: number
   avg_c2s_ms: number
   avg_think_ms: number
+  avg_total_ms: number
   max_s2c_ms: number
   max_c2s_ms: number
   max_think_ms: number

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -95,6 +95,28 @@ export function gamePlayers(g: GameSummary): { id: string; game_score: number; t
   })
 }
 
+// Per-player performance aggregate over one stage of a tournament (see the C++
+// aggregatePlayerStats). `histogram` buckets end-to-end move time into bucket_ms
+// slices; the final bucket is the "timeout" bucket (auto-played moves).
+export interface PlayerLatencyBreakdown {
+  avg_s2c_ms: number
+  avg_c2s_ms: number
+  avg_think_ms: number
+  max_s2c_ms: number
+  max_c2s_ms: number
+  max_think_ms: number
+  max_total_ms: number
+  sample_count: number
+}
+
+export interface PlayerStats {
+  histogram: number[]      // length = move_timeout_ms/100 + 1; last entry = timeout bucket
+  move_count: number       // total moves (sum of histogram)
+  timeout_count: number    // moves that landed in the timeout bucket (auto-played)
+  timeout_games: number    // games in which this player timed out at least one move
+  latency: PlayerLatencyBreakdown
+}
+
 export interface TournamentSummary {
   tournament_id: string
   competition_id?: string
@@ -104,11 +126,22 @@ export interface TournamentSummary {
   finals: GameSummary[]
   qualifying_totals: Record<string, number>
   finals_totals: Record<string, number>
+  // Performance aggregates (present on tournaments recorded after #78). Keyed by
+  // stage -> slotId -> stats. move_timeout_ms / bucket_ms describe the histogram axis.
+  move_timeout_ms?: number
+  bucket_ms?: number
+  player_stats?: {
+    qualifying: Record<string, PlayerStats>
+    finals: Record<string, PlayerStats>
+  }
 }
 
 export interface TrickRecord {
   first_player: string
   moves: string[] // play order, parallel to nothing else; first_player played moves[0]
+  // Per-move provenance aligned with moves[]: "player" | "timeout" | "give_up".
+  // Absent when every move was a normal player move (the common case).
+  move_sources?: string[]
   winner: string
   points: number
 }

--- a/web/frontend/src/components/Card.css
+++ b/web/frontend/src/components/Card.css
@@ -130,6 +130,51 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
+/* Played because the move timed out (random legal card): red border + "*". */
+.card--timeout {
+  border-color: #e23b3b;
+  box-shadow: 0 0 0 2px #e23b3b, 0 1px 4px rgba(0, 0, 0, 0.25);
+}
+
+/* Auto-played after repeated timeouts (give-up mode): darker red border + "#". */
+.card--giveup {
+  border-color: #8c1212;
+  box-shadow: 0 0 0 2px #8c1212, 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* A timed-out card that also won the trick keeps the red ring (reason matters
+   more than the win highlight here). */
+.card--timeout.card--win {
+  border-color: #e23b3b;
+  box-shadow: 0 0 0 2px #e23b3b, 0 0 0 4px #f5b301, 0 1px 4px rgba(0, 0, 0, 0.25);
+}
+.card--giveup.card--win {
+  border-color: #8c1212;
+  box-shadow: 0 0 0 2px #8c1212, 0 0 0 4px #f5b301, 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* "*" / "#" badge marking how a card was auto-played, bottom-left so it doesn't
+   collide with the top-right points badge. */
+.card__timeout-mark {
+  position: absolute;
+  bottom: -7px;
+  left: -7px;
+  background: #e23b3b;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
+  border-radius: 999px;
+  min-width: 14px;
+  text-align: center;
+  padding: 2px 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.card--giveup .card__timeout-mark {
+  background: #8c1212;
+}
+
 /* Empty card slot placeholder in the trick grid. */
 .card-slot--empty {
   width: 48px;

--- a/web/frontend/src/components/Card.tsx
+++ b/web/frontend/src/components/Card.tsx
@@ -1,21 +1,35 @@
 import { parseCard, isRedSuit, rankLabel, SUIT_SYMBOL, cardPoints } from '../lib/cards'
 import './Card.css'
 
+// How a played card was chosen, when it wasn't the player's own choice. Drives a
+// red border + a "*"/"#" marker so timed-out / auto-played cards stand out.
+export type MoveSource = 'player' | 'timeout' | 'give_up'
+
+const MOVE_SOURCE_MARK: Record<string, string> = { timeout: '*', give_up: '#' }
+const MOVE_SOURCE_TITLE: Record<string, string> = {
+  timeout: 'Played at random — the player ran out of time on this move (*)',
+  give_up: 'Auto-played — the player had already timed out repeatedly, so the server stopped waiting (#)',
+}
+
 interface CardProps {
   code: string
   highlight?: boolean // winning card
   legal?: boolean // legal to play in this context (green outline)
   dim?: boolean // illegal in this context (faded)
   selected?: boolean // chosen (e.g. picked to pass): raised + ringed
+  // Provenance of a played card. 'timeout' → red border + "*"; 'give_up' →
+  // darker-red border + "#". 'player'/undefined → no marker.
+  moveSource?: MoveSource
   onClick?: () => void
   size?: 'sm' | 'md'
   title?: string // tooltip override for clickable cards
 }
 
-export function Card({ code, highlight, legal, dim, selected, onClick, size = 'md', title }: CardProps) {
+export function Card({ code, highlight, legal, dim, selected, moveSource, onClick, size = 'md', title }: CardProps) {
   const { rank, suit } = parseCard(code)
   const red = isRedSuit(suit)
   const pts = cardPoints(code)
+  const mark = moveSource ? MOVE_SOURCE_MARK[moveSource] : undefined
   const className = [
     'card',
     `card--${size}`,
@@ -24,17 +38,19 @@ export function Card({ code, highlight, legal, dim, selected, onClick, size = 'm
     legal ? 'card--legal' : '',
     dim ? 'card--dim' : '',
     selected ? 'card--selected' : '',
+    moveSource === 'timeout' ? 'card--timeout' : '',
+    moveSource === 'give_up' ? 'card--giveup' : '',
     onClick ? 'card--clickable' : '',
   ]
     .filter(Boolean)
     .join(' ')
 
+  // A move-source tooltip takes precedence so the timeout reason is discoverable.
+  const tooltip = mark ? MOVE_SOURCE_TITLE[moveSource as string]
+    : (title ?? (onClick ? 'Click to see hand before this play' : undefined))
+
   return (
-    <div
-      className={className}
-      onClick={onClick}
-      title={title ?? (onClick ? 'Click to see hand before this play' : undefined)}
-    >
+    <div className={className} onClick={onClick} title={tooltip}>
       <span className="card__corner card__corner--tl">
         <span className="card__rank">{rankLabel(rank)}</span>
         <span className="card__suit">{SUIT_SYMBOL[suit]}</span>
@@ -45,6 +61,7 @@ export function Card({ code, highlight, legal, dim, selected, onClick, size = 'm
         <span className="card__suit">{SUIT_SYMBOL[suit]}</span>
       </span>
       {pts > 0 && <span className="card__points">+{pts}</span>}
+      {mark && <span className="card__timeout-mark" aria-hidden="true">{mark}</span>}
     </div>
   )
 }

--- a/web/frontend/src/components/PlayerPerformance.css
+++ b/web/frontend/src/components/PlayerPerformance.css
@@ -141,12 +141,17 @@
 
 @media (max-width: 600px) {
   .perf-detail-row > td {
-    padding: 10px 8px;
+    padding: 10px 6px;
   }
-  /* Fill the phone width and stay pinned to the left while the table scrolls. */
+  /* Pin to the left and size to the phone viewport. The box lives in a colspan
+     cell of a table that is far wider than the screen, so it is sized relative
+     to the viewport (not the cell). The subtracted constant covers the app +
+     card + cell padding to its left plus a margin on the right, so the panel
+     never forces horizontal overflow off the screen. */
   .perf-detail-box {
-    left: 8px;
-    width: calc(100vw - 32px);
+    left: 6px;
+    width: calc(100vw - 56px);
+    max-width: calc(100vw - 56px);
     padding: 10px 12px;
   }
   .perf-hist {

--- a/web/frontend/src/components/PlayerPerformance.css
+++ b/web/frontend/src/components/PlayerPerformance.css
@@ -1,24 +1,29 @@
-.perf-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 12px;
+/* Caret in the player cell of an expandable aggregate row. */
+.perf-caret {
+  display: inline-block;
+  width: 1em;
+  margin-right: 4px;
+  color: #888;
+  font-size: 11px;
 }
 
-.perf-card {
-  padding: 12px;
+/* The expanded detail row sits flush under its player row. */
+.perf-detail-row > td {
+  background: #fafafa;
+  padding: 8px 12px;
 }
 
-.perf-card__head {
+/* Inline performance detail shown in an expanded aggregate-table row. */
+.perf-detail-box {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
+  flex-direction: column;
   gap: 8px;
-  margin-bottom: 10px;
+  max-width: 360px;
+  padding: 4px 0 8px;
 }
 
-.perf-card__sub {
+.perf-summary {
   font-size: 12px;
-  white-space: nowrap;
 }
 
 .perf-card__timeouts {
@@ -79,13 +84,12 @@
   box-shadow: 0 0 0 1px #8c1212;
 }
 
-.perf-detail {
+.perf-pct {
   font-size: 12px;
-  margin: 8px 0;
   min-height: 32px;
 }
 
-.perf-detail--hint {
+.perf-pct--hint {
   display: flex;
   align-items: center;
 }

--- a/web/frontend/src/components/PlayerPerformance.css
+++ b/web/frontend/src/components/PlayerPerformance.css
@@ -1,0 +1,116 @@
+.perf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.perf-card {
+  padding: 12px;
+}
+
+.perf-card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.perf-card__sub {
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.perf-card__timeouts {
+  color: #d11a2a;
+  font-weight: 600;
+}
+
+/* Histogram: a row of clickable bars growing from a shared baseline. */
+.perf-hist {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 90px;
+  padding: 0;
+  border-bottom: 1px solid #d8d8d8;
+}
+
+.perf-bar {
+  flex: 1 1 0;
+  min-width: 2px;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.perf-bar__fill {
+  display: block;
+  width: 100%;
+  min-height: 1px;
+  background: #4a86e8;
+  border-radius: 2px 2px 0 0;
+  transition: background 0.08s ease;
+}
+
+.perf-bar:hover .perf-bar__fill {
+  background: #2a5bd7;
+}
+
+.perf-bar--timeout .perf-bar__fill {
+  background: #e23b3b;
+}
+
+.perf-bar--timeout:hover .perf-bar__fill {
+  background: #c12222;
+}
+
+.perf-bar--sel .perf-bar__fill {
+  background: #1a3f9e;
+  box-shadow: 0 0 0 1px #1a3f9e;
+}
+
+.perf-bar--timeout.perf-bar--sel .perf-bar__fill {
+  background: #8c1212;
+  box-shadow: 0 0 0 1px #8c1212;
+}
+
+.perf-detail {
+  font-size: 12px;
+  margin: 8px 0;
+  min-height: 32px;
+}
+
+.perf-detail--hint {
+  display: flex;
+  align-items: center;
+}
+
+.perf-latency {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.perf-latency th,
+.perf-latency td {
+  text-align: right;
+  padding: 2px 6px;
+  border-bottom: 1px solid #eee;
+}
+
+.perf-latency th:first-child,
+.perf-latency td:first-child {
+  text-align: left;
+  color: #555;
+}
+
+.perf-latency__total td {
+  font-weight: 600;
+  border-bottom: none;
+}

--- a/web/frontend/src/components/PlayerPerformance.css
+++ b/web/frontend/src/components/PlayerPerformance.css
@@ -7,19 +7,33 @@
   font-size: 11px;
 }
 
-/* The expanded detail row sits flush under its player row. */
+/* The expanded detail row sits flush under its player row. Dark so the colored
+   histogram bars and the latency figures stand out clearly. */
 .perf-detail-row > td {
-  background: #fafafa;
-  padding: 8px 12px;
+  background: #0f1722;
+  padding: 12px;
 }
 
-/* Inline performance detail shown in an expanded aggregate-table row. */
+/* Inline performance detail shown in an expanded aggregate-table row. A dark
+   card; pinned to the viewport's left edge so it stays readable while the wide
+   aggregate table scrolls horizontally on a phone. */
 .perf-detail-box {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  max-width: 360px;
-  padding: 4px 0 8px;
+  position: sticky;
+  left: 12px;
+  width: min(420px, calc(100vw - 48px));
+  color: #e6ebf2;
+  background: #18222f;
+  border: 1px solid #243042;
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+/* Keep muted sub-labels legible on the dark card. */
+.perf-detail-box .muted {
+  color: #9aa6b4;
 }
 
 .perf-summary {
@@ -27,7 +41,7 @@
 }
 
 .perf-card__timeouts {
-  color: #d11a2a;
+  color: #ff6b78;
   font-weight: 600;
 }
 
@@ -38,7 +52,7 @@
   gap: 1px;
   height: 90px;
   padding: 0;
-  border-bottom: 1px solid #d8d8d8;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .perf-bar {
@@ -57,31 +71,31 @@
   display: block;
   width: 100%;
   min-height: 1px;
-  background: #4a86e8;
+  background: #5b9bff;
   border-radius: 2px 2px 0 0;
   transition: background 0.08s ease;
 }
 
 .perf-bar:hover .perf-bar__fill {
-  background: #2a5bd7;
+  background: #8fbcff;
 }
 
 .perf-bar--timeout .perf-bar__fill {
-  background: #e23b3b;
+  background: #ff5b5b;
 }
 
 .perf-bar--timeout:hover .perf-bar__fill {
-  background: #c12222;
+  background: #ff8585;
 }
 
 .perf-bar--sel .perf-bar__fill {
-  background: #1a3f9e;
-  box-shadow: 0 0 0 1px #1a3f9e;
+  background: #cfe0ff;
+  box-shadow: 0 0 0 1px #cfe0ff;
 }
 
 .perf-bar--timeout.perf-bar--sel .perf-bar__fill {
-  background: #8c1212;
-  box-shadow: 0 0 0 1px #8c1212;
+  background: #ffd0d0;
+  box-shadow: 0 0 0 1px #ffd0d0;
 }
 
 .perf-pct {
@@ -105,16 +119,37 @@
 .perf-latency td {
   text-align: right;
   padding: 2px 6px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  color: #d4dbe4;
+}
+
+.perf-latency th {
+  color: #9aa6b4;
 }
 
 .perf-latency th:first-child,
 .perf-latency td:first-child {
   text-align: left;
-  color: #555;
+  color: #aab4c0;
 }
 
 .perf-latency__total td {
   font-weight: 600;
   border-bottom: none;
+  color: #f0f3f7;
+}
+
+@media (max-width: 600px) {
+  .perf-detail-row > td {
+    padding: 10px 8px;
+  }
+  /* Fill the phone width and stay pinned to the left while the table scrolls. */
+  .perf-detail-box {
+    left: 8px;
+    width: calc(100vw - 32px);
+    padding: 10px 12px;
+  }
+  .perf-hist {
+    height: 76px;
+  }
 }

--- a/web/frontend/src/components/PlayerPerformance.tsx
+++ b/web/frontend/src/components/PlayerPerformance.tsx
@@ -1,87 +1,47 @@
 import { useState } from 'react'
 import type { PlayerStats } from '../api/client'
-import { PlayerName } from './PlayerName'
-import { nameResolver } from '../lib/playerId'
 import './PlayerPerformance.css'
 
-interface PlayerPerformanceProps {
-  // slotId -> per-player performance aggregate for this stage.
-  stats: Record<string, PlayerStats>
+interface PlayerMetricsProps {
+  stats: PlayerStats
   moveTimeoutMs: number
   bucketMs: number
-  nameOf: ReturnType<typeof nameResolver>
-}
-
-/**
- * Performance section: one card per player with a move-time histogram (100ms
- * buckets, the final "timeout" bucket drawn red) plus the latency breakdown
- * (server→client, think, client→server). Clicking a bucket reveals what
- * percentile of that player's moves fell in it and at-or-below it.
- */
-export function PlayerPerformance({ stats, moveTimeoutMs, bucketMs, nameOf }: PlayerPerformanceProps) {
-  const slots = Object.keys(stats).sort((a, b) => {
-    // Most-timed-out players first, then by total moves.
-    const d = (stats[b].timeout_count ?? 0) - (stats[a].timeout_count ?? 0)
-    if (d !== 0) return d
-    return (stats[b].move_count ?? 0) - (stats[a].move_count ?? 0)
-  })
-  if (slots.length === 0) return <p className="muted">No performance data recorded for this stage.</p>
-  return (
-    <div className="perf-grid">
-      {slots.map((slot) => (
-        <PlayerCard
-          key={slot}
-          d={nameOf(slot)}
-          stats={stats[slot]}
-          moveTimeoutMs={moveTimeoutMs}
-          bucketMs={bucketMs}
-        />
-      ))}
-    </div>
-  )
 }
 
 function fmtMs(ms: number): string {
+  if (ms < 0) return '—'
   if (ms >= 1000) return `${(ms / 1000).toFixed(ms >= 10000 ? 0 : 1)}s`
   return `${Math.round(ms)}ms`
 }
 
-function PlayerCard({
-  d,
-  stats,
-  moveTimeoutMs,
-  bucketMs,
-}: {
-  d: ReturnType<ReturnType<typeof nameResolver>>
-  stats: PlayerStats
-  moveTimeoutMs: number
-  bucketMs: number
-}) {
+/**
+ * One player's performance detail: a move-time histogram (100ms buckets, the
+ * final "timeout" bucket drawn red) plus the latency breakdown (server→client,
+ * think, client→server, and end-to-end). Clicking a bucket reveals what
+ * percentile of that player's moves fell in it and at-or-below it. Rendered
+ * inside an expanded aggregate-table row, so it carries no player name itself.
+ */
+export function PlayerMetrics({ stats, moveTimeoutMs, bucketMs }: PlayerMetricsProps) {
   const [sel, setSel] = useState<number | null>(null)
   const hist = stats.histogram ?? []
   const total = stats.move_count || hist.reduce((a, b) => a + b, 0)
   const maxCount = Math.max(1, ...hist)
   const lastIdx = hist.length - 1
 
-  // Range label for a bucket. The last bucket collects timeouts / auto-plays.
   const bucketLabel = (i: number): string => {
     if (i === lastIdx) return `≥ ${fmtMs(moveTimeoutMs)} (timeout)`
     return `${fmtMs(i * bucketMs)}–${fmtMs((i + 1) * bucketMs)}`
   }
-
   const cumAtOrBelow = (i: number): number => hist.slice(0, i + 1).reduce((a, b) => a + b, 0)
 
   const lat = stats.latency
   return (
-    <div className="perf-card card-surface">
-      <div className="perf-card__head">
-        <PlayerName d={d} />
-        <span className="muted perf-card__sub">
-          {total} moves
-          {stats.timeout_count > 0 && (
-            <span className="perf-card__timeouts"> · {stats.timeout_count} timed out</span>
-          )}
-        </span>
+    <div className="perf-detail-box">
+      <div className="perf-summary muted">
+        {total} moves
+        {stats.timeout_count > 0 && (
+          <span className="perf-card__timeouts"> · {stats.timeout_count} timed out</span>
+        )}
       </div>
 
       <div className="perf-hist" role="group" aria-label="Move-time histogram">
@@ -107,7 +67,7 @@ function PlayerCard({
       </div>
 
       {sel !== null ? (
-        <div className="perf-detail">
+        <div className="perf-pct">
           <strong>{bucketLabel(sel)}</strong>
           <div className="muted">
             {hist[sel]} move{hist[sel] === 1 ? '' : 's'} ·{' '}
@@ -116,7 +76,7 @@ function PlayerCard({
           </div>
         </div>
       ) : (
-        <div className="perf-detail muted perf-detail--hint">Click a bucket for percentiles.</div>
+        <div className="perf-pct muted perf-pct--hint">Click a bucket for percentiles.</div>
       )}
 
       {lat && lat.sample_count > 0 && (
@@ -146,7 +106,7 @@ function PlayerCard({
             </tr>
             <tr className="perf-latency__total">
               <td>End-to-end</td>
-              <td className="muted">—</td>
+              <td>{fmtMs(lat.avg_total_ms)}</td>
               <td>{fmtMs(lat.max_total_ms)}</td>
             </tr>
           </tbody>

--- a/web/frontend/src/components/PlayerPerformance.tsx
+++ b/web/frontend/src/components/PlayerPerformance.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import type { PlayerStats } from '../api/client'
+import { PlayerName } from './PlayerName'
+import { nameResolver } from '../lib/playerId'
+import './PlayerPerformance.css'
+
+interface PlayerPerformanceProps {
+  // slotId -> per-player performance aggregate for this stage.
+  stats: Record<string, PlayerStats>
+  moveTimeoutMs: number
+  bucketMs: number
+  nameOf: ReturnType<typeof nameResolver>
+}
+
+/**
+ * Performance section: one card per player with a move-time histogram (100ms
+ * buckets, the final "timeout" bucket drawn red) plus the latency breakdown
+ * (server→client, think, client→server). Clicking a bucket reveals what
+ * percentile of that player's moves fell in it and at-or-below it.
+ */
+export function PlayerPerformance({ stats, moveTimeoutMs, bucketMs, nameOf }: PlayerPerformanceProps) {
+  const slots = Object.keys(stats).sort((a, b) => {
+    // Most-timed-out players first, then by total moves.
+    const d = (stats[b].timeout_count ?? 0) - (stats[a].timeout_count ?? 0)
+    if (d !== 0) return d
+    return (stats[b].move_count ?? 0) - (stats[a].move_count ?? 0)
+  })
+  if (slots.length === 0) return <p className="muted">No performance data recorded for this stage.</p>
+  return (
+    <div className="perf-grid">
+      {slots.map((slot) => (
+        <PlayerCard
+          key={slot}
+          d={nameOf(slot)}
+          stats={stats[slot]}
+          moveTimeoutMs={moveTimeoutMs}
+          bucketMs={bucketMs}
+        />
+      ))}
+    </div>
+  )
+}
+
+function fmtMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(ms >= 10000 ? 0 : 1)}s`
+  return `${Math.round(ms)}ms`
+}
+
+function PlayerCard({
+  d,
+  stats,
+  moveTimeoutMs,
+  bucketMs,
+}: {
+  d: ReturnType<ReturnType<typeof nameResolver>>
+  stats: PlayerStats
+  moveTimeoutMs: number
+  bucketMs: number
+}) {
+  const [sel, setSel] = useState<number | null>(null)
+  const hist = stats.histogram ?? []
+  const total = stats.move_count || hist.reduce((a, b) => a + b, 0)
+  const maxCount = Math.max(1, ...hist)
+  const lastIdx = hist.length - 1
+
+  // Range label for a bucket. The last bucket collects timeouts / auto-plays.
+  const bucketLabel = (i: number): string => {
+    if (i === lastIdx) return `≥ ${fmtMs(moveTimeoutMs)} (timeout)`
+    return `${fmtMs(i * bucketMs)}–${fmtMs((i + 1) * bucketMs)}`
+  }
+
+  const cumAtOrBelow = (i: number): number => hist.slice(0, i + 1).reduce((a, b) => a + b, 0)
+
+  const lat = stats.latency
+  return (
+    <div className="perf-card card-surface">
+      <div className="perf-card__head">
+        <PlayerName d={d} />
+        <span className="muted perf-card__sub">
+          {total} moves
+          {stats.timeout_count > 0 && (
+            <span className="perf-card__timeouts"> · {stats.timeout_count} timed out</span>
+          )}
+        </span>
+      </div>
+
+      <div className="perf-hist" role="group" aria-label="Move-time histogram">
+        {hist.map((count, i) => {
+          const isTimeout = i === lastIdx
+          const h = Math.round((count / maxCount) * 100)
+          return (
+            <button
+              type="button"
+              key={i}
+              className={
+                'perf-bar' +
+                (isTimeout ? ' perf-bar--timeout' : '') +
+                (sel === i ? ' perf-bar--sel' : '')
+              }
+              title={`${bucketLabel(i)}: ${count} move${count === 1 ? '' : 's'}`}
+              onClick={() => setSel(sel === i ? null : i)}
+            >
+              <span className="perf-bar__fill" style={{ height: `${h}%` }} />
+            </button>
+          )
+        })}
+      </div>
+
+      {sel !== null ? (
+        <div className="perf-detail">
+          <strong>{bucketLabel(sel)}</strong>
+          <div className="muted">
+            {hist[sel]} move{hist[sel] === 1 ? '' : 's'} ·{' '}
+            {total ? ((hist[sel] / total) * 100).toFixed(1) : '0.0'}% in this bucket ·{' '}
+            {total ? ((cumAtOrBelow(sel) / total) * 100).toFixed(1) : '0.0'}% at or below
+          </div>
+        </div>
+      ) : (
+        <div className="perf-detail muted perf-detail--hint">Click a bucket for percentiles.</div>
+      )}
+
+      {lat && lat.sample_count > 0 && (
+        <table className="perf-latency">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Avg</th>
+              <th>Max</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td title="Server → client network time">S→C</td>
+              <td>{fmtMs(lat.avg_s2c_ms)}</td>
+              <td>{fmtMs(lat.max_s2c_ms)}</td>
+            </tr>
+            <tr>
+              <td title="Client think time">Think</td>
+              <td>{fmtMs(lat.avg_think_ms)}</td>
+              <td>{fmtMs(lat.max_think_ms)}</td>
+            </tr>
+            <tr>
+              <td title="Client → server network time">C→S</td>
+              <td>{fmtMs(lat.avg_c2s_ms)}</td>
+              <td>{fmtMs(lat.max_c2s_ms)}</td>
+            </tr>
+            <tr className="perf-latency__total">
+              <td>End-to-end</td>
+              <td className="muted">—</td>
+              <td>{fmtMs(lat.max_total_ms)}</td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/web/frontend/src/components/TrickRow.tsx
+++ b/web/frontend/src/components/TrickRow.tsx
@@ -1,6 +1,6 @@
 import type { TrickRecord } from '../api/client'
 import { placeTrickCards, NUM_COLS, CENTER } from '../lib/seating'
-import { Card } from './Card'
+import { Card, type MoveSource } from './Card'
 import './TrickRow.css'
 
 interface TrickRowProps {
@@ -32,6 +32,7 @@ export function TrickRow({ trick, trickIndex, playerOrder, selected, onCardClick
                   <Card
                     code={cell.card}
                     highlight={cell.isWinner}
+                    moveSource={cell.source as MoveSource | undefined}
                     onClick={onCardClick ? () => onCardClick(cell.player, cell.card, trickIndex) : undefined}
                   />
                 ) : (

--- a/web/frontend/src/lib/aggregate.ts
+++ b/web/frontend/src/lib/aggregate.ts
@@ -37,6 +37,9 @@ export interface Aggregate {
   gamePointsByPlayer: Record<string, number>
   tournamentPointsByPlayer: Record<string, number>
   moonShotsByPlayer: Record<string, number>
+  // slotId -> number of games in which this player timed out at least one move
+  // (i.e. their auto_move_count for that game was > 0).
+  timeoutGamesByPlayer: Record<string, number>
 }
 
 /** team of a full/slot id (first path component). */
@@ -95,6 +98,7 @@ export function aggregate(games: GameSummary[]): Aggregate {
   const gamePointsByPlayer: Record<string, number> = {}
   const tournamentPointsByPlayer: Record<string, number> = {}
   const moonShotsByPlayer: Record<string, number> = {}
+  const timeoutGamesByPlayer: Record<string, number> = {}
   for (const g of games) {
     for (const p of gamePlayers(g)) {
       const key = slotId(p.id)
@@ -104,6 +108,10 @@ export function aggregate(games: GameSummary[]): Aggregate {
     }
     if (g.winner) add(gamesWonByPlayer, slotId(g.winner), 1)
     for (const [id, v] of Object.entries(g.moon_shots ?? {})) add(moonShotsByPlayer, slotId(id), v)
+    // Count this as a "timeout game" for any player who auto-played >= 1 move.
+    for (const [id, v] of Object.entries(g.auto_move_count ?? {})) {
+      if (v > 0) add(timeoutGamesByPlayer, slotId(id), 1)
+    }
   }
   return {
     numGames: games.length,
@@ -112,6 +120,7 @@ export function aggregate(games: GameSummary[]): Aggregate {
     gamePointsByPlayer,
     tournamentPointsByPlayer,
     moonShotsByPlayer,
+    timeoutGamesByPlayer,
   }
 }
 

--- a/web/frontend/src/lib/seating.ts
+++ b/web/frontend/src/lib/seating.ts
@@ -40,6 +40,9 @@ export interface PlacedCard {
   card: string
   player: string
   isWinner: boolean
+  // How this card was chosen: "player" | "timeout" | "give_up" (undefined when
+  // the trick carries no move_sources, i.e. all normal player moves).
+  source?: string
 }
 
 /**
@@ -60,7 +63,12 @@ export function placeTrickCards(
   const cells: (PlacedCard | null)[] = Array(NUM_COLS).fill(null)
   trick.moves.forEach((card, i) => {
     const player = playerOrder[(firstSeat + i) % n]
-    cells[startCol + i] = { card, player, isWinner: player === trick.winner }
+    cells[startCol + i] = {
+      card,
+      player,
+      isWinner: player === trick.winner,
+      source: trick.move_sources?.[i],
+    }
   })
   return cells
 }

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -4,6 +4,7 @@ import { api, gamePlayers, type GameSummary } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver, playerSortKey, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
+import { PlayerPerformance } from '../components/PlayerPerformance'
 import {
   aggregate,
   allTeams,
@@ -28,6 +29,7 @@ type SortKey =
   | 'tournament'
   | 'avgGame'
   | 'moon'
+  | 'timeoutGames'
 // Columns that compare as text (localeCompare).
 const TEXT_SORTS: SortKey[] = ['team', 'player']
 // Columns whose natural/default direction is ascending (smallest/best first).
@@ -236,7 +238,8 @@ export function TournamentDetail() {
         cmp = (agg.tournamentPointsByPlayer[a] ?? 0) - (agg.tournamentPointsByPlayer[b] ?? 0)
       else if (sortKey === 'avgGame')
         cmp = avgOf(agg.gamePointsByPlayer, a) - avgOf(agg.gamePointsByPlayer, b)
-      else cmp = (agg.moonShotsByPlayer[a] ?? 0) - (agg.moonShotsByPlayer[b] ?? 0)
+      else if (sortKey === 'moon') cmp = (agg.moonShotsByPlayer[a] ?? 0) - (agg.moonShotsByPlayer[b] ?? 0)
+      else cmp = (agg.timeoutGamesByPlayer[a] ?? 0) - (agg.timeoutGamesByPlayer[b] ?? 0)
       if (cmp === 0) cmp = playerSortKey(nameOf(a)).localeCompare(playerSortKey(nameOf(b)))
       return sortAsc ? cmp : -cmp
     })
@@ -349,6 +352,13 @@ export function TournamentDetail() {
               />
               <SortTh label="Avg game score" col="avgGame" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
               <SortTh label="Moon shots" col="moon" sortKey={sortKey} sortAsc={sortAsc} onSort={toggleSort} />
+              <SortTh
+                label="Timeout games"
+                col="timeoutGames"
+                sortKey={sortKey}
+                sortAsc={sortAsc}
+                onSort={toggleSort}
+              />
             </tr>
           </thead>
           <tbody>
@@ -365,6 +375,7 @@ export function TournamentDetail() {
                   <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
                   <td>{avgOf(agg.gamePointsByPlayer, p).toFixed(2)}</td>
                   <td>{agg.moonShotsByPlayer[p] ?? 0}</td>
+                  <td>{agg.timeoutGamesByPlayer[p] ?? 0}</td>
                 </tr>
               )
             })}
@@ -435,6 +446,18 @@ export function TournamentDetail() {
           </div>
         )}
       </div>
+
+      {data.player_stats && (
+        <>
+          <h2>Performance</h2>
+          <PlayerPerformance
+            stats={data.player_stats[stage]}
+            moveTimeoutMs={data.move_timeout_ms ?? 0}
+            bucketMs={data.bucket_ms ?? 100}
+            nameOf={nameOf}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -1,10 +1,10 @@
-import { useMemo, type ReactNode } from 'react'
+import { Fragment, useMemo, useState, type ReactNode } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { api, gamePlayers, type GameSummary } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver, playerSortKey, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
-import { PlayerPerformance } from '../components/PlayerPerformance'
+import { PlayerMetrics } from '../components/PlayerPerformance'
 import {
   aggregate,
   allTeams,
@@ -39,6 +39,17 @@ export function TournamentDetail() {
   const { cid = '', index = '' } = useParams()
   const { data, loading, error } = useFetch(() => api.tournament(cid, index), [cid, index])
   const navigate = useNavigate()
+
+  // Which aggregate rows have their performance detail (histogram + latency)
+  // expanded. Ephemeral UI state — not persisted to the URL.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const toggleExpand = (slot: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(slot)) next.delete(slot)
+      else next.add(slot)
+      return next
+    })
 
   // Filter / stage / sort / page selections all live in the URL so the view is
   // shareable and survives back/forward navigation.
@@ -328,6 +339,12 @@ export function TournamentDetail() {
         />
 
         <h2>Aggregate over {agg.numGames} matching game(s)</h2>
+        {data.player_stats && (
+          <p className="muted" style={{ fontSize: 12, marginTop: 0 }}>
+            Click a player to expand their move-time histogram and latency breakdown. Those
+            performance metrics cover every game in this stage — the filters above don't affect them.
+          </p>
+        )}
         <table className="data">
           <thead>
             <tr>
@@ -364,19 +381,40 @@ export function TournamentDetail() {
           <tbody>
             {aggRows.map((p) => {
               const d = nameOf(p)
+              const stats = data.player_stats?.[stage]?.[p]
+              const isOpen = expanded.has(p)
               return (
-                <tr key={p}>
-                  <td>{rankByPlayer[p] ?? '—'}</td>
-                  <td style={{ color: d.color, fontWeight: 600 }}>{d.team ?? '—'}</td>
-                  <td><PlayerName d={d} /></td>
-                  <td>{avgOf(agg.tournamentPointsByPlayer, p).toFixed(2)}</td>
-                  <td>{agg.gamesByPlayer[p] ?? 0}</td>
-                  <td>{agg.gamesWonByPlayer[p] ?? 0}</td>
-                  <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
-                  <td>{avgOf(agg.gamePointsByPlayer, p).toFixed(2)}</td>
-                  <td>{agg.moonShotsByPlayer[p] ?? 0}</td>
-                  <td>{agg.timeoutGamesByPlayer[p] ?? 0}</td>
-                </tr>
+                <Fragment key={p}>
+                  <tr
+                    className={stats ? 'row-link' : undefined}
+                    onClick={stats ? () => toggleExpand(p) : undefined}
+                  >
+                    <td>{rankByPlayer[p] ?? '—'}</td>
+                    <td style={{ color: d.color, fontWeight: 600 }}>{d.team ?? '—'}</td>
+                    <td>
+                      {stats && <span className="perf-caret">{isOpen ? '▾' : '▸'}</span>}
+                      <PlayerName d={d} />
+                    </td>
+                    <td>{avgOf(agg.tournamentPointsByPlayer, p).toFixed(2)}</td>
+                    <td>{agg.gamesByPlayer[p] ?? 0}</td>
+                    <td>{agg.gamesWonByPlayer[p] ?? 0}</td>
+                    <td>{agg.tournamentPointsByPlayer[p] ?? 0}</td>
+                    <td>{avgOf(agg.gamePointsByPlayer, p).toFixed(2)}</td>
+                    <td>{agg.moonShotsByPlayer[p] ?? 0}</td>
+                    <td>{agg.timeoutGamesByPlayer[p] ?? 0}</td>
+                  </tr>
+                  {stats && isOpen && (
+                    <tr className="perf-detail-row">
+                      <td colSpan={10}>
+                        <PlayerMetrics
+                          stats={stats}
+                          moveTimeoutMs={data.move_timeout_ms ?? 0}
+                          bucketMs={data.bucket_ms ?? 100}
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               )
             })}
           </tbody>
@@ -446,18 +484,6 @@ export function TournamentDetail() {
           </div>
         )}
       </div>
-
-      {data.player_stats && (
-        <>
-          <h2>Performance</h2>
-          <PlayerPerformance
-            stats={data.player_stats[stage]}
-            moveTimeoutMs={data.move_timeout_ms ?? 0}
-            bucketMs={data.bucket_ms ?? 100}
-            nameOf={nameOf}
-          />
-        </>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Implements #78 — "Record timed out moves" — end to end across the C++ server, the recorded game/tournament JSON, and the web UI. All five parts of the issue in one PR.

1. **Aggregate timeout-games column** — TournamentDetail gains a sortable "Timeout games" column counting games where a player auto-played at least one move.
2. **JSON move-source notation** — each played card now carries a source: a normal player move, `*` (played at random after the move timed out), or `#` (auto-played because the previous N moves had timed out). Emitted in the detail JSON only when a trick contains a non-player move.
3. **Trick-view borders/markers** — cards played on a timeout get a red border + `*`; auto-played (give-up) cards get a darker red border + `#`, each with an explanatory tooltip.
4. **Per-player move-time histograms** — the tournament server records an end-to-end move-time histogram in 100ms buckets per player; the final bucket collects timeouts/auto-plays and renders red. A new Performance section below the games list draws each player's histogram; clicking a bucket shows the percentile of moves in that bucket and the percentile at-or-below it.
5. **Latency breakdown** — below each histogram, the s2c / think / c2s latency breakdown (avg + max) is listed.

## Implementation notes

- Server records move source by distinguishing timeout (waited full timeout, then random legal card) from give-up (auto-played immediately after repeated timeouts) in the connection layer, threaded through the remote player and trick runner into the game recorder.
- Backend already passes recorded JSON through unchanged, so the new fields flow to the frontend with no backend code change (frontend is types-only on the API surface).

## Test plan

- [x] `bazel build //server:tournament_server //server:server` green
- [x] `bazel test //tests:all` green
- [x] `npm run build` (web/frontend) green
- [ ] Run a tournament with a slow/timing-out player and confirm the JSON markers, trick borders, aggregate column, histogram buckets, and latency breakdown render correctly
