### PR TITLE
#83 Live game interactive UI improvements

### DIFF
--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -178,8 +178,15 @@ SDK_SESSION_TIMEOUT_S = int(os.environ.get("HEARTS_SDK_TIMEOUT_S", "150"))
 # "Slow down for interactivity" pacing (only applied when a table enables
 # slow_mode in its lobby). AI moves pause this long so a human can follow them,
 # and a finished trick lingers this long (auto-collect) before the next begins.
+# The collect pause is longer than the move pause so a human watching has a beat
+# to register the points an AI just took before the next trick starts.
 AI_MOVE_DELAY_S = float(os.environ.get("HEARTS_SLOW_AI_MOVE_S", "2"))
-COLLECT_DELAY_S = float(os.environ.get("HEARTS_SLOW_COLLECT_S", "2"))
+COLLECT_DELAY_S = float(os.environ.get("HEARTS_SLOW_COLLECT_S", "4"))
+
+# Bounds for the lobby-configurable human decision timeout (seconds): long enough
+# to actually think, short enough that a walked-away human can't wedge a game.
+MIN_TIMEOUT_S = 10.0
+MAX_TIMEOUT_S = 600.0
 
 _ABORT = object()  # sentinel pushed onto a seat queue to unblock a thinking human
 
@@ -278,6 +285,10 @@ class Seat:
     skip_move_delay: bool = False
     response_queue: "queue.Queue" = field(default_factory=queue.Queue)
     cards_ref: List[Card] = field(default_factory=list)  # live hand reference
+    # The seat's *current* hand (2-char codes), kept fresh by the human player's
+    # observer hooks so the browser can show the cards even when it isn't this
+    # seat's turn (not just inside a pending prompt).
+    hand: List[str] = field(default_factory=list)
     passed: List[str] = field(default_factory=list)      # cards I passed this round
     received: List[str] = field(default_factory=list)    # cards passed to me this round
     # Per-round passing history (round_idx -> cards), so the live view's
@@ -345,12 +356,16 @@ class WebHumanPlayer(Player):
         self._seat.passed = []      # reset passing record for the new round
         self._seat.received = []
         self._seat.skip_move_delay = False
+        self._seat.hand = self._hand_strings()
         self._table.on_new_round(round)
 
     def handle_new_trick(self, trick):
         self._table.on_new_trick(trick)
 
     def handle_move(self, player, card, report_latency_ms=None, decided_move_latency_ms=None):
+        # Keep the seat's visible hand current after every move (mine drops a
+        # card; others' moves don't change it but refreshing is cheap and safe).
+        self._seat.hand = self._hand_strings()
         self._table.on_move(player, card)
 
     def handle_finished_trick(self, trick, winning_player):
@@ -367,19 +382,22 @@ class WebHumanPlayer(Player):
         self._seat.received = [str(c) for c in cards]
         if self._round is not None:
             self._seat.received_by_round[self._round.round_idx] = list(self._seat.received)
+        self._seat.hand = self._hand_strings()
         self._table.schedule_broadcast()
 
     # -- decisions: block on the browser ------------------------------------
     def get_cards_to_pass(self, pass_dir, receiving_player):
         seat = self._seat
         hand = self._hand_strings()
+        seat.hand = hand
+        timeout_s = self._table.timeout_s
         seat.pending = {
             "kind": "pass",
             "hand": hand,
             "pass_direction": pass_dir.value,
             "receiving_player": _pid(receiving_player),
-            "deadline": time.time() + HUMAN_DECISION_TIMEOUT_S,
-            "timeout_s": HUMAN_DECISION_TIMEOUT_S,
+            "deadline": time.time() + timeout_s,
+            "timeout_s": timeout_s,
         }
         self._table.schedule_broadcast()
         chosen = self._await_response()
@@ -395,10 +413,12 @@ class WebHumanPlayer(Player):
         seat = self._seat
         legal = [str(c) for c in legal_moves]
         hand = self._hand_strings()
+        seat.hand = hand
+        timeout_s = self._table.timeout_s
         seat.pending = {
             "kind": "move", "hand": hand, "legal_moves": legal, "trick_idx": trick.trick_idx,
-            "deadline": time.time() + HUMAN_DECISION_TIMEOUT_S,
-            "timeout_s": HUMAN_DECISION_TIMEOUT_S,
+            "deadline": time.time() + timeout_s,
+            "timeout_s": timeout_s,
         }
         self._table.set_turn(seat.pid)
         self._table.schedule_broadcast()
@@ -411,7 +431,7 @@ class WebHumanPlayer(Player):
     # -- helpers ------------------------------------------------------------
     def _await_response(self):
         try:
-            return self._seat.response_queue.get(timeout=HUMAN_DECISION_TIMEOUT_S)
+            return self._seat.response_queue.get(timeout=self._table.timeout_s)
         except queue.Empty:
             return _ABORT
 
@@ -591,6 +611,10 @@ class Table:
         #   hide_prev_tricks — hide a round's completed tricks until it finishes.
         self.slow_mode = False
         self.hide_prev_tricks = False
+        # Human decision budget (seconds), configurable in the lobby. The server
+        # auto-moves after its own MOVE_TIMEOUT_MS, so this is a per-table override
+        # for the browser-side wait; defaults to HUMAN_DECISION_TIMEOUT_S.
+        self.timeout_s = HUMAN_DECISION_TIMEOUT_S
         # Inter-trick collect gate (only active under slow_mode). Holds the
         # finished trick on the table until the winner collects it: a human
         # taps "Collect cards"; an AI auto-collects after COLLECT_DELAY_S.
@@ -721,15 +745,21 @@ class Table:
         seat.log = []
         return None
 
-    def set_options(self, slow_mode=None, hide_prev_tricks=None) -> Optional[str]:
-        """Set the slow-mode / hide-previous-tricks pacing options. Lobby-only:
-        once the game starts these are frozen."""
+    def set_options(self, slow_mode=None, hide_prev_tricks=None, timeout_s=None) -> Optional[str]:
+        """Set the slow-mode / hide-previous-tricks / timeout pacing options.
+        Lobby-only: once the game starts these are frozen."""
         if self.status != "lobby":
             return "Game already started"
         if slow_mode is not None:
             self.slow_mode = bool(slow_mode)
         if hide_prev_tricks is not None:
             self.hide_prev_tricks = bool(hide_prev_tricks)
+        if timeout_s is not None:
+            try:
+                t = float(timeout_s)
+            except (TypeError, ValueError):
+                return "Invalid timeout"
+            self.timeout_s = max(MIN_TIMEOUT_S, min(MAX_TIMEOUT_S, t))
         return None
 
     # -- start --------------------------------------------------------------
@@ -749,8 +779,13 @@ class Table:
 
         _ensure_stdout_router()  # so bots' print() output is captured per seat
 
+        # The SDK session timeout must sit above the human decision budget so a
+        # waiting seat thread doesn't give up before a slow human (or the collect
+        # gate) resolves. Bump it when the lobby raised the timeout past the default.
+        session_timeout = max(SDK_SESSION_TIMEOUT_S, int(self.timeout_s) + 35)
+
         try:
-            self.connection = ManagedConnection(timeout_s=SDK_SESSION_TIMEOUT_S)
+            self.connection = ManagedConnection(timeout_s=session_timeout)
         except Exception as e:  # server down / unreachable
             return f"Could not connect to game server: {e}"
 
@@ -768,7 +803,7 @@ class Table:
             try:
                 thread, _session = MakeSession(
                     self.connection, GameType.ANY, player_cls,
-                    lobby_code=self.lobby_code, timeout_s=SDK_SESSION_TIMEOUT_S,
+                    lobby_code=self.lobby_code, timeout_s=session_timeout,
                 )
             except Exception as e:
                 return f"Failed to create session for {seat.name}: {e}"
@@ -887,20 +922,23 @@ class Table:
             return  # not the winner (or not a local seat) — nothing to gate
         human = seat.kind == "human"
         moves = [{"player": _pid(m.player), "card": str(m.card)} for m in trick.moves]
+        points = trick.get_current_point_value()
         with self._state_lock:
             self._collect_event.clear()
             self._collecting = {
                 "winner": seat.pid,
                 "human": human,
-                "deadline": time.time() + (HUMAN_DECISION_TIMEOUT_S if human else COLLECT_DELAY_S),
+                "deadline": time.time() + (self.timeout_s if human else COLLECT_DELAY_S),
                 "delay_s": COLLECT_DELAY_S,
-                "trick": {"trick_idx": trick.trick_idx, "moves": moves, "winner": seat.pid},
+                # `points` lets the UI label the button ("Collect N points").
+                "trick": {"trick_idx": trick.trick_idx, "moves": moves,
+                          "winner": seat.pid, "points": points},
             }
         self.schedule_broadcast()
         if human:
             # Wait for the browser to tap "Collect cards" (bounded so a walked-
             # away human can't wedge the game / block status -> finished).
-            self._collect_event.wait(timeout=HUMAN_DECISION_TIMEOUT_S)
+            self._collect_event.wait(timeout=self.timeout_s)
         else:
             time.sleep(COLLECT_DELAY_S)
             seat.skip_move_delay = True  # lead the next trick immediately
@@ -957,6 +995,24 @@ class Table:
 
     def _seat_for_tag(self, tag: str) -> Optional[Seat]:
         return next((s for s in self.seats if s.player_tag == tag), None)
+
+    @staticmethod
+    def _redact_log(log: List[dict]) -> List[dict]:
+        """Strip card-revealing text from an AI seat's log for hide-tricks mode.
+
+        With "hide previous tricks" on, the activity log would otherwise leak
+        what a bot played/passed (and any cards it printed), defeating the point.
+        We keep the line (so a hung/slow bot is still visible) but replace the
+        card-bearing text with a neutral placeholder. Status lines (game/round/
+        think/error) carry no card info, so they pass through unchanged.
+        """
+        redacted = {"move": "Played a card", "pass": "Passed 3 cards", "print": "(output hidden)"}
+        out = []
+        for e in log:
+            if e.get("kind") in redacted:
+                e = {**e, "text": redacted[e["kind"]]}
+            out.append(e)
+        return out
 
     # -- snapshots ----------------------------------------------------------
     def _cumulative_scores(self) -> Dict[str, int]:
@@ -1042,6 +1098,7 @@ class Table:
                     "pid": seat.pid,
                     "name": seat.name,
                     "pending": seat.pending,
+                    "hand": list(seat.hand),
                     "passed": list(seat.passed),
                     "received": list(seat.received),
                     "passed_by_round": {str(k): v for k, v in seat.passed_by_round.items()},
@@ -1050,12 +1107,15 @@ class Table:
             # AI seats this browser added: surface their activity log so the
             # owner can watch the bot (and spot a hung/slow one).
             elif seat.kind == "ai" and seat.owner_client_id == client_id:
+                # Hide-tricks mode also hides what the bot played/printed, so the
+                # log can't be used to peek at the round in progress.
+                log = self._redact_log(seat.log) if self.hide_prev_tricks else list(seat.log)
                 ai.append({
                     "seat_id": seat.seat_id,
                     "ai_type": seat.ai_type,
                     "name": seat.name,
                     "pid": seat.pid,
-                    "log": list(seat.log),
+                    "log": log,
                 })
         return {
             "type": "state",
@@ -1066,6 +1126,7 @@ class Table:
                 "lobby_code": self.lobby_code,  # share with CLI clients to co-fill open seats
                 "slow_mode": self.slow_mode,
                 "hide_prev_tricks": self.hide_prev_tricks,
+                "timeout_s": self.timeout_s,
                 "seats": [s.public_view(client_id) for s in self.seats],
                 # Per-table AI options = uploaded clients for this table only
                 # (the global discovered list is fetched separately and cached).

--- a/web/backend/live.py
+++ b/web/backend/live.py
@@ -175,6 +175,12 @@ def load_uploaded_player(source: str) -> type:
 HUMAN_DECISION_TIMEOUT_S = float(os.environ.get("HEARTS_HUMAN_TIMEOUT_S", "115"))
 SDK_SESSION_TIMEOUT_S = int(os.environ.get("HEARTS_SDK_TIMEOUT_S", "150"))
 
+# "Slow down for interactivity" pacing (only applied when a table enables
+# slow_mode in its lobby). AI moves pause this long so a human can follow them,
+# and a finished trick lingers this long (auto-collect) before the next begins.
+AI_MOVE_DELAY_S = float(os.environ.get("HEARTS_SLOW_AI_MOVE_S", "2"))
+COLLECT_DELAY_S = float(os.environ.get("HEARTS_SLOW_COLLECT_S", "2"))
+
 _ABORT = object()  # sentinel pushed onto a seat queue to unblock a thinking human
 
 LIVE_LOG_CAP = 60  # max activity-log entries kept per AI seat
@@ -266,6 +272,10 @@ class Seat:
     player_tag: Optional[str] = None
     pid: Optional[str] = None  # resolved "tag(session)" once the game begins
     pending: Optional[dict] = None
+    # Slow-mode pacing: set when this seat's collect pause already provided the
+    # beat before its leading move, so that move plays immediately (no extra
+    # AI delay stacked on top of the collect wait).
+    skip_move_delay: bool = False
     response_queue: "queue.Queue" = field(default_factory=queue.Queue)
     cards_ref: List[Card] = field(default_factory=list)  # live hand reference
     passed: List[str] = field(default_factory=list)      # cards I passed this round
@@ -334,6 +344,7 @@ class WebHumanPlayer(Player):
         self._seat.cards_ref = round.cards_in_hand  # dealt 13 (pass-pool fallback)
         self._seat.passed = []      # reset passing record for the new round
         self._seat.received = []
+        self._seat.skip_move_delay = False
         self._table.on_new_round(round)
 
     def handle_new_trick(self, trick):
@@ -344,6 +355,7 @@ class WebHumanPlayer(Player):
 
     def handle_finished_trick(self, trick, winning_player):
         self._table.on_finished_trick(trick, winning_player)
+        self._table.gate_collect(self._seat, trick, winning_player)
 
     def handle_finished_round(self, round, round_points):
         self._table.on_finished_round(round, round_points)
@@ -467,6 +479,7 @@ def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
 
     def handle_new_round(self, round):
         _safe("handle_new_round", lambda: base_cls.handle_new_round(self, round))
+        seat.skip_move_delay = False
         table.log_seat(seat, "round", f"Round {round.round_idx + 1} — dealt {len(round.cards_in_hand)} cards")
         table.on_new_round(round)
 
@@ -484,6 +497,7 @@ def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
     def handle_finished_trick(self, trick, winning_player):
         _safe("handle_finished_trick", lambda: base_cls.handle_finished_trick(self, trick, winning_player))
         table.on_finished_trick(trick, winning_player)
+        table.gate_collect(seat, trick, winning_player)
 
     def handle_finished_round(self, round, round_points):
         _safe("handle_finished_round", lambda: base_cls.handle_finished_round(self, round, round_points))
@@ -510,6 +524,14 @@ def _make_ai_cls(table: "Table", seat: Seat, base_cls: type) -> type:
         return cards
 
     def get_move(self, trick, legal_moves, move_request_latency_ms=None):
+        # Slow-mode pacing: pause before an AI move so a human can follow it.
+        # The leading move after a collect pause skips the extra delay (the
+        # collect wait already provided the beat — "play first move immediately").
+        if table.slow_mode:
+            if seat.skip_move_delay:
+                seat.skip_move_delay = False
+            else:
+                time.sleep(AI_MOVE_DELAY_S)
         table.log_seat(seat, "think",
                        f"Thinking · trick {trick.trick_idx + 1} · {len(legal_moves)} legal…",
                        pending=True)
@@ -562,6 +584,18 @@ class Table:
         self.lobby_code = f"weblive_{code}_{uuid.uuid4().hex[:8]}"
         self.seats: List[Seat] = [Seat(index=i, seat_id=f"seat-{i}") for i in range(4)]
         self.status = "lobby"  # "lobby" | "playing" | "finished"
+
+        # "Slow down for interactivity" options. Set in the lobby and frozen at
+        # start (a running game can't change pacing without confusing seats).
+        #   slow_mode        — pause before AI moves + gate trick collection.
+        #   hide_prev_tricks — hide a round's completed tricks until it finishes.
+        self.slow_mode = False
+        self.hide_prev_tricks = False
+        # Inter-trick collect gate (only active under slow_mode). Holds the
+        # finished trick on the table until the winner collects it: a human
+        # taps "Collect cards"; an AI auto-collects after COLLECT_DELAY_S.
+        self._collecting: Optional[dict] = None
+        self._collect_event = threading.Event()
 
         # WebSocket connections keyed by a unique per-connection id -> (ws,
         # client_id). Keyed by connection (not client_id) so two sockets sharing
@@ -685,6 +719,17 @@ class Table:
         seat.ai_type = None
         seat.owner_client_id = None
         seat.log = []
+        return None
+
+    def set_options(self, slow_mode=None, hide_prev_tricks=None) -> Optional[str]:
+        """Set the slow-mode / hide-previous-tricks pacing options. Lobby-only:
+        once the game starts these are frozen."""
+        if self.status != "lobby":
+            return "Game already started"
+        if slow_mode is not None:
+            self.slow_mode = bool(slow_mode)
+        if hide_prev_tricks is not None:
+            self.hide_prev_tricks = bool(hide_prev_tricks)
         return None
 
     # -- start --------------------------------------------------------------
@@ -823,6 +868,64 @@ class Table:
             }
         self.schedule_broadcast()
 
+    def gate_collect(self, seat: Seat, trick, winning_player):
+        """Hold a just-finished trick on the table until it's collected.
+
+        Called from every seat's ``handle_finished_trick`` hook, but only the
+        *winning local seat's* thread does the gating (it's the one that leads
+        the next trick, so blocking it pauses the game cleanly without racing
+        the other observers). A human winner must tap "Collect cards"; an AI
+        winner auto-collects after a short delay and then leads immediately.
+
+        The finished trick's cards travel inside ``_collecting`` so the frontend
+        can keep showing them even after the shared ``current_trick`` advances
+        (and regardless of the hide-previous-tricks option).
+        """
+        if not self.slow_mode:
+            return
+        if seat.pid is None or _pid(winning_player) != seat.pid:
+            return  # not the winner (or not a local seat) — nothing to gate
+        human = seat.kind == "human"
+        moves = [{"player": _pid(m.player), "card": str(m.card)} for m in trick.moves]
+        with self._state_lock:
+            self._collect_event.clear()
+            self._collecting = {
+                "winner": seat.pid,
+                "human": human,
+                "deadline": time.time() + (HUMAN_DECISION_TIMEOUT_S if human else COLLECT_DELAY_S),
+                "delay_s": COLLECT_DELAY_S,
+                "trick": {"trick_idx": trick.trick_idx, "moves": moves, "winner": seat.pid},
+            }
+        self.schedule_broadcast()
+        if human:
+            # Wait for the browser to tap "Collect cards" (bounded so a walked-
+            # away human can't wedge the game / block status -> finished).
+            self._collect_event.wait(timeout=HUMAN_DECISION_TIMEOUT_S)
+        else:
+            time.sleep(COLLECT_DELAY_S)
+            seat.skip_move_delay = True  # lead the next trick immediately
+        with self._state_lock:
+            self._collecting = None
+        self.schedule_broadcast()
+
+    def collect(self, seat_id: str, client_id: str) -> Optional[str]:
+        """Browser action: the human trick-winner collected the finished trick."""
+        with self._state_lock:
+            collecting = self._collecting
+        if collecting is None:
+            return None  # already collected / nothing pending — treat as a no-op
+        if not collecting.get("human"):
+            return "Trick is collecting automatically"
+        seat = self._seat(seat_id)
+        if seat is None:
+            return "No such seat"
+        if seat.kind != "human" or seat.owner_client_id != client_id:
+            return "Not your seat"
+        if seat.pid != collecting.get("winner"):
+            return "Only the trick winner can collect"
+        self._collect_event.set()
+        return None
+
     def on_finished_round(self, round, round_points):
         with self._state_lock:
             self._round_results[round.round_idx] = {_pid(p): v for p, v in round_points.items()}
@@ -879,12 +982,18 @@ class Table:
         expandable per-round tables in the live view."""
         rounds = []
         for ridx in sorted(self._round_tricks):
+            complete = ridx in self._round_results
+            tricks = self._round_tricks_sorted(ridx)
+            # hide_prev_tricks: a round's tricks stay hidden until it finishes,
+            # so players can't review earlier tricks of the round in progress.
+            if self.hide_prev_tricks and not complete:
+                tricks = []
             rounds.append({
                 "round_idx": ridx,
                 "pass_direction": self._round_pass_dir.get(ridx),
-                "tricks": self._round_tricks_sorted(ridx),
+                "tricks": tricks,
                 "scores": dict(self._round_results.get(ridx, {})),
-                "complete": ridx in self._round_results,
+                "complete": complete,
             })
         return rounds
 
@@ -893,6 +1002,13 @@ class Table:
             ct = self._current_trick
             moves = [{"player": pid, "card": ct["moves"][pid]} for pid in ct["order"]]
             completed_tricks = self._round_tricks_sorted(self._round_idx)
+            completed_count = len(completed_tricks)
+            # hide_prev_tricks: keep the trick count (for progress) but withhold
+            # the in-progress round's finished tricks until the round completes.
+            round_complete = self._round_idx in self._round_results
+            shown_completed = (
+                [] if (self.hide_prev_tricks and not round_complete) else completed_tricks
+            )
             return {
                 "status": self.status,
                 "player_order": list(self._player_order),
@@ -906,12 +1022,13 @@ class Table:
                     "leader": ct["leader"],
                     "moves": moves,
                 },
-                "completed_trick_count": len(completed_tricks),
-                "completed_tricks": completed_tricks,
+                "completed_trick_count": completed_count,
+                "completed_tricks": shown_completed,
                 "rounds": self._rounds_history(),
                 "turn": self._turn,
                 "winner": self._winner,
                 "final_points": dict(self._final_points),
+                "collecting": dict(self._collecting) if self._collecting else None,
             }
 
     def snapshot_for(self, client_id: Optional[str]) -> dict:
@@ -947,6 +1064,8 @@ class Table:
                 "code": self.code,
                 "status": self.status,
                 "lobby_code": self.lobby_code,  # share with CLI clients to co-fill open seats
+                "slow_mode": self.slow_mode,
+                "hide_prev_tricks": self.hide_prev_tricks,
                 "seats": [s.public_view(client_id) for s in self.seats],
                 # Per-table AI options = uploaded clients for this table only
                 # (the global discovered list is fetched separately and cached).

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -221,6 +221,11 @@ async def live_ws(websocket: WebSocket, code: str, client_id: Optional[str] = No
                     e = table.add_open(str(msg.get("seat_id", "")), str(msg.get("name", "")))
                 elif action == "clear_seat":
                     e = table.clear_seat(str(msg.get("seat_id", "")))
+                elif action == "set_options":
+                    e = table.set_options(slow_mode=msg.get("slow_mode"),
+                                          hide_prev_tricks=msg.get("hide_prev_tricks"))
+                elif action == "collect":
+                    e = table.collect(str(msg.get("seat_id", "")), client_id)
                 elif action == "start":
                     e = await asyncio.get_running_loop().run_in_executor(None, table.start)
                 elif action == "decide":

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -223,7 +223,8 @@ async def live_ws(websocket: WebSocket, code: str, client_id: Optional[str] = No
                     e = table.clear_seat(str(msg.get("seat_id", "")))
                 elif action == "set_options":
                     e = table.set_options(slow_mode=msg.get("slow_mode"),
-                                          hide_prev_tricks=msg.get("hide_prev_tricks"))
+                                          hide_prev_tricks=msg.get("hide_prev_tricks"),
+                                          timeout_s=msg.get("timeout_s"))
                 elif action == "collect":
                     e = table.collect(str(msg.get("seat_id", "")), client_id)
                 elif action == "start":

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -203,6 +203,7 @@ export interface LiveCollecting {
     trick_idx: number
     winner: string
     moves: LiveMove[]     // the four cards, in play order
+    points?: number       // points in the trick (label the Collect button)
   }
 }
 
@@ -223,6 +224,7 @@ export interface LiveMySeat {
   pid: string
   name: string
   pending: LivePending | null
+  hand?: string[]      // my current hand, always present (even when not my turn)
   passed?: string[]    // cards I passed this round
   received?: string[]  // cards passed to me this round
   passed_by_round?: Record<string, string[]>    // round_idx -> cards I passed
@@ -257,6 +259,7 @@ export interface LiveSnapshot {
     uploaded_ai_types?: AiTypeOption[]       // per-table uploaded clients
     slow_mode?: boolean                      // pace AI moves + gate trick collection
     hide_prev_tricks?: boolean               // hide a round's tricks until it ends
+    timeout_s?: number                       // human decision budget (configurable)
   }
   public: LivePublic | null
   you: { client_id: string; seats: LiveMySeat[]; ai?: LiveAiSeat[] }

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -188,6 +188,22 @@ export interface LivePublic {
   turn: string | null
   winner: string | null
   final_points: Record<string, number>
+  // Slow-mode inter-trick collect gate: the just-finished trick is held on the
+  // table until collected (a human taps "Collect cards"; an AI auto-collects).
+  collecting?: LiveCollecting | null
+}
+
+// The finished trick being held during a slow-mode collect pause.
+export interface LiveCollecting {
+  winner: string          // pid of the trick winner (who collects + leads next)
+  human: boolean          // true => a human must tap "Collect cards"
+  deadline?: number       // server epoch seconds when it auto-advances
+  delay_s?: number        // auto-collect delay (for sizing a countdown)
+  trick: {
+    trick_idx: number
+    winner: string
+    moves: LiveMove[]     // the four cards, in play order
+  }
 }
 
 export interface LivePending {
@@ -239,6 +255,8 @@ export interface LiveSnapshot {
     seats: LiveSeat[]
     lobby_code?: string                      // share with CLI clients to fill open seats
     uploaded_ai_types?: AiTypeOption[]       // per-table uploaded clients
+    slow_mode?: boolean                      // pace AI moves + gate trick collection
+    hide_prev_tricks?: boolean               // hide a round's tricks until it ends
   }
   public: LivePublic | null
   you: { client_id: string; seats: LiveMySeat[]; ai?: LiveAiSeat[] }

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -31,7 +31,7 @@ export type SendAction =
   | { action: 'add_ai'; seat_id: string; ai_type: string; name?: string }
   | { action: 'add_open'; seat_id: string; name?: string }
   | { action: 'clear_seat'; seat_id: string }
-  | { action: 'set_options'; slow_mode?: boolean; hide_prev_tricks?: boolean }
+  | { action: 'set_options'; slow_mode?: boolean; hide_prev_tricks?: boolean; timeout_s?: number }
   | { action: 'start' }
   | { action: 'decide'; seat_id: string; value: string | string[] }
   | { action: 'collect'; seat_id: string }

--- a/web/frontend/src/lib/liveSocket.ts
+++ b/web/frontend/src/lib/liveSocket.ts
@@ -31,8 +31,10 @@ export type SendAction =
   | { action: 'add_ai'; seat_id: string; ai_type: string; name?: string }
   | { action: 'add_open'; seat_id: string; name?: string }
   | { action: 'clear_seat'; seat_id: string }
+  | { action: 'set_options'; slow_mode?: boolean; hide_prev_tricks?: boolean }
   | { action: 'start' }
   | { action: 'decide'; seat_id: string; value: string | string[] }
+  | { action: 'collect'; seat_id: string }
 
 export interface LiveConnection {
   snapshot: LiveSnapshot | null

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -502,7 +502,84 @@
   font-weight: 700;
 }
 
+/* --- Lobby table options (slow mode / hide previous tricks) ---------------- */
+.table-settings__opt {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 0;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1.4;
+}
+.table-settings__opt + .table-settings__opt {
+  border-top: 1px solid var(--sx-hairline, #2a2a2a);
+}
+.table-settings__opt input[type='checkbox'] {
+  margin-top: 3px;
+  flex: 0 0 auto;
+}
+
+/* --- My-turn cue toggles (sit at the end of the info bar) ------------------ */
+.live-cues {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-left: auto;
+}
+.live-cues__toggles {
+  display: flex;
+  gap: 14px;
+}
+.live-cues__toggles label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+/* --- Slow-mode collect gate ----------------------------------------------- */
+.collect-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 0 0 14px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  border: 1px solid var(--sx-hairline, #333);
+  background: var(--sx-card, rgba(255, 255, 255, 0.03));
+}
+.collect-bar--mine {
+  border-color: #4caf50;
+  background: rgba(76, 175, 80, 0.12);
+}
+.collect-bar__label {
+  font-weight: 600;
+}
+.collect-bar__btn {
+  margin-left: auto;
+  background: #4caf50;
+  border-color: #4caf50;
+  color: #0c2912;
+  font-weight: 700;
+  padding: 10px 20px;
+}
+.collect-bar--auto .collect-bar__label {
+  color: var(--sx-muted, #9aa);
+  font-weight: 500;
+}
+
 @media (max-width: 600px) {
+  .live-cues {
+    margin-left: 0;
+    flex-basis: 100%;
+  }
+  .collect-bar {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  }
   .live-table-info {
     gap: 20px;
     padding: 12px 14px;

--- a/web/frontend/src/pages/LivePlay.css
+++ b/web/frontend/src/pages/LivePlay.css
@@ -177,9 +177,11 @@
   display: flex;
   align-items: center;
 }
+/* Same footprint as a played md card (.card--md) so the seat doesn't resize when
+   a card lands in / leaves the slot. */
 .live-seat__empty {
-  width: 64px;
-  height: 90px;
+  width: 48px;
+  height: 66px;
   border: 1px dashed var(--sx-hairline, #444);
   border-radius: 6px;
   opacity: 0.4;
@@ -519,6 +521,22 @@
   margin-top: 3px;
   flex: 0 0 auto;
 }
+/* A non-checkbox option row (label text + an inline control on the right). */
+.table-settings__opt--inline {
+  justify-content: space-between;
+  gap: 16px;
+}
+.table-settings__timeout {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.table-settings__timeout input[type='number'] {
+  width: 72px;
+  padding: 6px 8px;
+  font: inherit;
+}
 
 /* --- My-turn cue toggles (sit at the end of the info bar) ------------------ */
 .live-cues {
@@ -537,6 +555,11 @@
   gap: 5px;
   font-size: 13px;
   cursor: pointer;
+}
+/* An unavailable cue (e.g. vibration on iOS Safari): dim + not-allowed. */
+.live-cues__opt--off {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* --- Slow-mode collect gate ----------------------------------------------- */
@@ -617,6 +640,11 @@
   }
   .live-seat__card {
     min-height: 74px;
+  }
+  .live-seat__empty {
+    /* Match the phone .card--md size (34x48) so the slot stays a constant size. */
+    width: 34px;
+    height: 48px;
   }
   .live-seat__score {
     font-size: 11px;

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -41,35 +41,82 @@ function setCuePref(k: CueKind, on: boolean) {
 }
 
 let _audioCtx: AudioContext | null = null
-function playTurnTone() {
+function getAudioCtx(): AudioContext | null {
   try {
-    const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    const Ctor =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!Ctor) return null
     _audioCtx = _audioCtx ?? new Ctor()
-    const ctx = _audioCtx
-    if (ctx.state === 'suspended') void ctx.resume()
-    const osc = ctx.createOscillator()
-    const gain = ctx.createGain()
-    osc.type = 'sine'
-    osc.frequency.setValueAtTime(880, ctx.currentTime)
-    osc.frequency.setValueAtTime(1320, ctx.currentTime + 0.12)
-    gain.gain.setValueAtTime(0.0001, ctx.currentTime)
-    gain.gain.exponentialRampToValueAtTime(0.18, ctx.currentTime + 0.02)
-    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.3)
-    osc.connect(gain)
-    gain.connect(ctx.destination)
-    osc.start()
-    osc.stop(ctx.currentTime + 0.32)
+    return _audioCtx
   } catch {
-    /* audio unavailable — ignore */
+    return null
   }
 }
 
-/** Fire haptic/sound cues on the rising edge of `active` (it becoming my turn). */
+/** Resume the audio context. iOS Safari starts it 'suspended' and 'interrupts'
+ *  it whenever the tab backgrounds (which is why sound "worked for a while then
+ *  stopped"); resuming must happen from a user gesture or on returning to the
+ *  foreground. Safe to call repeatedly. */
+function unlockAudio() {
+  const ctx = getAudioCtx()
+  if (ctx && ctx.state !== 'running') void ctx.resume()
+}
+
+function emitTone(ctx: AudioContext) {
+  const osc = ctx.createOscillator()
+  const gain = ctx.createGain()
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(880, ctx.currentTime)
+  osc.frequency.setValueAtTime(1320, ctx.currentTime + 0.12)
+  gain.gain.setValueAtTime(0.0001, ctx.currentTime)
+  gain.gain.exponentialRampToValueAtTime(0.18, ctx.currentTime + 0.02)
+  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.3)
+  osc.connect(gain)
+  gain.connect(ctx.destination)
+  osc.start()
+  osc.stop(ctx.currentTime + 0.32)
+}
+
+function playTurnTone() {
+  const ctx = getAudioCtx()
+  if (!ctx) return
+  // If the context was suspended/interrupted (backgrounded tab), resume first
+  // and emit only once it's actually running so the tone isn't silently dropped.
+  if (ctx.state === 'running') {
+    try {
+      emitTone(ctx)
+    } catch {
+      /* ignore */
+    }
+  } else {
+    ctx
+      .resume()
+      .then(() => {
+        try {
+          emitTone(ctx)
+        } catch {
+          /* ignore */
+        }
+      })
+      .catch(() => {})
+  }
+}
+
+/** Whether the Vibration API is actually usable. iOS Safari exposes no
+ *  navigator.vibrate, so the buzz cue can't work there — we surface that with a
+ *  disabled toggle instead of a control that silently does nothing. */
+function vibrationSupported(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function'
+}
+
+/** Fire haptic/sound cues on the rising edge of `active` (it becoming my turn,
+ *  or my needing to collect). */
 function useTurnCue(active: boolean, vibrate: boolean, sound: boolean) {
   const wasActive = useRef(false)
   useEffect(() => {
     if (active && !wasActive.current) {
-      if (vibrate) navigator.vibrate?.([55, 40, 55])
+      if (vibrate && vibrationSupported()) navigator.vibrate?.([55, 40, 55])
       if (sound) playTurnTone()
     }
     wasActive.current = active
@@ -329,6 +376,21 @@ function Lobby({ table, send }: { table: LobbyTable; send: (a: SendAction) => vo
 function TableSettings({ table, send }: { table: LobbyTable; send: (a: SendAction) => void }) {
   const slow = !!table.slow_mode
   const hide = !!table.hide_prev_tricks
+  // Editable decision timeout. Kept in local state while typing, committed on
+  // blur/Enter (the backend clamps to 10–600s). Re-sync if another lobby client
+  // changes it.
+  const serverTimeout = Math.round(table.timeout_s ?? 115)
+  const [timeoutInput, setTimeoutInput] = useState(String(serverTimeout))
+  const [lastServer, setLastServer] = useState(serverTimeout)
+  if (serverTimeout !== lastServer) {
+    setLastServer(serverTimeout)
+    setTimeoutInput(String(serverTimeout))
+  }
+  const commitTimeout = () => {
+    const v = Number(timeoutInput)
+    if (Number.isFinite(v) && timeoutInput.trim() !== '') send({ action: 'set_options', timeout_s: v })
+    else setTimeoutInput(String(serverTimeout))
+  }
   return (
     <div className="card-surface table-settings" style={{ marginTop: 16 }}>
       <h3 style={{ margin: '0 0 8px' }}>Table options</h3>
@@ -354,9 +416,32 @@ function TableSettings({ table, send }: { table: LobbyTable; send: (a: SendActio
         <span>
           <strong>Hide previous tricks until the round ends</strong>
           <span className="muted"> — earlier tricks of the current round stay hidden until the
-            round finishes scoring.</span>
+            round finishes scoring. AI activity logs are redacted too, so they can't be used to
+            peek.</span>
         </span>
       </label>
+      <div className="table-settings__opt table-settings__opt--inline">
+        <span>
+          <strong>Decision timeout</strong>
+          <span className="muted"> — how long a human seat has to pass or play before the server
+            auto-decides for them.</span>
+        </span>
+        <span className="table-settings__timeout">
+          <input
+            type="number"
+            min={10}
+            max={600}
+            step={5}
+            value={timeoutInput}
+            onChange={(e) => setTimeoutInput(e.target.value)}
+            onBlur={commitTimeout}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+            }}
+          />
+          <span className="muted">s</span>
+        </span>
+      </div>
     </div>
   )
 }
@@ -524,22 +609,28 @@ function CollectBar({
   send: (a: SendAction) => void
   nameOf: (pid: string) => string
 }) {
+  const points = collecting.trick?.points ?? 0
+  const ptsLabel = `${points} ${points === 1 ? 'point' : 'points'}`
   if (mySeat) {
     return (
       <div className="collect-bar collect-bar--mine">
-        <span className="collect-bar__label">You won the trick.</span>
+        <span className="collect-bar__label">
+          You won the trick{points > 0 ? ` — ${ptsLabel}` : ''}.
+        </span>
         <button
           className="btn collect-bar__btn"
           onClick={() => send({ action: 'collect', seat_id: mySeat.seat_id })}
         >
-          Collect cards →
+          {points > 0 ? `Collect ${ptsLabel} →` : 'Collect cards →'}
         </button>
       </div>
     )
   }
   return (
     <div className="collect-bar collect-bar--auto">
-      <span className="collect-bar__label">{nameOf(collecting.winner)} won the trick — collecting…</span>
+      <span className="collect-bar__label">
+        {nameOf(collecting.winner)} won the trick{points > 0 ? ` (+${points})` : ''} — collecting…
+      </span>
     </div>
   )
 }
@@ -561,13 +652,34 @@ function PlayView({
   // return, so they live at the top regardless of whether the game has begun.
   const [vibrate, setVibrate] = useState(() => cuePref('vibrate'))
   const [sound, setSound] = useState(() => cuePref('sound'))
+  const canVibrate = vibrationSupported()
   const myTurn = mySeats.some((s) => s.pending != null)
   useTurnCue(myTurn, vibrate, sound)
+  // Also cue when it's my turn to collect a finished trick (slow mode). Computed
+  // here (before the early return below) so the hook order stays stable.
+  const collectingTop = pub?.collecting ?? null
+  const myCollectTop = !!(
+    collectingTop?.human && mySeats.some((s) => s.pid === collectingTop.winner)
+  )
+  useTurnCue(myCollectTop, vibrate, sound)
   const toggleCue = (k: CueKind, on: boolean) => {
     setCuePref(k, on)
     if (k === 'vibrate') setVibrate(on)
-    else setSound(on)
+    else {
+      setSound(on)
+      if (on) unlockAudio() // grant audio within this user gesture (iOS)
+    }
   }
+  // Re-unlock audio when returning to the foreground — iOS interrupts the
+  // context on backgrounding, which is why sound would stop after a while.
+  useEffect(() => {
+    if (!sound) return
+    const onVis = () => {
+      if (document.visibilityState === 'visible') unlockAudio()
+    }
+    document.addEventListener('visibilitychange', onVis)
+    return () => document.removeEventListener('visibilitychange', onVis)
+  }, [sound])
 
   if (!pub) return <p className="muted">Waiting for the game to begin…</p>
   const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
@@ -616,9 +728,21 @@ function PlayView({
           <div className="live-cues">
             <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>MY-TURN CUES</span>
             <div className="live-cues__toggles">
-              <label title="Vibrate when it's your turn (supported devices only)">
-                <input type="checkbox" checked={vibrate} onChange={(e) => toggleCue('vibrate', e.target.checked)} />
-                <span>Buzz</span>
+              <label
+                className={canVibrate ? '' : 'live-cues__opt--off'}
+                title={
+                  canVibrate
+                    ? "Vibrate when it's your turn"
+                    : 'Vibration is not supported on this device/browser (e.g. Safari on iPhone)'
+                }
+              >
+                <input
+                  type="checkbox"
+                  checked={vibrate && canVibrate}
+                  disabled={!canVibrate}
+                  onChange={(e) => toggleCue('vibrate', e.target.checked)}
+                />
+                <span>Buzz{canVibrate ? '' : ' (n/a)'}</span>
               </label>
               <label title="Play a tone when it's your turn">
                 <input type="checkbox" checked={sound} onChange={(e) => toggleCue('sound', e.target.checked)} />
@@ -628,11 +752,6 @@ function PlayView({
           </div>
         )}
       </div>
-
-      {/* Slow-mode collect gate: the finished trick is held until collected. */}
-      {collecting && (
-        <CollectBar collecting={collecting} mySeat={myCollectSeat} send={send} nameOf={nameOf} />
-      )}
 
       {/* This round so far: passing + completed tricks, same UI as tournaments. */}
       <RoundHistory pub={pub} mySeats={mySeats} />
@@ -670,6 +789,12 @@ function PlayView({
           </div>
         </div>
       </div>
+
+      {/* Slow-mode collect gate: the finished trick is held until collected. Sits
+          beneath the table so the prompt is right under the cards just played. */}
+      {collecting && (
+        <CollectBar collecting={collecting} mySeat={myCollectSeat} send={send} nameOf={nameOf} />
+      )}
 
       {pub.winner && (
         <div className="card-surface live-winner">
@@ -772,16 +897,10 @@ function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[]
 
   const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
 
-  const byIdx = (idx: number) => rounds.find((r) => r.round_idx === idx)
-  const playStarted = (r: LiveRound) =>
-    r.tricks.length > 0 || (pub.round_idx === r.round_idx && pub.current_trick.trick_idx != null)
-  // Auto-collapse: round finished AND the next round's passing stage is done
-  // (its play has started). The latest/live round never auto-collapses.
-  const autoCollapsed = (r: LiveRound) => {
-    if (!r.complete) return false
-    const next = byIdx(r.round_idx + 1)
-    return !!next && playStarted(next)
-  }
+  // Only the live (current, not-yet-complete) round is expanded by default; a
+  // round collapses as soon as it completes, so attention stays on live play.
+  // Either way the user can toggle any row open/closed manually.
+  const isLiveRound = (r: LiveRound) => pub.round_idx === r.round_idx && !r.complete
 
   // Shared grid: round | pass | one fractional column per player.
   const gridStyle = { ['--player-cols' as string]: String(pub.player_order.length) } as React.CSSProperties
@@ -799,7 +918,7 @@ function RoundHistory({ pub, mySeats }: { pub: LivePublic; mySeats: LiveMySeat[]
       </div>
 
       {rounds.map((r) => {
-        const expanded = overrides[r.round_idx] ?? !autoCollapsed(r)
+        const expanded = overrides[r.round_idx] ?? isLiveRound(r)
         const toggle = () =>
           setOverrides((prev) => ({ ...prev, [r.round_idx]: !expanded }))
         return (
@@ -978,6 +1097,10 @@ function DecisionTimer({ deadline, timeoutS, serverOffset }: { deadline: number;
 
 function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a: SendAction) => void; serverOffset: number }) {
   const [picked, setPicked] = useState<string[]>([])
+  // A single card "pre-selected" while it isn't my turn — lets me plan my play
+  // ahead. Cleared automatically if it's no longer legal once my move prompt
+  // arrives, or if it leaves my hand.
+  const [selected, setSelected] = useState<string | null>(null)
   const pending = seat.pending
 
   // Clear the pass selection whenever the prompt changes (e.g. a new round's
@@ -991,14 +1114,25 @@ function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a:
     setPicked([])
   }
 
-  const hand = pending?.hand ?? []
+  // The hand is always available (backend keeps seat.hand fresh), so the cards
+  // stay visible even when it isn't my turn; fall back to the prompt's hand.
+  const hand = seat.hand ?? pending?.hand ?? []
   const legal = new Set(pending?.legal_moves ?? [])
+
+  // Drop a pre-selection that's become invalid: not legal now that it's my move
+  // turn, or no longer in my hand at all. Done during render (guarded so it
+  // can't loop) per React's "adjust state on prop change" pattern.
+  if (selected != null && (!hand.includes(selected) || (pending?.kind === 'move' && !legal.has(selected)))) {
+    setSelected(null)
+  }
 
   const togglePass = (card: string) => {
     setPicked((prev) =>
       prev.includes(card) ? prev.filter((c) => c !== card) : prev.length < 3 ? [...prev, card] : prev,
     )
   }
+
+  const toggleSelect = (card: string) => setSelected((prev) => (prev === card ? null : card))
 
   // Render the hand grouped by suit (suit-then-rank sorted) with a gap between
   // suits, matching the tournament hand layout.
@@ -1077,23 +1211,41 @@ function MySeatPanel({ seat, send, serverOffset }: { seat: LiveMySeat; send: (a:
             </button>
           </div>
         </>
-      ) : pending?.kind === 'move' ? (
+      ) : (
+        // Move turn OR idle: the hand is always shown and tappable. On my move
+        // turn, legal cards play on click; off-turn (or for illegal cards) a tap
+        // just pre-selects/highlights the card so I can plan ahead.
         groupedHand((c) => {
-          const ok = legal.has(c)
+          const isMove = pending?.kind === 'move'
+          const legalNow = isMove && legal.has(c)
+          const illegalNow = isMove && !legal.has(c)
           return (
             <Card
               key={c}
               code={c}
               size="md"
-              legal={ok}
-              dim={!ok}
-              onClick={ok ? () => send({ action: 'decide', seat_id: seat.seat_id, value: c }) : undefined}
-              title={ok ? 'Click to play' : 'Not legal to play now'}
+              legal={legalNow}
+              dim={illegalNow}
+              selected={selected === c}
+              onClick={
+                legalNow
+                  ? () => send({ action: 'decide', seat_id: seat.seat_id, value: c })
+                  : illegalNow
+                    ? undefined
+                    : () => toggleSelect(c)
+              }
+              title={
+                legalNow
+                  ? 'Click to play'
+                  : illegalNow
+                    ? 'Not legal to play now'
+                    : selected === c
+                      ? 'Tap to deselect'
+                      : 'Tap to pre-select for your turn'
+              }
             />
           )
         })
-      ) : (
-        groupedHand((c) => <Card key={c} code={c} size="md" />)
       )}
     </div>
   )

--- a/web/frontend/src/pages/LivePlay.tsx
+++ b/web/frontend/src/pages/LivePlay.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api } from '../api/client'
-import type { LiveSeat, LiveMySeat, LivePublic, LiveRound, AiTypeOption, LiveAiSeat, LiveLogEntry, LiveTableSummary, LiveSnapshot } from '../api/client'
+import type { LiveSeat, LiveMySeat, LivePublic, LiveRound, AiTypeOption, LiveAiSeat, LiveLogEntry, LiveTableSummary, LiveSnapshot, LiveCollecting } from '../api/client'
 import { useLiveTable, type SendAction } from '../lib/liveSocket'
 import { Card } from '../components/Card'
 import { TrickRow } from '../components/TrickRow'
@@ -15,6 +15,65 @@ import './LivePlay.css'
 function suitGroups(hand: string[]): string[][] {
   const sorted = sortBySuitThenRank(hand)
   return SUIT_ORDER.map((s) => sorted.filter((c) => (c[1] as Suit) === s)).filter((g) => g.length > 0)
+}
+
+// --- Sensory turn cues (haptic + sound) --------------------------------------
+// When it becomes the player's turn, optionally buzz (Vibration API) and/or play
+// a short tone (Web Audio). Both are off by default and toggled per-browser
+// (localStorage) — phones throttle background tabs and some browsers gate audio
+// behind a user gesture, so we keep it opt-in and fail silently.
+
+type CueKind = 'vibrate' | 'sound'
+const cueKey = (k: CueKind) => `hearts-cue-${k}`
+function cuePref(k: CueKind): boolean {
+  try {
+    return localStorage.getItem(cueKey(k)) === '1'
+  } catch {
+    return false
+  }
+}
+function setCuePref(k: CueKind, on: boolean) {
+  try {
+    localStorage.setItem(cueKey(k), on ? '1' : '0')
+  } catch {
+    /* private mode / disabled storage — cue just won't persist */
+  }
+}
+
+let _audioCtx: AudioContext | null = null
+function playTurnTone() {
+  try {
+    const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    _audioCtx = _audioCtx ?? new Ctor()
+    const ctx = _audioCtx
+    if (ctx.state === 'suspended') void ctx.resume()
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(880, ctx.currentTime)
+    osc.frequency.setValueAtTime(1320, ctx.currentTime + 0.12)
+    gain.gain.setValueAtTime(0.0001, ctx.currentTime)
+    gain.gain.exponentialRampToValueAtTime(0.18, ctx.currentTime + 0.02)
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.3)
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.start()
+    osc.stop(ctx.currentTime + 0.32)
+  } catch {
+    /* audio unavailable — ignore */
+  }
+}
+
+/** Fire haptic/sound cues on the rising edge of `active` (it becoming my turn). */
+function useTurnCue(active: boolean, vibrate: boolean, sound: boolean) {
+  const wasActive = useRef(false)
+  useEffect(() => {
+    if (active && !wasActive.current) {
+      if (vibrate) navigator.vibrate?.([55, 40, 55])
+      if (sound) playTurnTone()
+    }
+    wasActive.current = active
+  }, [active, vibrate, sound])
 }
 
 // AI seat options are discovered by the backend (every Player subclass under
@@ -236,6 +295,8 @@ function Lobby({ table, send }: { table: LobbyTable; send: (a: SendAction) => vo
           <SeatCard key={seat.seat_id} seat={seat} send={send} aiOptions={aiOptions} code={table.code} />
         ))}
       </div>
+      <TableSettings table={table} send={send} />
+
       <div className="row-actions" style={{ marginTop: 16 }}>
         <button className="btn" disabled={!allFilled} onClick={() => send({ action: 'start' })}>
           Start game
@@ -260,6 +321,43 @@ function Lobby({ table, send }: { table: LobbyTable; send: (a: SendAction) => vo
         </div>
       )}
     </>
+  )
+}
+
+// Pacing options, chosen in the lobby and frozen at start. Backend mirrors the
+// state in the snapshot so every connected client sees the same toggles.
+function TableSettings({ table, send }: { table: LobbyTable; send: (a: SendAction) => void }) {
+  const slow = !!table.slow_mode
+  const hide = !!table.hide_prev_tricks
+  return (
+    <div className="card-surface table-settings" style={{ marginTop: 16 }}>
+      <h3 style={{ margin: '0 0 8px' }}>Table options</h3>
+      <label className="table-settings__opt">
+        <input
+          type="checkbox"
+          checked={slow}
+          onChange={(e) => send({ action: 'set_options', slow_mode: e.target.checked })}
+        />
+        <span>
+          <strong>Slow down for interactivity</strong>
+          <span className="muted"> — AI players pause before each move, and a finished trick
+            stays on the table until it's collected (you tap “Collect cards” when you win;
+            AI-won tricks clear after a beat).</span>
+        </span>
+      </label>
+      <label className="table-settings__opt">
+        <input
+          type="checkbox"
+          checked={hide}
+          onChange={(e) => send({ action: 'set_options', hide_prev_tricks: e.target.checked })}
+        />
+        <span>
+          <strong>Hide previous tricks until the round ends</strong>
+          <span className="muted"> — earlier tricks of the current round stay hidden until the
+            round finishes scoring.</span>
+        </span>
+      </label>
+    </div>
   )
 }
 
@@ -413,6 +511,39 @@ function PlayDirectionRing() {
   )
 }
 
+/** Slow-mode collect gate: prompt the human winner to collect, or show a passive
+ *  "collecting…" notice while an AI-won trick clears on its own. */
+function CollectBar({
+  collecting,
+  mySeat,
+  send,
+  nameOf,
+}: {
+  collecting: LiveCollecting
+  mySeat: LiveMySeat | undefined
+  send: (a: SendAction) => void
+  nameOf: (pid: string) => string
+}) {
+  if (mySeat) {
+    return (
+      <div className="collect-bar collect-bar--mine">
+        <span className="collect-bar__label">You won the trick.</span>
+        <button
+          className="btn collect-bar__btn"
+          onClick={() => send({ action: 'collect', seat_id: mySeat.seat_id })}
+        >
+          Collect cards →
+        </button>
+      </div>
+    )
+  }
+  return (
+    <div className="collect-bar collect-bar--auto">
+      <span className="collect-bar__label">{nameOf(collecting.winner)} won the trick — collecting…</span>
+    </div>
+  )
+}
+
 function PlayView({
   pub,
   mySeats,
@@ -426,10 +557,31 @@ function PlayView({
   send: (a: SendAction) => void
   serverOffset: number
 }) {
+  // Sensory turn cues (opt-in, per-browser). Hooks must run before any early
+  // return, so they live at the top regardless of whether the game has begun.
+  const [vibrate, setVibrate] = useState(() => cuePref('vibrate'))
+  const [sound, setSound] = useState(() => cuePref('sound'))
+  const myTurn = mySeats.some((s) => s.pending != null)
+  useTurnCue(myTurn, vibrate, sound)
+  const toggleCue = (k: CueKind, on: boolean) => {
+    setCuePref(k, on)
+    if (k === 'vibrate') setVibrate(on)
+    else setSound(on)
+  }
+
   if (!pub) return <p className="muted">Waiting for the game to begin…</p>
   const nameOf = (pid: string) => pub.players[pid]?.name ?? pid
+  // While a finished trick is being collected (slow mode), keep its cards on the
+  // table — they travel inside `collecting.trick` so this survives the shared
+  // current_trick advancing and the hide-previous-tricks option.
+  const collecting = pub.collecting ?? null
+  const activeMoves = collecting?.trick?.moves ?? pub.current_trick.moves
   const trickCard: Record<string, string> = {}
-  for (const m of pub.current_trick.moves) trickCard[m.player] = m.card
+  for (const m of activeMoves) trickCard[m.player] = m.card
+  // I'm the human collector when I own the winning seat of the held trick.
+  const myCollectSeat = collecting?.human
+    ? mySeats.find((s) => s.pid === collecting.winner)
+    : undefined
 
   // Arrange the 4 players in the quadrants of a 2x2 grid in game (seating)
   // order, with "me" (or the first seat) bottom-left and the rest going
@@ -460,7 +612,27 @@ function PlayView({
           <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>TRICK</span>
           <div className="live-stat">{pub.completed_trick_count + 1} / 13</div>
         </div>
+        {mySeats.length > 0 && (
+          <div className="live-cues">
+            <span className="muted" style={{ fontSize: 11, letterSpacing: 1 }}>MY-TURN CUES</span>
+            <div className="live-cues__toggles">
+              <label title="Vibrate when it's your turn (supported devices only)">
+                <input type="checkbox" checked={vibrate} onChange={(e) => toggleCue('vibrate', e.target.checked)} />
+                <span>Buzz</span>
+              </label>
+              <label title="Play a tone when it's your turn">
+                <input type="checkbox" checked={sound} onChange={(e) => toggleCue('sound', e.target.checked)} />
+                <span>Sound</span>
+              </label>
+            </div>
+          </div>
+        )}
       </div>
+
+      {/* Slow-mode collect gate: the finished trick is held until collected. */}
+      {collecting && (
+        <CollectBar collecting={collecting} mySeat={myCollectSeat} send={send} nameOf={nameOf} />
+      )}
 
       {/* This round so far: passing + completed tricks, same UI as tournaments. */}
       <RoundHistory pub={pub} mySeats={mySeats} />
@@ -472,13 +644,12 @@ function PlayView({
         {tablePos.map((pos) => {
           const pid = seatAt[pos]
           if (!pid) return <div key={pos} className={`live-seat-slot live-seat-slot--${pos}`} />
-          const isTurn = pub.turn === pid
+          const isTurn = pub.turn === pid || collecting?.winner === pid
           return (
             <div key={pos} className={`live-seat-slot live-seat-slot--${pos}`}>
               <div className={`live-seat ${isTurn ? 'live-seat--turn' : ''}`}>
                 <div className="live-seat__name">
                   {nameOf(pid)}
-                  {isTurn && <span className="pill live-seat__turn">to play</span>}
                 </div>
                 <div className="live-seat__card">
                   {trickCard[pid] ? <Card code={trickCard[pid]} size="md" /> : <div className="live-seat__empty" />}


### PR DESCRIPTION
Closes #83.

Adds a "slow down for interactivity" mode and related UX to live lobby play.

## What's included
1. **Remove the "to play" element** — the seat highlight (`live-seat--turn`) already marks whose turn it is, so the redundant pill is gone.
2. **Slow down for interactivity** (lobby setting, frozen at game start):
   - AI players pause ~2s before each move so a human can follow them.
   - A finished trick is **held on the table until collected**. A human trick-winner must tap **Collect cards** before the next trick starts (so they register the points they just took); an AI-won trick auto-collects after ~2s and then **leads its first move immediately** (no extra delay stacked on the collect pause).
   - The held trick travels inside the snapshot's `collecting` field, so it stays visible even after the shared `current_trick` advances and regardless of the hide-previous-tricks option.
3. **My-turn sensory cues** (per-browser, opt-in, persisted in `localStorage`): optional vibration (Vibration API) and/or a short Web Audio tone fired on the rising edge of your turn. Both fail silently where unsupported.
4. **Hide previous tricks until the round ends** (lobby setting): a round's completed tricks stay hidden until the round finishes scoring; the live current trick still shows.

## Implementation
- **Backend** (`web/backend/live.py`, `main.py`): `Table.set_options` / `gate_collect` / `collect`; `slow_mode` + `hide_prev_tricks` settings; `collecting` + table-setting snapshot fields; `set_options` / `collect` WebSocket actions. The collect gate blocks only the winning **local** seat's thread (the one that leads next), with a human wait bounded by the decision timeout and an AI auto-collect.
- **Frontend** (`LivePlay.tsx` + CSS, `client.ts`, `liveSocket.ts`): `TableSettings` lobby toggles, `CollectBar`, my-turn cue toggles, `collecting`-aware table rendering, and supporting types.

## Notes / limitations
- If a trick is won by an **open (external CLI)** seat there is no local thread to gate on, so that trick is not held — documented in `gate_collect`.
- Settings are lobby-only and frozen once the game starts.

## Test plan
- [x] `npm run build` (tsc + vite) green
- [x] Backend `py_compile` + import smoke test (Table settings/collect/snapshot)
- [x] Unit simulation of the collect gate: AI auto-collect timing + skip-delay flag, non-winner no-block, human collect unblock
- [ ] Manual: enable slow mode, play a live game with a human + AIs — confirm the collect button gates human-won tricks, AI tricks auto-clear and lead immediately, and cues fire on your turn
- [ ] Manual: enable hide-previous-tricks — confirm a round's earlier tricks stay hidden until it finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
