### PR TITLE
#84 Competition-level info + TV-cast view

### DIFF
--- a/web/frontend/src/components/LineChart.css
+++ b/web/frontend/src/components/LineChart.css
@@ -1,0 +1,71 @@
+.line-chart {
+  width: 100%;
+  /* Cap so the fixed aspect ratio doesn't make the chart absurdly tall on very
+     wide screens (e.g. a TV-cast view). */
+  max-width: 1080px;
+}
+
+.line-chart svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.line-chart__empty {
+  padding: 24px 0;
+  text-align: center;
+  font-size: 13px;
+}
+
+.line-chart__grid {
+  stroke: #eef0f3;
+  stroke-width: 1;
+}
+
+.line-chart__axis {
+  stroke: #c7ccd3;
+  stroke-width: 1;
+}
+
+.line-chart__tick {
+  fill: #8a93a0;
+}
+
+.line-chart__axis-label {
+  fill: #5a6472;
+  font-weight: 600;
+}
+
+.line-chart__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  margin-top: 10px;
+  font-size: 13px;
+}
+
+.line-chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #3a4452;
+}
+
+.line-chart__swatch {
+  width: 14px;
+  height: 4px;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+/* TV-cast mode — bigger legend so it reads from across the room. */
+.line-chart--big .line-chart__legend {
+  font-size: 18px;
+  gap: 8px 24px;
+  margin-top: 14px;
+}
+
+.line-chart--big .line-chart__swatch {
+  width: 20px;
+  height: 6px;
+}

--- a/web/frontend/src/components/LineChart.css
+++ b/web/frontend/src/components/LineChart.css
@@ -58,6 +58,82 @@
   display: inline-block;
 }
 
+/* Clickable data points (when a details callback is wired up). */
+.line-chart__dot--clickable {
+  cursor: pointer;
+}
+.line-chart__dot--clickable:hover {
+  stroke: #1b2330;
+  stroke-width: 2;
+}
+
+/* Click-to-inspect detail panel: players ranked at the chosen x value. */
+.line-chart__details {
+  margin-top: 10px;
+  border: 1px solid #e2e6ec;
+  border-radius: 8px;
+  background: #fafbfc;
+  padding: 8px 10px;
+}
+
+.line-chart__details-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.line-chart__details-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  color: #8a93a0;
+  padding: 0 4px;
+}
+.line-chart__details-close:hover {
+  color: #3a4452;
+}
+
+.line-chart__details-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.line-chart__details-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.line-chart__details-rank {
+  width: 20px;
+  text-align: right;
+  color: #8a93a0;
+  font-variant-numeric: tabular-nums;
+}
+
+.line-chart__details-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.line-chart__details-value {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
 /* TV-cast mode — bigger legend so it reads from across the room. */
 .line-chart--big .line-chart__legend {
   font-size: 18px;

--- a/web/frontend/src/components/LineChart.css
+++ b/web/frontend/src/components/LineChart.css
@@ -67,13 +67,19 @@
   stroke-width: 2;
 }
 
-/* Click-to-inspect detail panel: players ranked at the chosen x value. */
+/* Click-to-inspect detail panel: players ranked at the chosen x value.
+   Black background per design (PR #86 review). */
 .line-chart__details {
   margin-top: 10px;
-  border: 1px solid #e2e6ec;
+  border: 1px solid #000;
   border-radius: 8px;
-  background: #fafbfc;
+  background: #000;
+  color: #f4f6f8;
   padding: 8px 10px;
+}
+
+.line-chart__details .muted {
+  color: #b8c0cc;
 }
 
 .line-chart__details-head {
@@ -82,6 +88,7 @@
   justify-content: space-between;
   font-size: 13px;
   margin-bottom: 6px;
+  color: #fff;
 }
 
 .line-chart__details-close {
@@ -90,11 +97,11 @@
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
-  color: #8a93a0;
+  color: #aab2bf;
   padding: 0 4px;
 }
 .line-chart__details-close:hover {
-  color: #3a4452;
+  color: #fff;
 }
 
 .line-chart__details-list {

--- a/web/frontend/src/components/LineChart.tsx
+++ b/web/frontend/src/components/LineChart.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useState } from 'react'
 import './LineChart.css'
 
 export interface ChartPoint {
@@ -10,6 +10,14 @@ export interface ChartSeries {
   label: string
   color: string
   points: ChartPoint[]
+}
+
+/** One row in the click-to-inspect detail panel for a given x value. */
+export interface PointDetailRow {
+  id: string
+  label: string
+  color: string
+  value: number
 }
 
 export interface LineChartProps {
@@ -29,6 +37,13 @@ export interface LineChartProps {
   yMin?: number
   /** Larger fonts / thicker strokes for TV-cast readability. */
   big?: boolean
+  /** When set, data points become clickable: clicking one opens a panel listing
+   *  these rows (already sorted) for that x value. */
+  pointDetails?: (x: number) => PointDetailRow[]
+  /** Title for the detail panel header (defaults to the formatted x value). */
+  detailTitle?: (x: number) => string
+  /** Format a detail row's value (defaults to 2 decimal places). */
+  detailValueFormat?: (v: number) => string
 }
 
 // A "nice" axis: round the domain outward to pleasant tick boundaries and return
@@ -65,8 +80,12 @@ export function LineChart({
   xTicks,
   yMin,
   big = false,
+  pointDetails,
+  detailTitle,
+  detailValueFormat,
 }: LineChartProps) {
   const clipId = useId()
+  const [selectedX, setSelectedX] = useState<number | null>(null)
   const allPoints = series.flatMap((s) => s.points)
   if (allPoints.length === 0) {
     return <div className="muted line-chart__empty">No data to chart yet.</div>
@@ -152,7 +171,15 @@ export function LineChart({
               <g key={s.label}>
                 {pts.length > 1 && <path d={d} fill="none" stroke={s.color} strokeWidth={stroke} strokeLinejoin="round" strokeLinecap="round" />}
                 {pts.map((p) => (
-                  <circle key={p.x} cx={sx(p.x)} cy={sy(p.y)} r={dot} fill={s.color}>
+                  <circle
+                    key={p.x}
+                    cx={sx(p.x)}
+                    cy={sy(p.y)}
+                    r={pointDetails ? dot + 3 : dot}
+                    fill={s.color}
+                    className={pointDetails ? 'line-chart__dot--clickable' : undefined}
+                    onClick={pointDetails ? () => setSelectedX((cur) => (cur === p.x ? null : p.x)) : undefined}
+                  >
                     <title>{`${s.label} · ${xTickFormat(p.x)}: ${yTickFormat(p.y)}`}</title>
                   </circle>
                 ))}
@@ -181,6 +208,16 @@ export function LineChart({
         )}
       </svg>
 
+      {pointDetails && selectedX != null && (
+        <PointDetailPanel
+          x={selectedX}
+          rows={pointDetails(selectedX)}
+          title={detailTitle ? detailTitle(selectedX) : xTickFormat(selectedX)}
+          valueFormat={detailValueFormat ?? ((v) => v.toFixed(2))}
+          onClose={() => setSelectedX(null)}
+        />
+      )}
+
       <div className="line-chart__legend">
         {series.map((s) => (
           <span key={s.label} className="line-chart__legend-item">
@@ -189,6 +226,45 @@ export function LineChart({
           </span>
         ))}
       </div>
+    </div>
+  )
+}
+
+/** Click-to-inspect panel: ranks every player at a chosen x value, highest first. */
+function PointDetailPanel({
+  rows,
+  title,
+  valueFormat,
+  onClose,
+}: {
+  x: number
+  rows: PointDetailRow[]
+  title: string
+  valueFormat: (v: number) => string
+  onClose: () => void
+}) {
+  return (
+    <div className="line-chart__details">
+      <div className="line-chart__details-head">
+        <strong>{title}</strong>
+        <button type="button" className="line-chart__details-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+      </div>
+      {rows.length === 0 ? (
+        <div className="muted" style={{ fontSize: 12 }}>No data at this point.</div>
+      ) : (
+        <ol className="line-chart__details-list">
+          {rows.map((r, i) => (
+            <li key={r.id}>
+              <span className="line-chart__details-rank">{i + 1}</span>
+              <span className="line-chart__swatch" style={{ background: r.color }} />
+              <span className="line-chart__details-label">{r.label}</span>
+              <span className="line-chart__details-value">{valueFormat(r.value)}</span>
+            </li>
+          ))}
+        </ol>
+      )}
     </div>
   )
 }

--- a/web/frontend/src/components/LineChart.tsx
+++ b/web/frontend/src/components/LineChart.tsx
@@ -1,0 +1,194 @@
+import { useId } from 'react'
+import './LineChart.css'
+
+export interface ChartPoint {
+  x: number
+  y: number
+}
+
+export interface ChartSeries {
+  label: string
+  color: string
+  points: ChartPoint[]
+}
+
+export interface LineChartProps {
+  series: ChartSeries[]
+  /** Logical (viewBox) width; the SVG scales to its container. */
+  width?: number
+  height?: number
+  xLabel?: string
+  yLabel?: string
+  /** Format an x value for axis ticks (defaults to integer string). */
+  xTickFormat?: (x: number) => string
+  /** Format a y value for axis ticks. */
+  yTickFormat?: (y: number) => string
+  /** Force the x ticks to land on these exact values (e.g. game indices). */
+  xTicks?: number[]
+  /** Pin the y axis minimum (defaults to the data min, clamped at/above 0). */
+  yMin?: number
+  /** Larger fonts / thicker strokes for TV-cast readability. */
+  big?: boolean
+}
+
+// A "nice" axis: round the domain outward to pleasant tick boundaries and return
+// evenly spaced tick values. Keeps gridlines legible instead of landing on
+// arbitrary fractions of the raw data range.
+function niceTicks(min: number, max: number, count: number): number[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [0, 1]
+  if (min === max) {
+    // Degenerate range — show a small band around the single value.
+    const pad = Math.abs(min) > 1 ? Math.abs(min) * 0.1 : 1
+    min -= pad
+    max += pad
+  }
+  const span = max - min
+  const rawStep = span / Math.max(1, count)
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)))
+  const norm = rawStep / mag
+  const step = (norm >= 5 ? 5 : norm >= 2 ? 2 : 1) * mag
+  const start = Math.floor(min / step) * step
+  const end = Math.ceil(max / step) * step
+  const ticks: number[] = []
+  for (let v = start; v <= end + step / 2; v += step) ticks.push(Number(v.toFixed(10)))
+  return ticks
+}
+
+export function LineChart({
+  series,
+  width = 760,
+  height = 340,
+  xLabel,
+  yLabel,
+  xTickFormat = (x) => String(x),
+  yTickFormat = (y) => (Number.isInteger(y) ? String(y) : y.toFixed(1)),
+  xTicks,
+  yMin,
+  big = false,
+}: LineChartProps) {
+  const clipId = useId()
+  const allPoints = series.flatMap((s) => s.points)
+  if (allPoints.length === 0) {
+    return <div className="muted line-chart__empty">No data to chart yet.</div>
+  }
+
+  const pad = big
+    ? { top: 18, right: 24, bottom: 56, left: 64 }
+    : { top: 14, right: 18, bottom: 44, left: 52 }
+  const plotW = width - pad.left - pad.right
+  const plotH = height - pad.top - pad.bottom
+
+  const xs = allPoints.map((p) => p.x)
+  const ys = allPoints.map((p) => p.y)
+  const xMinData = Math.min(...xs)
+  const xMaxData = Math.max(...xs)
+  const yMinData = Math.min(...ys)
+  const yMaxData = Math.max(...ys)
+
+  const yTickVals = niceTicks(yMin ?? Math.min(0, yMinData), yMaxData, big ? 5 : 6)
+  const yLo = yTickVals[0]
+  const yHi = yTickVals[yTickVals.length - 1]
+
+  const xTickVals =
+    xTicks && xTicks.length
+      ? xTicks
+      : niceTicks(xMinData, xMaxData, Math.min(8, Math.max(2, xMaxData - xMinData)))
+  const xLo = xTicks && xTicks.length ? Math.min(...xTicks) : xTickVals[0]
+  const xHi = xTicks && xTicks.length ? Math.max(...xTicks) : xTickVals[xTickVals.length - 1]
+
+  const sx = (x: number) => pad.left + (xHi === xLo ? plotW / 2 : ((x - xLo) / (xHi - xLo)) * plotW)
+  const sy = (y: number) => pad.top + (yHi === yLo ? plotH / 2 : plotH - ((y - yLo) / (yHi - yLo)) * plotH)
+
+  const stroke = big ? 3 : 2
+  const dot = big ? 4 : 3
+  const tickFont = big ? 15 : 11
+  const labelFont = big ? 16 : 12
+
+  return (
+    <div className={`line-chart${big ? ' line-chart--big' : ''}`}>
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" preserveAspectRatio="xMidYMid meet">
+        <defs>
+          <clipPath id={clipId}>
+            <rect x={pad.left} y={pad.top} width={plotW} height={plotH} />
+          </clipPath>
+        </defs>
+
+        {/* Horizontal gridlines + y ticks */}
+        {yTickVals.map((t) => {
+          const y = sy(t)
+          return (
+            <g key={`y${t}`}>
+              <line x1={pad.left} y1={y} x2={pad.left + plotW} y2={y} className="line-chart__grid" />
+              <text x={pad.left - 8} y={y} className="line-chart__tick" textAnchor="end" dominantBaseline="middle" fontSize={tickFont}>
+                {yTickFormat(t)}
+              </text>
+            </g>
+          )
+        })}
+
+        {/* x ticks */}
+        {xTickVals.map((t) => {
+          const x = sx(t)
+          return (
+            <g key={`x${t}`}>
+              <line x1={x} y1={pad.top + plotH} x2={x} y2={pad.top + plotH + 4} className="line-chart__axis" />
+              <text x={x} y={pad.top + plotH + 8} className="line-chart__tick" textAnchor="middle" dominantBaseline="hanging" fontSize={tickFont}>
+                {xTickFormat(t)}
+              </text>
+            </g>
+          )
+        })}
+
+        {/* Axes */}
+        <line x1={pad.left} y1={pad.top} x2={pad.left} y2={pad.top + plotH} className="line-chart__axis" />
+        <line x1={pad.left} y1={pad.top + plotH} x2={pad.left + plotW} y2={pad.top + plotH} className="line-chart__axis" />
+
+        {/* Series */}
+        <g clipPath={`url(#${clipId})`}>
+          {series.map((s) => {
+            const pts = [...s.points].sort((a, b) => a.x - b.x)
+            const d = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${sx(p.x).toFixed(2)},${sy(p.y).toFixed(2)}`).join(' ')
+            return (
+              <g key={s.label}>
+                {pts.length > 1 && <path d={d} fill="none" stroke={s.color} strokeWidth={stroke} strokeLinejoin="round" strokeLinecap="round" />}
+                {pts.map((p) => (
+                  <circle key={p.x} cx={sx(p.x)} cy={sy(p.y)} r={dot} fill={s.color}>
+                    <title>{`${s.label} · ${xTickFormat(p.x)}: ${yTickFormat(p.y)}`}</title>
+                  </circle>
+                ))}
+              </g>
+            )
+          })}
+        </g>
+
+        {/* Axis labels */}
+        {xLabel && (
+          <text x={pad.left + plotW / 2} y={height - 4} className="line-chart__axis-label" textAnchor="middle" fontSize={labelFont}>
+            {xLabel}
+          </text>
+        )}
+        {yLabel && (
+          <text
+            x={14}
+            y={pad.top + plotH / 2}
+            className="line-chart__axis-label"
+            textAnchor="middle"
+            fontSize={labelFont}
+            transform={`rotate(-90 14 ${pad.top + plotH / 2})`}
+          >
+            {yLabel}
+          </text>
+        )}
+      </svg>
+
+      <div className="line-chart__legend">
+        {series.map((s) => (
+          <span key={s.label} className="line-chart__legend-item">
+            <span className="line-chart__swatch" style={{ background: s.color }} />
+            {s.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -302,6 +302,124 @@ button.btn.btn--active:hover {
   text-decoration: none;
 }
 
+/* "Live" badge next to an in-progress competition / tournament. */
+.badge-live {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: #e8f7f0;
+  color: #1c9c7c;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  animation: badge-live-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes badge-live-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+/* A row of stage-toggle / control buttons that can sit beside a heading. */
+.chart-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.chart-controls__spacer {
+  flex: 1;
+}
+
+/* ---- TV-cast competition view -------------------------------------------- */
+/* Larger type + a dark, glanceable layout so the competition page can be cast
+   to a TV and read passively from across the room. */
+.cast-mode {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  overflow-y: auto;
+  background: #0f1722;
+  color: #e8edf3;
+  padding: 28px 40px 48px;
+}
+
+.cast-mode h1 {
+  font-size: 34px;
+  margin-bottom: 6px;
+}
+
+.cast-mode h2 {
+  font-size: 22px;
+  color: #aeb9c7;
+}
+
+.cast-mode .card-surface {
+  background: #18222f;
+  box-shadow: none;
+  border: 1px solid #243042;
+}
+
+.cast-mode table.data th {
+  color: #8493a6;
+}
+
+.cast-mode table.data td {
+  font-size: 18px;
+  border-bottom-color: #243042;
+}
+
+.cast-mode table.data th {
+  border-bottom-color: #243042;
+}
+
+.cast-mode table.data tbody tr:hover {
+  background: transparent;
+}
+
+.cast-mode .muted {
+  color: #8493a6;
+}
+
+.cast-mode .line-chart__grid {
+  stroke: #243042;
+}
+.cast-mode .line-chart__axis {
+  stroke: #3a4a60;
+}
+.cast-mode .line-chart__tick {
+  fill: #8493a6;
+}
+.cast-mode .line-chart__axis-label {
+  fill: #aeb9c7;
+}
+.cast-mode .line-chart__legend-item {
+  color: #cdd6e2;
+}
+
+.cast-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.cast-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .cast-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 600px) {
   h1 {
     font-size: 19px;

--- a/web/frontend/src/lib/chartData.ts
+++ b/web/frontend/src/lib/chartData.ts
@@ -3,26 +3,36 @@ import type { ChartSeries } from '../components/LineChart'
 import { teamColor } from './playerId'
 import { teamOf, teamPlayerKey } from './aggregate'
 
+/** Average the last `windowSize` entries (or all of them when no window). */
+function windowedAvg(list: number[], windowSize?: number): number {
+  const arr = windowSize && windowSize > 0 ? list.slice(-windowSize) : list
+  if (arr.length === 0) return 0
+  return arr.reduce((a, b) => a + b, 0) / arr.length
+}
+
 /**
  * For one tournament's games: each team's best player's *average* tournament
  * points. "Best" = the (team, player_tag) with the highest per-game average
- * within this tournament. Returns team -> that average.
+ * within this tournament. Returns team -> that average. With `windowSize`, each
+ * player's average covers only their most recent N games (rolling window).
  */
-export function teamTopPlayerAvg(games: GameSummary[]): Record<string, number> {
-  const sumByTP: Record<string, number> = {}
-  const gamesByTP: Record<string, number> = {}
+export function teamTopPlayerAvg(games: GameSummary[], windowSize?: number): Record<string, number> {
+  // Per (team, player_tag): the ordered list of per-game tournament points.
+  const ptsByTP = new Map<string, number[]>()
   for (const g of games) {
-    const seen = new Set<string>()
+    const perTP: Record<string, number> = {}
     for (const p of gamePlayers(g)) {
       const key = teamPlayerKey(p.id)
-      sumByTP[key] = (sumByTP[key] ?? 0) + p.tournament_points
-      seen.add(key)
+      perTP[key] = (perTP[key] ?? 0) + p.tournament_points
     }
-    for (const key of seen) gamesByTP[key] = (gamesByTP[key] ?? 0) + 1
+    for (const [key, pts] of Object.entries(perTP)) {
+      if (!ptsByTP.has(key)) ptsByTP.set(key, [])
+      ptsByTP.get(key)!.push(pts)
+    }
   }
   const best: Record<string, number> = {}
-  for (const [key, sum] of Object.entries(sumByTP)) {
-    const avg = sum / (gamesByTP[key] || 1)
+  for (const [key, list] of ptsByTP) {
+    const avg = windowedAvg(list, windowSize)
     const team = key.split('/')[0]
     if (best[team] === undefined || avg > best[team]) best[team] = avg
   }
@@ -38,12 +48,13 @@ export interface TournamentStageGames {
  * Competition-wide chart series: x = tournament index, y = the team's
  * top-performing player's average tournament points in that tournament, one
  * series per team (labelled + colored by team name). Teams only get a point for
- * tournaments in which they actually appeared.
+ * tournaments in which they actually appeared. `windowSize` caps each player's
+ * average to their most recent N games within the tournament.
  */
-export function competitionSeries(tournaments: TournamentStageGames[]): ChartSeries[] {
+export function competitionSeries(tournaments: TournamentStageGames[], windowSize?: number): ChartSeries[] {
   const byTeam = new Map<string, { x: number; y: number }[]>()
   for (const t of [...tournaments].sort((a, b) => a.index - b.index)) {
-    const best = teamTopPlayerAvg(t.games)
+    const best = teamTopPlayerAvg(t.games, windowSize)
     for (const [team, avg] of Object.entries(best)) {
       if (!byTeam.has(team)) byTeam.set(team, [])
       byTeam.get(team)!.push({ x: t.index, y: avg })
@@ -56,33 +67,76 @@ export function competitionSeries(tournaments: TournamentStageGames[]): ChartSer
 
 /**
  * Per-tournament chart series: x = game index (1-based), y = each team's
- * cumulative average tournament points through that game. A team's per-game
- * tournament points is the sum of its players' tournament points in that game;
- * the cumulative average carries forward across games the team sat out, so each
- * series is a continuous line once the team has played at least one game.
+ * average tournament points through that game. A team's per-game tournament
+ * points is the sum of its players' tournament points in that game. With no
+ * window the average is cumulative (and carries forward across games the team
+ * sat out, so each series is a continuous line once the team has played at least
+ * one game); with `windowSize` it's the mean of the team's most recent N games.
  */
-export function tournamentCumulativeSeries(games: GameSummary[]): ChartSeries[] {
-  const totals = new Map<string, { sum: number; count: number; points: { x: number; y: number }[] }>()
+export function tournamentCumulativeSeries(games: GameSummary[], windowSize?: number): ChartSeries[] {
+  // Per team: the ordered list of per-game tournament points, plus the emitted
+  // chart points (one per game index once the team has appeared).
+  const ptsByTeam = new Map<string, number[]>()
+  const series = new Map<string, { x: number; y: number }[]>()
   games.forEach((g, i) => {
     const x = i + 1
-    // Sum this game's tournament points per team.
     const perTeam: Record<string, number> = {}
     for (const p of gamePlayers(g)) {
       const team = teamOf(p.id)
       perTeam[team] = (perTeam[team] ?? 0) + p.tournament_points
     }
     for (const [team, pts] of Object.entries(perTeam)) {
-      if (!totals.has(team)) totals.set(team, { sum: 0, count: 0, points: [] })
-      const t = totals.get(team)!
-      t.sum += pts
-      t.count += 1
+      if (!ptsByTeam.has(team)) {
+        ptsByTeam.set(team, [])
+        series.set(team, [])
+      }
+      ptsByTeam.get(team)!.push(pts)
     }
     // Emit a point at this x for every team that has played by now (carry-forward).
-    for (const t of totals.values()) {
-      if (t.count > 0) t.points.push({ x, y: t.sum / t.count })
+    for (const [team, list] of ptsByTeam) {
+      if (list.length > 0) series.get(team)!.push({ x, y: windowedAvg(list, windowSize) })
     }
   })
-  return [...totals.entries()]
+  return [...series.entries()]
     .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([team, t]) => ({ label: team, color: teamColor(team), points: t.points }))
+    .map(([team, points]) => ({ label: team, color: teamColor(team), points }))
+}
+
+/** A player's average tournament points over a set of games, keyed "team/tag". */
+export interface PlayerAvg {
+  key: string
+  team: string
+  tag: string
+  avg: number
+}
+
+/**
+ * Each (team, player_tag)'s average tournament points across `games`, sorted
+ * descending (ties broken by key). With `windowSize`, only each player's most
+ * recent N games count. Used to drill into a chart point and list who led at it.
+ */
+export function playerAvgsForGames(games: GameSummary[], windowSize?: number): PlayerAvg[] {
+  const ptsByTP = new Map<string, number[]>()
+  for (const g of games) {
+    const perTP: Record<string, number> = {}
+    for (const p of gamePlayers(g)) {
+      const key = teamPlayerKey(p.id)
+      perTP[key] = (perTP[key] ?? 0) + p.tournament_points
+    }
+    for (const [key, pts] of Object.entries(perTP)) {
+      if (!ptsByTP.has(key)) ptsByTP.set(key, [])
+      ptsByTP.get(key)!.push(pts)
+    }
+  }
+  return [...ptsByTP.entries()]
+    .map(([key, list]) => {
+      const [team, tag] = key.split('/')
+      return { key, team, tag, avg: windowedAvg(list, windowSize) }
+    })
+    .sort((a, b) => b.avg - a.avg || a.key.localeCompare(b.key))
+}
+
+/** Player averages through game index `x` (1-based) of a tournament's games. */
+export function playerAvgsThroughGame(games: GameSummary[], x: number, windowSize?: number): PlayerAvg[] {
+  return playerAvgsForGames(games.slice(0, x), windowSize)
 }

--- a/web/frontend/src/lib/chartData.ts
+++ b/web/frontend/src/lib/chartData.ts
@@ -1,0 +1,88 @@
+import { gamePlayers, type GameSummary } from '../api/client'
+import type { ChartSeries } from '../components/LineChart'
+import { teamColor } from './playerId'
+import { teamOf, teamPlayerKey } from './aggregate'
+
+/**
+ * For one tournament's games: each team's best player's *average* tournament
+ * points. "Best" = the (team, player_tag) with the highest per-game average
+ * within this tournament. Returns team -> that average.
+ */
+export function teamTopPlayerAvg(games: GameSummary[]): Record<string, number> {
+  const sumByTP: Record<string, number> = {}
+  const gamesByTP: Record<string, number> = {}
+  for (const g of games) {
+    const seen = new Set<string>()
+    for (const p of gamePlayers(g)) {
+      const key = teamPlayerKey(p.id)
+      sumByTP[key] = (sumByTP[key] ?? 0) + p.tournament_points
+      seen.add(key)
+    }
+    for (const key of seen) gamesByTP[key] = (gamesByTP[key] ?? 0) + 1
+  }
+  const best: Record<string, number> = {}
+  for (const [key, sum] of Object.entries(sumByTP)) {
+    const avg = sum / (gamesByTP[key] || 1)
+    const team = key.split('/')[0]
+    if (best[team] === undefined || avg > best[team]) best[team] = avg
+  }
+  return best
+}
+
+export interface TournamentStageGames {
+  index: number
+  games: GameSummary[]
+}
+
+/**
+ * Competition-wide chart series: x = tournament index, y = the team's
+ * top-performing player's average tournament points in that tournament, one
+ * series per team (labelled + colored by team name). Teams only get a point for
+ * tournaments in which they actually appeared.
+ */
+export function competitionSeries(tournaments: TournamentStageGames[]): ChartSeries[] {
+  const byTeam = new Map<string, { x: number; y: number }[]>()
+  for (const t of [...tournaments].sort((a, b) => a.index - b.index)) {
+    const best = teamTopPlayerAvg(t.games)
+    for (const [team, avg] of Object.entries(best)) {
+      if (!byTeam.has(team)) byTeam.set(team, [])
+      byTeam.get(team)!.push({ x: t.index, y: avg })
+    }
+  }
+  return [...byTeam.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([team, points]) => ({ label: team, color: teamColor(team), points }))
+}
+
+/**
+ * Per-tournament chart series: x = game index (1-based), y = each team's
+ * cumulative average tournament points through that game. A team's per-game
+ * tournament points is the sum of its players' tournament points in that game;
+ * the cumulative average carries forward across games the team sat out, so each
+ * series is a continuous line once the team has played at least one game.
+ */
+export function tournamentCumulativeSeries(games: GameSummary[]): ChartSeries[] {
+  const totals = new Map<string, { sum: number; count: number; points: { x: number; y: number }[] }>()
+  games.forEach((g, i) => {
+    const x = i + 1
+    // Sum this game's tournament points per team.
+    const perTeam: Record<string, number> = {}
+    for (const p of gamePlayers(g)) {
+      const team = teamOf(p.id)
+      perTeam[team] = (perTeam[team] ?? 0) + p.tournament_points
+    }
+    for (const [team, pts] of Object.entries(perTeam)) {
+      if (!totals.has(team)) totals.set(team, { sum: 0, count: 0, points: [] })
+      const t = totals.get(team)!
+      t.sum += pts
+      t.count += 1
+    }
+    // Emit a point at this x for every team that has played by now (carry-forward).
+    for (const t of totals.values()) {
+      if (t.count > 0) t.points.push({ x, y: t.sum / t.count })
+    }
+  })
+  return [...totals.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([team, t]) => ({ label: team, color: teamColor(team), points: t.points }))
+}

--- a/web/frontend/src/pages/CompetitionDetail.tsx
+++ b/web/frontend/src/pages/CompetitionDetail.tsx
@@ -14,12 +14,6 @@ const SUMMARY_REFRESH_MS = 15000
 // points climb live (per PR #86 review).
 const CHART_REFRESH_MS = 1000
 
-function formatTime(iso: string | null): string {
-  if (!iso) return '—'
-  const d = new Date(iso)
-  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
-}
-
 function formatLength(seconds: number | null): string {
   if (seconds == null) return '—'
   const s = Math.round(seconds)
@@ -40,8 +34,6 @@ export function CompetitionDetail() {
 
   const [params, setParams] = useSearchParams()
   const stage: 'qualifying' | 'finals' = params.get('cstage') === 'qualifying' ? 'qualifying' : 'finals'
-  // Averaging window for the chart: full tournament, or a rolling 10-game window.
-  const windowSize = params.get('cwin') === '10' ? 10 : undefined
   const castMode = params.get('cast') === '1'
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params)
@@ -97,7 +89,7 @@ export function CompetitionDetail() {
     }))
   }, [summaries, indexKey, stage])
 
-  const series = useMemo(() => competitionSeries(perTournament, windowSize), [perTournament, windowSize])
+  const series = useMemo(() => competitionSeries(perTournament), [perTournament])
 
   // Lookup of a tournament index -> its (stage-filtered) games, so clicking a
   // chart point can list every player's average in that tournament.
@@ -109,13 +101,13 @@ export function CompetitionDetail() {
 
   const pointDetails = useCallback(
     (x: number) =>
-      playerAvgsForGames(gamesByIndex.get(x) ?? [], windowSize).map((pa) => ({
+      playerAvgsForGames(gamesByIndex.get(x) ?? []).map((pa) => ({
         id: pa.key,
         label: `${pa.team} / ${pa.tag}`,
         color: teamColor(pa.team),
         value: pa.avg,
       })),
-    [gamesByIndex, windowSize],
+    [gamesByIndex],
   )
 
   const xTicks = useMemo(() => tournaments.map((t) => Number(t.index)), [indexKey])
@@ -130,32 +122,13 @@ export function CompetitionDetail() {
   const chartCard = (
     <div className="card-surface">
       <div className="chart-controls">
-        <strong style={{ fontSize: 14 }}>Top player per team, by tournament</strong>
+        <strong style={{ fontSize: 14 }}>{stage === 'finals' ? 'Finals Scores' : 'Qualifying Scores'}</strong>
         <span className="chart-controls__spacer" />
         <button
-          className={`btn${stage === 'qualifying' ? ' btn--active' : ''}`}
-          onClick={() => setParam('cstage', 'qualifying')}
+          className="btn"
+          onClick={() => setParam('cstage', stage === 'finals' ? 'qualifying' : null)}
         >
-          Qualifying
-        </button>
-        <button
-          className={`btn${stage === 'finals' ? ' btn--active' : ''}`}
-          onClick={() => setParam('cstage', null)}
-        >
-          Finals
-        </button>
-        <span style={{ width: 12 }} />
-        <button
-          className={`btn${windowSize === undefined ? ' btn--active' : ''}`}
-          onClick={() => setParam('cwin', null)}
-        >
-          Full avg
-        </button>
-        <button
-          className={`btn${windowSize === 10 ? ' btn--active' : ''}`}
-          onClick={() => setParam('cwin', '10')}
-        >
-          Last 10
+          Show {stage === 'finals' ? 'Qualifying' : 'Finals'} Scores
         </button>
       </div>
       <LineChart
@@ -163,7 +136,7 @@ export function CompetitionDetail() {
         big={castMode}
         height={castMode ? 380 : 320}
         xLabel="Tournament"
-        yLabel="Avg tournament points"
+        yLabel="Avg points per game (top player)"
         xTicks={xTicks}
         xTickFormat={(x) => `#${x}`}
         pointDetails={pointDetails}
@@ -187,76 +160,87 @@ export function CompetitionDetail() {
         </button>
       </div>
 
-      <div className="muted" style={{ marginBottom: 12, fontSize: 13 }}>
-        {!data.is_legacy && <>Started {formatTime(data.started_at)} · </>}
-        {data.qualifying_games != null && (
-          <>
-            {data.qualifying_games} qualifying · {data.finals_games ?? '—'} finals games ·{' '}
-          </>
-        )}
-        Teams: {data.teams.length > 0 ? data.teams.join(', ') : '—'}
-        {castMode && <> · auto-refreshing every {SUMMARY_REFRESH_MS / 1000}s</>}
-      </div>
+      <div
+        style={
+          castMode
+            ? { display: 'grid', gridTemplateColumns: 'minmax(0, 1.4fr) minmax(0, 1fr)', gap: 24, alignItems: 'start' }
+            : undefined
+        }
+      >
+        {/* Competition section (top, or left in TV view): the arc chart, rules,
+            and the full list of tournaments. */}
+        <div>
+          {hasChart && (
+            <>
+              <h2 style={{ marginTop: 0 }}>Competition overview</h2>
+              {chartCard}
+            </>
+          )}
 
-      {/* Registration countdown for the next tournament — only while THIS
-          competition is the one currently running. */}
-      {isLiveCompetition && <NextTournamentBanner />}
+          {rules && (
+            <>
+              <h2>Rules</h2>
+              <div className="card-surface">
+                <table className="data rules-table">
+                  <tbody>
+                    <RuleRow label="Qualifying games" value={rules.qualifying_games} />
+                    <RuleRow label="Finals games" value={rules.finals_games} />
+                    <RuleRow
+                      label="Qualifying points (1st–4th)"
+                      value={rules.qualifying_points?.length ? rules.qualifying_points.join(' / ') : '—'}
+                    />
+                    <RuleRow label="Max players per team" value={rules.max_players_per_team} />
+                    <RuleRow label="Allow multi-team finals" value={rules.allow_multi_team_finals ? 'Yes' : 'No'} />
+                    <RuleRow label="Move timeout" value={`${rules.move_timeout_ms} ms`} />
+                    <RuleRow label="Auto-move after timeouts" value={rules.auto_move_after_timeouts} />
+                    <RuleRow label="Max concurrent games per team" value={rules.max_concurrent_games_per_team} />
+                    <RuleRow label="Fallback player tag" value={rules.fallback_player_tag} />
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
 
-      {/* Live standings for THIS competition (only when it's the one running). */}
-      <LiveStatsPanel cid={data.competition_id} />
-
-      {/* Competition arc chart. */}
-      {hasChart && (
-        <>
-          <h2>Competition overview</h2>
-          {chartCard}
-        </>
-      )}
-
-      {rules && !castMode && (
-        <>
-          <h2>Rules</h2>
+          <h2>Tournaments ({data.tournaments.length})</h2>
           <div className="card-surface">
-            <table className="data rules-table">
+            <table className="data">
+              <thead>
+                <tr>
+                  <th>Index</th>
+                  <th>Start time</th>
+                  <th>Duration</th>
+                  <th>1st place</th>
+                  <th>2nd place</th>
+                  <th>3rd place</th>
+                  <th>4th place</th>
+                </tr>
+              </thead>
               <tbody>
-                <RuleRow label="Qualifying games" value={rules.qualifying_games} />
-                <RuleRow label="Finals games" value={rules.finals_games} />
-                <RuleRow
-                  label="Qualifying points (1st–4th)"
-                  value={rules.qualifying_points?.length ? rules.qualifying_points.join(' / ') : '—'}
-                />
-                <RuleRow label="Max players per team" value={rules.max_players_per_team} />
-                <RuleRow label="Allow multi-team finals" value={rules.allow_multi_team_finals ? 'Yes' : 'No'} />
-                <RuleRow label="Move timeout" value={`${rules.move_timeout_ms} ms`} />
-                <RuleRow label="Auto-move after timeouts" value={rules.auto_move_after_timeouts} />
-                <RuleRow label="Max concurrent games per team" value={rules.max_concurrent_games_per_team} />
-                <RuleRow label="Fallback player tag" value={rules.fallback_player_tag} />
+                {tournaments.map((t) => (
+                  <TournamentRowView key={t.index} t={t} cid={cid} nameOf={nameOf} navigate={navigate} />
+                ))}
               </tbody>
             </table>
           </div>
-        </>
-      )}
 
-      <h2>Tournaments ({data.tournaments.length})</h2>
-      <div className="card-surface">
-        <table className="data">
-          <thead>
-            <tr>
-              <th>Index</th>
-              <th>Start time</th>
-              <th>Duration</th>
-              <th>1st place</th>
-              <th>2nd place</th>
-              <th>3rd place</th>
-              <th>4th place</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tournaments.map((t) => (
-              <TournamentRowView key={t.index} t={t} cid={cid} nameOf={nameOf} navigate={navigate} />
-            ))}
-          </tbody>
-        </table>
+          {/* Next-tournament registration — below the competition info when NOT
+              in TV view (the last-tournament section that hosts it is hidden). */}
+          {!castMode && isLiveCompetition && (
+            <div style={{ marginTop: 16 }}>
+              <NextTournamentBanner />
+            </div>
+          )}
+        </div>
+
+        {/* Last/current tournament section (right in TV view) — TV mode only,
+            since the same detail is available on the tournament page itself.
+            The next-tournament banner sits beneath it here. */}
+        {castMode && (
+          <div>
+            <LiveStatsPanel cid={data.competition_id} />
+            {isLiveCompetition && <NextTournamentBanner />}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/frontend/src/pages/CompetitionDetail.tsx
+++ b/web/frontend/src/pages/CompetitionDetail.tsx
@@ -1,9 +1,14 @@
 import { useMemo } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import { api, type TournamentRow } from '../api/client'
-import { useFetch } from '../lib/useFetch'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { api, type TournamentRow, type TournamentSummary } from '../api/client'
+import { useFetch, usePoll } from '../lib/useFetch'
 import { nameResolver } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
+import { LineChart } from '../components/LineChart'
+import { competitionSeries } from '../lib/chartData'
+import { LiveStatsPanel } from './LiveStats'
+
+const SUMMARY_REFRESH_MS = 15000
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—'
@@ -24,8 +29,20 @@ function formatLength(seconds: number | null): string {
 
 export function CompetitionDetail() {
   const { cid = '' } = useParams()
-  const { data, loading, error } = useFetch(() => api.competition(cid), [cid])
+  // Poll so a live competition's placements/standings refresh on their own,
+  // which also keeps the TV-cast view current without interaction.
+  const { data, loading, error } = usePoll(() => api.competition(cid), SUMMARY_REFRESH_MS, [cid])
   const navigate = useNavigate()
+
+  const [params, setParams] = useSearchParams()
+  const stage: 'qualifying' | 'finals' = params.get('cstage') === 'qualifying' ? 'qualifying' : 'finals'
+  const castMode = params.get('cast') === '1'
+  const setParam = (key: string, value: string | null) => {
+    const next = new URLSearchParams(params)
+    if (value == null) next.delete(key)
+    else next.set(key, value)
+    setParams(next, { replace: false })
+  }
 
   const nameOf = useMemo(() => {
     const ids: string[] = []
@@ -48,20 +65,83 @@ export function CompetitionDetail() {
     [cid, rulesIndex],
   )
 
-  if (loading) return <p className="muted">Loading…</p>
-  if (error) return <p className="muted">Error: {error}</p>
+  // Fetch every tournament's per-game summary so we can chart the competition
+  // arc. Polls alongside the detail so the in-progress tournament's points keep
+  // climbing on screen.
+  const indexKey = tournaments.map((t) => t.index).join(',')
+  const { data: summaries } = usePoll<TournamentSummary[]>(
+    () =>
+      tournaments.length
+        ? Promise.all(tournaments.map((t) => api.tournament(cid, t.index)))
+        : Promise.resolve([]),
+    SUMMARY_REFRESH_MS,
+    [cid, indexKey],
+  )
+
+  const series = useMemo(() => {
+    if (!summaries || !summaries.length) return []
+    const perTournament = summaries.map((s, i) => ({
+      index: Number(tournaments[i]?.index ?? i + 1),
+      games: stage === 'finals' ? s.finals : s.qualifying,
+    }))
+    return competitionSeries(perTournament)
+  }, [summaries, indexKey, stage])
+
+  const xTicks = useMemo(() => tournaments.map((t) => Number(t.index)), [indexKey])
+
+  if (loading && !data) return <p className="muted">Loading…</p>
+  if (error && !data) return <p className="muted">Error: {error}</p>
   if (!data) return <p className="muted">Not found.</p>
 
   const title = data.is_legacy ? 'Ungrouped tournaments (legacy)' : `Competition ${data.competition_id}`
+  const hasChart = series.length > 0
+
+  const chartCard = (
+    <div className="card-surface">
+      <div className="chart-controls">
+        <strong style={{ fontSize: 14 }}>Top player per team, by tournament</strong>
+        <span className="chart-controls__spacer" />
+        <button
+          className={`btn${stage === 'qualifying' ? ' btn--active' : ''}`}
+          onClick={() => setParam('cstage', 'qualifying')}
+        >
+          Qualifying
+        </button>
+        <button
+          className={`btn${stage === 'finals' ? ' btn--active' : ''}`}
+          onClick={() => setParam('cstage', null)}
+        >
+          Finals
+        </button>
+      </div>
+      <LineChart
+        series={series}
+        big={castMode}
+        height={castMode ? 380 : 320}
+        xLabel="Tournament"
+        yLabel="Avg tournament points"
+        xTicks={xTicks}
+        xTickFormat={(x) => `#${x}`}
+      />
+    </div>
+  )
 
   return (
-    <div>
-      <div className="crumbs">
-        <Link to="/">Competitions</Link> / {data.is_legacy ? 'legacy' : data.competition_id}
-      </div>
-      <h1>{title}</h1>
+    <div className={castMode ? 'cast-mode' : undefined}>
+      {!castMode && (
+        <div className="crumbs">
+          <Link to="/">Competitions</Link> / {data.is_legacy ? 'legacy' : data.competition_id}
+        </div>
+      )}
 
-      <div className="muted" style={{ marginTop: -8, marginBottom: 12, fontSize: 13 }}>
+      <div className="cast-toggle-row" style={{ justifyContent: 'space-between', marginBottom: 8 }}>
+        <h1 style={{ margin: 0 }}>{title}</h1>
+        <button className={`btn${castMode ? ' btn--active' : ''}`} onClick={() => setParam('cast', castMode ? null : '1')}>
+          {castMode ? 'Exit TV view' : 'TV view'}
+        </button>
+      </div>
+
+      <div className="muted" style={{ marginBottom: 12, fontSize: 13 }}>
         {!data.is_legacy && <>Started {formatTime(data.started_at)} · </>}
         {data.qualifying_games != null && (
           <>
@@ -69,9 +149,21 @@ export function CompetitionDetail() {
           </>
         )}
         Teams: {data.teams.length > 0 ? data.teams.join(', ') : '—'}
+        {castMode && <> · auto-refreshing every {SUMMARY_REFRESH_MS / 1000}s</>}
       </div>
 
-      {rules && (
+      {/* Live standings for THIS competition (only when it's the one running). */}
+      <LiveStatsPanel cid={data.competition_id} />
+
+      {/* Competition arc chart. */}
+      {hasChart && (
+        <>
+          <h2>Competition overview</h2>
+          {chartCard}
+        </>
+      )}
+
+      {rules && !castMode && (
         <>
           <h2>Rules</h2>
           <div className="card-surface">
@@ -152,7 +244,7 @@ function TournamentRowView({
     >
       <td>
         #{t.index}
-        {!t.complete && <span className="muted" style={{ fontSize: 11 }}> (in progress)</span>}
+        {!t.complete && <span className="badge-live">● Live</span>}
       </td>
       <td>{t.began_at ? new Date(t.began_at).toLocaleString() : '—'}</td>
       <td className="muted">{formatLength(t.length_seconds)}</td>

--- a/web/frontend/src/pages/CompetitionDetail.tsx
+++ b/web/frontend/src/pages/CompetitionDetail.tsx
@@ -1,14 +1,18 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
-import { api, type TournamentRow, type TournamentSummary } from '../api/client'
+import { api, type GameSummary, type TournamentRow, type TournamentSummary } from '../api/client'
 import { useFetch, usePoll } from '../lib/useFetch'
-import { nameResolver } from '../lib/playerId'
+import { nameResolver, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
 import { LineChart } from '../components/LineChart'
-import { competitionSeries } from '../lib/chartData'
+import { competitionSeries, playerAvgsForGames } from '../lib/chartData'
 import { LiveStatsPanel } from './LiveStats'
+import { NextTournamentBanner } from './NextTournament'
 
 const SUMMARY_REFRESH_MS = 15000
+// The competition arc chart refreshes every second so an in-progress tournament's
+// points climb live (per PR #86 review).
+const CHART_REFRESH_MS = 1000
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—'
@@ -36,6 +40,8 @@ export function CompetitionDetail() {
 
   const [params, setParams] = useSearchParams()
   const stage: 'qualifying' | 'finals' = params.get('cstage') === 'qualifying' ? 'qualifying' : 'finals'
+  // Averaging window for the chart: full tournament, or a rolling 10-game window.
+  const windowSize = params.get('cwin') === '10' ? 10 : undefined
   const castMode = params.get('cast') === '1'
   const setParam = (key: string, value: string | null) => {
     const next = new URLSearchParams(params)
@@ -74,18 +80,43 @@ export function CompetitionDetail() {
       tournaments.length
         ? Promise.all(tournaments.map((t) => api.tournament(cid, t.index)))
         : Promise.resolve([]),
-    SUMMARY_REFRESH_MS,
+    CHART_REFRESH_MS,
     [cid, indexKey],
   )
 
-  const series = useMemo(() => {
+  // Is THIS competition the one currently running? Used to scope the next-up
+  // registration banner to the competition it belongs to.
+  const { data: live } = usePoll(() => api.live(), SUMMARY_REFRESH_MS, [])
+  const isLiveCompetition = !!live?.competition_id && live.competition_id === data?.competition_id
+
+  const perTournament = useMemo(() => {
     if (!summaries || !summaries.length) return []
-    const perTournament = summaries.map((s, i) => ({
+    return summaries.map((s, i) => ({
       index: Number(tournaments[i]?.index ?? i + 1),
       games: stage === 'finals' ? s.finals : s.qualifying,
     }))
-    return competitionSeries(perTournament)
   }, [summaries, indexKey, stage])
+
+  const series = useMemo(() => competitionSeries(perTournament, windowSize), [perTournament, windowSize])
+
+  // Lookup of a tournament index -> its (stage-filtered) games, so clicking a
+  // chart point can list every player's average in that tournament.
+  const gamesByIndex = useMemo(() => {
+    const m = new Map<number, GameSummary[]>()
+    for (const t of perTournament) m.set(t.index, t.games)
+    return m
+  }, [perTournament])
+
+  const pointDetails = useCallback(
+    (x: number) =>
+      playerAvgsForGames(gamesByIndex.get(x) ?? [], windowSize).map((pa) => ({
+        id: pa.key,
+        label: `${pa.team} / ${pa.tag}`,
+        color: teamColor(pa.team),
+        value: pa.avg,
+      })),
+    [gamesByIndex, windowSize],
+  )
 
   const xTicks = useMemo(() => tournaments.map((t) => Number(t.index)), [indexKey])
 
@@ -113,6 +144,19 @@ export function CompetitionDetail() {
         >
           Finals
         </button>
+        <span style={{ width: 12 }} />
+        <button
+          className={`btn${windowSize === undefined ? ' btn--active' : ''}`}
+          onClick={() => setParam('cwin', null)}
+        >
+          Full avg
+        </button>
+        <button
+          className={`btn${windowSize === 10 ? ' btn--active' : ''}`}
+          onClick={() => setParam('cwin', '10')}
+        >
+          Last 10
+        </button>
       </div>
       <LineChart
         series={series}
@@ -122,6 +166,8 @@ export function CompetitionDetail() {
         yLabel="Avg tournament points"
         xTicks={xTicks}
         xTickFormat={(x) => `#${x}`}
+        pointDetails={pointDetails}
+        detailTitle={(x) => `Tournament #${x} — players by avg`}
       />
     </div>
   )
@@ -151,6 +197,10 @@ export function CompetitionDetail() {
         Teams: {data.teams.length > 0 ? data.teams.join(', ') : '—'}
         {castMode && <> · auto-refreshing every {SUMMARY_REFRESH_MS / 1000}s</>}
       </div>
+
+      {/* Registration countdown for the next tournament — only while THIS
+          competition is the one currently running. */}
+      {isLiveCompetition && <NextTournamentBanner />}
 
       {/* Live standings for THIS competition (only when it's the one running). */}
       <LiveStatsPanel cid={data.competition_id} />

--- a/web/frontend/src/pages/CompetitionsList.tsx
+++ b/web/frontend/src/pages/CompetitionsList.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { api } from '../api/client'
 import { useFetch, usePoll } from '../lib/useFetch'
-import { NextTournamentBanner } from './NextTournament'
 
 function formatTime(iso: string | null): string {
   if (!iso) return '—'
@@ -21,7 +20,6 @@ export function CompetitionsList() {
 
   return (
     <div>
-      <NextTournamentBanner />
       <h1>Competitions</h1>
       {loading ? (
         <p className="muted">Loading competitions…</p>

--- a/web/frontend/src/pages/CompetitionsList.tsx
+++ b/web/frontend/src/pages/CompetitionsList.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { api } from '../api/client'
-import { useFetch } from '../lib/useFetch'
-import { LiveStatsPanel } from './LiveStats'
+import { useFetch, usePoll } from '../lib/useFetch'
 import { NextTournamentBanner } from './NextTournament'
 
 function formatTime(iso: string | null): string {
@@ -10,14 +9,19 @@ function formatTime(iso: string | null): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
 }
 
+const LIVE_REFRESH_MS = 5000
+
 export function CompetitionsList() {
   const { data, loading, error } = useFetch(() => api.competitions(), [])
+  // The currently-running competition (if any), so we can badge it as live. Polls
+  // quietly; `{}`/null just means nothing is running right now.
+  const { data: live } = usePoll(() => api.live(), LIVE_REFRESH_MS, [])
+  const ongoingCid = live?.competition_id ?? null
   const navigate = useNavigate()
 
   return (
     <div>
       <NextTournamentBanner />
-      <LiveStatsPanel />
       <h1>Competitions</h1>
       {loading ? (
         <p className="muted">Loading competitions…</p>
@@ -38,14 +42,19 @@ export function CompetitionsList() {
             </tr>
           </thead>
           <tbody>
-            {data.map((c) => (
+            {data.map((c) => {
+              const ongoing = !c.is_legacy && c.competition_id === ongoingCid
+              return (
               <tr
                 key={c.competition_id}
                 className="row-link"
                 onClick={() => navigate(`/c/${encodeURIComponent(c.competition_id)}`)}
               >
                 <td>{c.is_legacy ? <span className="muted">—</span> : formatTime(c.started_at)}</td>
-                <td>{c.is_legacy ? 'Ungrouped (legacy)' : c.competition_id}</td>
+                <td>
+                  {c.is_legacy ? 'Ungrouped (legacy)' : c.competition_id}
+                  {ongoing && <span className="badge-live">● Live</span>}
+                </td>
                 <td style={{ fontSize: 12 }}>
                   {c.teams.length > 0 ? (
                     c.teams.map((t, i) => (
@@ -65,7 +74,8 @@ export function CompetitionsList() {
                     : '—'}
                 </td>
               </tr>
-            ))}
+              )
+            })}
           </tbody>
         </table>
       </div>

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api, type GameSummary } from '../api/client'
+import { api, gamePlayers, type GameSummary } from '../api/client'
 import { usePoll } from '../lib/useFetch'
-import { nameResolver, teamColor } from '../lib/playerId'
-import { PlayerName } from '../components/PlayerName'
+import { teamColor } from '../lib/playerId'
+import { teamOf } from '../lib/aggregate'
 import { LineChart } from '../components/LineChart'
 import { tournamentCumulativeSeries, playerAvgsThroughGame } from '../lib/chartData'
 
@@ -11,22 +11,50 @@ const REFRESH_MS = 5000
 // The live cumulative chart refreshes every second (per PR #86 review).
 const CHART_REFRESH_MS = 1000
 
-function elapsedSince(iso: string | null): string {
+function formatStart(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString()
+}
+
+function runningFor(iso: string | null): string {
   if (!iso) return '—'
   const start = new Date(iso).getTime()
-  if (Number.isNaN(start)) return iso
-  const ms = Date.now() - start
-  const mins = Math.floor(ms / 60000)
+  if (Number.isNaN(start)) return '—'
+  const mins = Math.max(0, Math.floor((Date.now() - start) / 60000))
   const h = Math.floor(mins / 60)
   const m = mins % 60
-  return h > 0 ? `${h}h ${m}m ago` : `${m}m ago`
+  return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+/** Each team's average tournament points per game across `games`. */
+function teamAvgPoints(games: GameSummary[]): Record<string, number> {
+  const sum: Record<string, number> = {}
+  const cnt: Record<string, number> = {}
+  for (const g of games) {
+    const per: Record<string, number> = {}
+    for (const p of gamePlayers(g)) per[teamOf(p.id)] = (per[teamOf(p.id)] ?? 0) + p.tournament_points
+    for (const [t, v] of Object.entries(per)) {
+      sum[t] = (sum[t] ?? 0) + v
+      cnt[t] = (cnt[t] ?? 0) + 1
+    }
+  }
+  const avg: Record<string, number> = {}
+  for (const t of Object.keys(sum)) avg[t] = sum[t] / cnt[t]
+  return avg
+}
+
+interface TeamStandingRow {
+  team: string
+  qual: number | null
+  finals: number | null
 }
 
 // Embeddable live panel. Renders nothing until there is an in-progress
 // tournament. Pass `cid` to scope it to a single competition — it then renders
 // only when that competition is the one currently running.
 export function LiveStatsPanel({ cid }: { cid?: string } = {}) {
-  const { data, error } = usePoll(() => api.live(), REFRESH_MS, [])
+  const { data } = usePoll(() => api.live(), REFRESH_MS, [])
 
   // The live tournament's per-game cumulative chart. Hooks must run every render
   // (before the early returns), so they tolerate a not-yet-loaded `data`.
@@ -47,46 +75,72 @@ export function LiveStatsPanel({ cid }: { cid?: string } = {}) {
     () => tournamentCumulativeSeries(chartGames, chartWindow),
     [chartGames, chartWindow],
   )
-  const chartDetails = useCallback(
-    (x: number) =>
-      playerAvgsThroughGame(chartGames, x, chartWindow).map((pa) => ({
-        id: pa.key,
-        label: `${pa.team} / ${pa.tag}`,
-        color: teamColor(pa.team),
-        value: pa.avg,
-      })),
-    [chartGames, chartWindow],
-  )
+  const chartDetails = (x: number) =>
+    playerAvgsThroughGame(chartGames, x, chartWindow).map((pa) => ({
+      id: pa.key,
+      label: `${pa.team} / ${pa.tag}`,
+      color: teamColor(pa.team),
+      value: pa.avg,
+    }))
+
+  // Team standings: qualified teams (those with finals games) ranked by finals
+  // score, the rest by qualifying score. Once finals start, a divider separates
+  // the qualified four from everyone else.
+  const standings = useMemo(() => {
+    if (!summary) return { rows: [] as TeamStandingRow[], dividerAt: -1 }
+    const qualAvg = teamAvgPoints(summary.qualifying)
+    const finalsAvg = teamAvgPoints(summary.finals)
+    const finalsStarted = summary.finals.length > 0
+    const teams = new Set<string>([...Object.keys(qualAvg), ...Object.keys(finalsAvg)])
+    const qualified = [...teams]
+      .filter((t) => finalsAvg[t] !== undefined)
+      .sort((a, b) => finalsAvg[b] - finalsAvg[a] || a.localeCompare(b))
+    const others = [...teams]
+      .filter((t) => finalsAvg[t] === undefined)
+      .sort((a, b) => (qualAvg[b] ?? 0) - (qualAvg[a] ?? 0) || a.localeCompare(b))
+    const rows: TeamStandingRow[] = [...qualified, ...others].map((team) => ({
+      team,
+      qual: qualAvg[team] ?? null,
+      finals: finalsAvg[team] ?? null,
+    }))
+    return { rows, dividerAt: finalsStarted ? qualified.length : -1 }
+  }, [summary])
 
   if (!data || !data.competition_id || !data.tournament_index) return null
   if (cid && data.competition_id !== cid) return null
 
-  const standings = Object.entries(data.standings).sort((a, b) => b[1] - a[1])
-  const nameOf = nameResolver(standings.map(([p]) => p))
-
   return (
     <div style={{ marginBottom: 28 }}>
-      <h1>Live tournament stats</h1>
-      <p className="muted" style={{ marginTop: -8 }}>
-        Current tournament:{' '}
-        <Link
-          to={`/c/${encodeURIComponent(data.competition_id)}/t/${encodeURIComponent(data.tournament_index)}`}
-        >
-          {data.competition_id} · #{data.tournament_index}
+      <h1 style={{ marginTop: 0 }}>
+        <Link to={`/c/${encodeURIComponent(data.competition_id)}/t/${encodeURIComponent(data.tournament_index)}`}>
+          Tournament #{data.tournament_index}
         </Link>
-        <span style={{ marginLeft: 8, fontSize: 12 }}>
-          · auto-refreshing every {REFRESH_MS / 1000}s{error ? ' (reconnecting…)' : ''}
-        </span>
-      </p>
+      </h1>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 }}>
-        <Stat label="Began" value={elapsedSince(data.began_at)} />
-        <Stat label="Teams" value={String(data.num_teams)} />
+        <Stat label="Started" value={formatStart(data.began_at)} />
+        <Stat label="Running for" value={runningFor(data.began_at)} />
+      </div>
+
+      <h2>Games progress</h2>
+      <div className="card-surface">
+        <StageProgress
+          label="Qualifying"
+          done={data.qualifying_executed}
+          total={data.planned_qualifying_games}
+          color="#2a5bd7"
+        />
+        <StageProgress
+          label="Finals"
+          done={data.finals_executed}
+          total={data.planned_finals_games}
+          color="#1c9c7c"
+        />
       </div>
 
       {chartSeries.length > 0 && (
         <>
-          <h2>Cumulative tournament points by team (live)</h2>
+          <h2>Cumulative tournament points by team</h2>
           <div className="card-surface">
             <div className="chart-controls">
               <button
@@ -128,50 +182,32 @@ export function LiveStatsPanel({ cid }: { cid?: string } = {}) {
         </>
       )}
 
-      <h2>Games progress</h2>
-      <div className="card-surface">
-        <StageProgress
-          label="Qualifying"
-          done={data.qualifying_executed}
-          total={data.planned_qualifying_games}
-          color="#2a5bd7"
-        />
-        <StageProgress
-          label="Finals"
-          done={data.finals_executed}
-          total={data.planned_finals_games}
-          color="#1c9c7c"
-        />
-      </div>
-
-      <h2>Teams registered</h2>
-      <div className="card-surface">
-        {data.teams.map((t) => (
-          <span key={t.name} className="pill" style={{ marginRight: 6 }}>
-            {t.name}
-          </span>
-        ))}
-      </div>
-
       <h2>Current standings</h2>
       <div className="card-surface">
         <table className="data">
           <thead>
             <tr>
               <th>#</th>
-              <th>Player</th>
-              <th>Tournament points</th>
-              <th>Games won</th>
+              <th>Team</th>
+              <th>Avg qualifying score</th>
+              <th>Avg finals score</th>
             </tr>
           </thead>
           <tbody>
-            {standings.map(([player, pts], i) => (
-              <tr key={player}>
-                <td>{i + 1}</td>
-                <td><PlayerName d={nameOf(player)} /></td>
-                <td>{pts}</td>
-                <td>{data.games_won?.[player] ?? 0}</td>
-              </tr>
+            {standings.rows.map((r, i) => (
+              <Fragment key={r.team}>
+                {i === standings.dividerAt && (
+                  <tr className="standings-divider">
+                    <td colSpan={4}>Did not qualify for finals</td>
+                  </tr>
+                )}
+                <tr>
+                  <td>{i + 1}</td>
+                  <td style={{ color: teamColor(r.team), fontWeight: 600 }}>{r.team}</td>
+                  <td>{r.qual != null ? r.qual.toFixed(2) : '—'}</td>
+                  <td>{r.finals != null ? r.finals.toFixed(2) : '—'}</td>
+                </tr>
+              </Fragment>
             ))}
           </tbody>
         </table>

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -1,10 +1,15 @@
+import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api } from '../api/client'
+import { api, type GameSummary } from '../api/client'
 import { usePoll } from '../lib/useFetch'
-import { nameResolver } from '../lib/playerId'
+import { nameResolver, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
+import { LineChart } from '../components/LineChart'
+import { tournamentCumulativeSeries, playerAvgsThroughGame } from '../lib/chartData'
 
 const REFRESH_MS = 5000
+// The live cumulative chart refreshes every second (per PR #86 review).
+const CHART_REFRESH_MS = 1000
 
 function elapsedSince(iso: string | null): string {
   if (!iso) return '—'
@@ -22,6 +27,36 @@ function elapsedSince(iso: string | null): string {
 // only when that competition is the one currently running.
 export function LiveStatsPanel({ cid }: { cid?: string } = {}) {
   const { data, error } = usePoll(() => api.live(), REFRESH_MS, [])
+
+  // The live tournament's per-game cumulative chart. Hooks must run every render
+  // (before the early returns), so they tolerate a not-yet-loaded `data`.
+  const [chartStage, setChartStage] = useState<'qualifying' | 'finals'>('qualifying')
+  const [chartWindow, setChartWindow] = useState<number | undefined>(undefined)
+  const liveCid = data?.competition_id ?? ''
+  const liveIdx = data?.tournament_index ?? ''
+  const { data: summary } = usePoll(
+    () => (liveCid && liveIdx ? api.tournament(liveCid, liveIdx) : Promise.resolve(null)),
+    CHART_REFRESH_MS,
+    [liveCid, liveIdx],
+  )
+  const chartGames: GameSummary[] = useMemo(
+    () => (!summary ? [] : chartStage === 'finals' ? summary.finals : summary.qualifying),
+    [summary, chartStage],
+  )
+  const chartSeries = useMemo(
+    () => tournamentCumulativeSeries(chartGames, chartWindow),
+    [chartGames, chartWindow],
+  )
+  const chartDetails = useCallback(
+    (x: number) =>
+      playerAvgsThroughGame(chartGames, x, chartWindow).map((pa) => ({
+        id: pa.key,
+        label: `${pa.team} / ${pa.tag}`,
+        color: teamColor(pa.team),
+        value: pa.avg,
+      })),
+    [chartGames, chartWindow],
+  )
 
   if (!data || !data.competition_id || !data.tournament_index) return null
   if (cid && data.competition_id !== cid) return null
@@ -48,6 +83,50 @@ export function LiveStatsPanel({ cid }: { cid?: string } = {}) {
         <Stat label="Began" value={elapsedSince(data.began_at)} />
         <Stat label="Teams" value={String(data.num_teams)} />
       </div>
+
+      {chartSeries.length > 0 && (
+        <>
+          <h2>Cumulative tournament points by team (live)</h2>
+          <div className="card-surface">
+            <div className="chart-controls">
+              <button
+                className={`btn${chartStage === 'qualifying' ? ' btn--active' : ''}`}
+                onClick={() => setChartStage('qualifying')}
+              >
+                Qualifying
+              </button>
+              <button
+                className={`btn${chartStage === 'finals' ? ' btn--active' : ''}`}
+                onClick={() => setChartStage('finals')}
+              >
+                Finals
+              </button>
+              <span className="chart-controls__spacer" />
+              <button
+                className={`btn${chartWindow === undefined ? ' btn--active' : ''}`}
+                onClick={() => setChartWindow(undefined)}
+              >
+                Full avg
+              </button>
+              <button
+                className={`btn${chartWindow === 10 ? ' btn--active' : ''}`}
+                onClick={() => setChartWindow(10)}
+              >
+                Last 10
+              </button>
+            </div>
+            <LineChart
+              series={chartSeries}
+              height={300}
+              xLabel="Game index"
+              yLabel="Avg tournament points"
+              xTickFormat={(x) => String(x)}
+              pointDetails={chartDetails}
+              detailTitle={(x) => `Through game ${x} — players by avg`}
+            />
+          </div>
+        </>
+      )}
 
       <h2>Games progress</h2>
       <div className="card-surface">

--- a/web/frontend/src/pages/LiveStats.tsx
+++ b/web/frontend/src/pages/LiveStats.tsx
@@ -18,11 +18,13 @@ function elapsedSince(iso: string | null): string {
 }
 
 // Embeddable live panel. Renders nothing until there is an in-progress
-// tournament, so it can sit quietly at the top of the Competitions page.
-export function LiveStatsPanel() {
+// tournament. Pass `cid` to scope it to a single competition — it then renders
+// only when that competition is the one currently running.
+export function LiveStatsPanel({ cid }: { cid?: string } = {}) {
   const { data, error } = usePoll(() => api.live(), REFRESH_MS, [])
 
   if (!data || !data.competition_id || !data.tournament_index) return null
+  if (cid && data.competition_id !== cid) return null
 
   const standings = Object.entries(data.standings).sort((a, b) => b[1] - a[1])
   const nameOf = nameResolver(standings.map(([p]) => p))

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -1,11 +1,11 @@
-import { useMemo, type ReactNode } from 'react'
+import { useCallback, useMemo, type ReactNode } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { api, gamePlayers, type GameSummary } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver, playerSortKey, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
 import { LineChart } from '../components/LineChart'
-import { tournamentCumulativeSeries } from '../lib/chartData'
+import { tournamentCumulativeSeries, playerAvgsThroughGame } from '../lib/chartData'
 import {
   aggregate,
   allTeams,
@@ -52,6 +52,8 @@ export function TournamentDetail() {
   // an inclusion. Only affects not-yet-applied chips, so include and exclude
   // filters can coexist.
   const excludeMode = params.get('mode') === 'exclude'
+  // Averaging window for the cumulative chart: full tournament, or rolling 10.
+  const windowSize = params.get('win') === '10' ? 10 : undefined
   const minMoon = Number(params.get('minMoon')) || 0
   const page = Math.max(0, Number(params.get('page')) || 0)
   const sortKey = (params.get('sort') as SortKey) || 'rank'
@@ -76,7 +78,17 @@ export function TournamentDetail() {
 
   const teams = useMemo(() => allTeams(games), [games])
   const teamPlayers = useMemo(() => allTeamPlayers(games), [games])
-  const chartSeries = useMemo(() => tournamentCumulativeSeries(games), [games])
+  const chartSeries = useMemo(() => tournamentCumulativeSeries(games, windowSize), [games, windowSize])
+  const chartDetails = useCallback(
+    (x: number) =>
+      playerAvgsThroughGame(games, x, windowSize).map((pa) => ({
+        id: pa.key,
+        label: `${pa.team} / ${pa.tag}`,
+        color: teamColor(pa.team),
+        value: pa.avg,
+      })),
+    [games, windowSize],
+  )
 
   const keysToTPs = (keys: string[]): TeamPlayer[] =>
     keys.map((k) => {
@@ -273,12 +285,29 @@ export function TournamentDetail() {
         <>
           <h2>Cumulative tournament points by team</h2>
           <div className="card-surface">
+            <div className="chart-controls">
+              <span style={{ fontSize: 13 }} className="muted">Average window:</span>
+              <button
+                className={`btn${windowSize === undefined ? ' btn--active' : ''}`}
+                onClick={() => patch({ win: null })}
+              >
+                Full avg
+              </button>
+              <button
+                className={`btn${windowSize === 10 ? ' btn--active' : ''}`}
+                onClick={() => patch({ win: '10' })}
+              >
+                Last 10
+              </button>
+            </div>
             <LineChart
               series={chartSeries}
               height={300}
               xLabel="Game index"
-              yLabel="Cumulative avg tournament points"
+              yLabel={windowSize ? 'Rolling avg tournament points' : 'Cumulative avg tournament points'}
               xTickFormat={(x) => String(x)}
+              pointDetails={chartDetails}
+              detailTitle={(x) => `Through game ${x} — players by avg`}
             />
           </div>
         </>

--- a/web/frontend/src/pages/TournamentDetail.tsx
+++ b/web/frontend/src/pages/TournamentDetail.tsx
@@ -4,6 +4,8 @@ import { api, gamePlayers, type GameSummary } from '../api/client'
 import { useFetch } from '../lib/useFetch'
 import { nameResolver, playerSortKey, teamColor } from '../lib/playerId'
 import { PlayerName } from '../components/PlayerName'
+import { LineChart } from '../components/LineChart'
+import { tournamentCumulativeSeries } from '../lib/chartData'
 import {
   aggregate,
   allTeams,
@@ -74,6 +76,7 @@ export function TournamentDetail() {
 
   const teams = useMemo(() => allTeams(games), [games])
   const teamPlayers = useMemo(() => allTeamPlayers(games), [games])
+  const chartSeries = useMemo(() => tournamentCumulativeSeries(games), [games])
 
   const keysToTPs = (keys: string[]): TeamPlayer[] =>
     keys.map((k) => {
@@ -265,6 +268,21 @@ export function TournamentDetail() {
           Finals ({data.finals.length})
         </button>
       </div>
+
+      {chartSeries.length > 0 && (
+        <>
+          <h2>Cumulative tournament points by team</h2>
+          <div className="card-surface">
+            <LineChart
+              series={chartSeries}
+              height={300}
+              xLabel="Game index"
+              yLabel="Cumulative avg tournament points"
+              xTickFormat={(x) => String(x)}
+            />
+          </div>
+        </>
+      )}
 
       <h2>Filter &amp; aggregate</h2>
       <div className="card-surface">


### PR DESCRIPTION
Closes #84.

Adds competition-level summaries, line charts, and a TV-castable competition view.

## What's included
1. **Generic SVG line chart** (`components/LineChart.tsx`) — hand-rolled (no chart lib), with nice-rounded axis ticks, a legend, per-point tooltips, optional fixed x-ticks, and a `big` mode for TV-cast readability.
2. **Chart-aggregation helpers** (`lib/chartData.ts`):
   - `competitionSeries` — per team, its top-performing player's avg tournament points in each tournament.
   - `tournamentCumulativeSeries` — per team, cumulative avg tournament points by game index (carries forward across sat-out games for continuous lines).
3. **CompetitionDetail**:
   - **Competition overview chart** above the tournament list: x = tournament index, y = avg tournament points, one series per team (labelled + colored by team), with a qualifying/finals toggle that **defaults to finals**.
   - **Live tournament stats relocated here** and scoped to this competition — the panel only renders when this competition is the one currently running.
   - **TV-cast mode** (`?cast=1`, toggled by a "TV view" button): a full-screen, dark, larger-type, auto-refreshing layout summarizing the chart, current standings, and historical placements for passive viewing.
   - Per-tournament rows show a pulsing **Live** badge while in progress.
4. **CompetitionsList**: removed the global live-stats panel (now lives under its competition); added a **Live** badge on the currently-running competition.
5. **TournamentDetail**: a per-tournament **cumulative points by team** chart driven by the existing stage toggle — so the live tournament gets it too.

## Implementation
- Competition charts fetch each tournament's summary (`api.tournament`) and poll (15s) so an in-progress competition's points climb live without interaction.
- `LiveStatsPanel` gained an optional `cid` prop to scope it to a single competition.
- Charts scale to their container via `viewBox`, capped in width so the fixed aspect ratio stays sane on a wide TV.

## Notes / limitations
- "Ongoing" badge is driven by the live-tournament status endpoint (the meaningful currently-running signal), not a per-tournament scan of every competition in the list.
- Cast mode is a fixed full-screen overlay; "Exit TV view" (or removing `?cast=1`) returns to the normal page.

## Test plan
- [x] `npm run build` (tsc + vite) green
- [ ] Manual: open a competition with finished tournaments — confirm the overview chart shows one line per team, finals by default, toggling to qualifying
- [ ] Manual: during a live tournament, confirm the competition page shows live standings + the in-progress chart updating, and the competitions list badges it
- [ ] Manual: enable TV view and confirm it is large, dark, auto-refreshing, and readable from a distance
- [ ] Manual: open a tournament — confirm the cumulative-by-team chart and its stage toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
