### PR TITLE
#89: handle client disconnect gracefully (no server crash)

### DIFF
--- a/server/tournament_server.cpp
+++ b/server/tournament_server.cpp
@@ -938,6 +938,22 @@ static void writeResults(
 
 static std::atomic<PlayerGameSessionID> gameSessionCounter{100000};
 
+// Deliver a control/notification message to a queued client, swallowing the
+// network errors (broken pipe / connection reset) that arise when that client
+// has already disconnected. A client dropping out must never abort a broadcast
+// to the others — or, worse, escape its thread and std::terminate the whole
+// server (the bug behind issue #89).
+static void trySendControl(const std::shared_ptr<PlayerGameSession>& session,
+                           Message::Message message, const char* what)
+{
+    if (!session) return;
+    try {
+        session->send(std::move(message));
+    } catch (const std::exception& e) {
+        LOG("Could not deliver %s to a disconnected client: %s", what, e.what());
+    }
+}
+
 static GameResult runOneGame(
     const GameAssignment& assignment,
     const std::string& resultsDir,
@@ -976,12 +992,15 @@ static GameResult runOneGame(
         observer->result.playerTagToSlotId[tagSession] = slot->slotId;
         observer->result.playerOrder.push_back(tagSession); // actual seating order
 
-        slot->source->controlSession->send({{
+        // A client that has dropped since registering would throw "broken pipe"
+        // here; tolerate it so the game still starts for the other seats (the
+        // absent player simply times out and is auto-played).
+        trySendControl(slot->source->controlSession, {{
             {Tags::TYPE,                        ServerMsgTypes::Tournament::GAME_ASSIGNMENT},
             {Tags::Tournament::GAME_SESSION_ID, (long long)sid},
             {Tags::Tournament::GAME_ID,         assignment.gameId},
             {Tags::Tournament::STAGE,           assignment.stage}
-        }});
+        }}, "game assignment");
 
         sessions.push_back(session);
         players.push_back(std::make_shared<RemotePlayer>(
@@ -1310,11 +1329,11 @@ int main(int argc, char** argv)
         std::lock_guard<std::mutex> lock(lobby.mtx);
         for (auto& rp : lobby.players)
         {
-            rp.controlSession->send({{
+            trySendControl(rp.controlSession, {{
                 {Tags::TYPE, ServerMsgTypes::Tournament::STAGE_COMPLETE},
                 {"stage", "qualifying"},
                 {Tags::Tournament::RESULTS, stageResult}
-            }});
+            }}, "stage-complete notice");
         }
     }
 
@@ -1447,10 +1466,10 @@ int main(int argc, char** argv)
         std::lock_guard<std::mutex> lock(lobby.mtx);
         for (auto& rp : lobby.players)
         {
-            rp.controlSession->send({{
+            trySendControl(rp.controlSession, {{
                 {Tags::TYPE, ServerMsgTypes::Tournament::COMPLETE},
                 {Tags::Tournament::RESULTS, completeMsg}
-            }});
+            }}, "tournament-complete notice");
         }
     }
 


### PR DESCRIPTION
## Summary
Closes #89. A queued client dropping mid-tournament aborted the whole server with `SIGABRT` — `terminating due to uncaught exception of type boost::wrapexcept<boost::system::system_error>: write: Broken pipe` (exit code -6), killing every concurrent game.

**Root cause:** in-game writes are wrapped by `Game::runGame`'s try/catch, but three control-plane writes were not, and they run on the orchestration thread or a game worker thread:
- the per-game `GAME_ASSIGNMENT` message (`runOneGame`, before its own `try`)
- the `STAGE_COMPLETE` broadcast to all queued clients
- the `COMPLETE` broadcast to all queued clients

When a recipient had already disconnected, the throwing boost `write()` raised a broken-pipe exception that escaped its thread and called `std::terminate`.

## Fix
Route those sends through a new `trySendControl()` helper that catches the broken-pipe / connection-reset errors from a dead client and logs instead of propagating. A dropped player now simply times out and is auto-played; the game and the rest of the tournament finish normally for everyone else. No behavior change when all clients are connected.

## Test plan
- [x] `bazel build //server:tournament_server` compiles clean.
- [ ] CI: GTests, Integration Tests, Web UI.
- [ ] Manual: register clients to a tournament, kill one mid-game, confirm the server logs "Could not deliver … to a disconnected client" and keeps running to completion instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
