### PR TITLE
Slim tournament summary endpoint: drop unused per-game latency (~54% of payload)

### DIFF
--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -76,7 +76,9 @@ def competition_live(competition_id: str):
 
 @app.get("/api/competitions/{competition_id}/tournaments/{index}")
 def tournament(competition_id: str, index: str):
-    summary = results.get_summary(competition_id, index)
+    # Serve the slimmed summary (heavy unused per-game latency fields dropped) so
+    # large tournaments load quickly; the page reads aggregated stats instead.
+    summary = results.get_summary_web(competition_id, index)
     if summary is None:
         raise HTTPException(status_code=404, detail="tournament not found")
     return summary

--- a/web/backend/results.py
+++ b/web/backend/results.py
@@ -316,6 +316,28 @@ def get_summary(competition_id: str, index: str) -> Optional[dict]:
     return _read_json(tdir / "summary.json")
 
 
+# Per-game fields the web UI never reads. The tournament page shows aggregated
+# move-time stats from the small top-level "player_stats" object, so the verbose
+# per-game latency breakdown is pure dead weight on the wire — together these two
+# are ~half the summary.json bytes for a large tournament. Stripping them before
+# serving (alongside gzip) roughly halves the payload and the client-side JSON
+# parse, which was the dominant tournament-page load cost.
+_HEAVY_GAME_FIELDS = ("latency", "total_move_latency_ms")
+
+
+def get_summary_web(competition_id: str, index: str) -> Optional[dict]:
+    """get_summary() projected down to what the web tournament page needs:
+    the same document with the unused heavy per-game latency fields removed."""
+    summary = get_summary(competition_id, index)
+    if summary is None:
+        return None
+    for stage in ("qualifying", "finals"):
+        for game in summary.get(stage, []):
+            for field in _HEAVY_GAME_FIELDS:
+                game.pop(field, None)
+    return summary
+
+
 def get_rules(competition_id: str, index: str) -> Optional[dict]:
     tdir = _tournament_dir(competition_id, index)
     if tdir is None:


### PR DESCRIPTION
Closes #95. Follow-up to #92.

## Summary
After #92 added gzip, the big tournament at `c/2026-6-3_21-59-24.339/t/1` was still slow. Profiling the 4.6 MB `summary.json` showed the cause isn't rendering or client compute (only 6 teams/players here) — it's the payload: **two per-game fields the web UI never reads make up ~54% of it.**

- per-game `latency` (per-slot s2c/c2s/think breakdown) — ~41%
- per-game `total_move_latency_ms` — ~13%

The tournament page shows move-time stats from the small aggregated top-level `player_stats`, so the per-game latency is dead weight on the wire and in the client's JSON parse.

This projects those two fields out of the tournament-summary **endpoint** response via a new `get_summary_web()`. The on-disk `summary.json` and the per-game detail endpoint are untouched, so nothing else changes.

## Measured (example 2102-game tournament)
| | size |
|---|---|
| raw `summary.json` | 4.61 MB |
| slimmed, minified (what FastAPI serializes) | 1.25 MB |
| slimmed + gzip (on the wire) | **~0.09 MB** |

≈50× smaller on the wire than the original uncompressed response, and the browser parses 1.25 MB instead of 4.6 MB.

## Test plan
- [x] `py_compile` clean on `results.py` / `main.py`
- [x] Slimmed doc still carries every field the page uses (`players`, `moon_shots`, `auto_move_count`, `winner`, `rounds_played`, `game_id`, `stage`, `detail_file`)
- [ ] CI green
- [ ] Manual: load the example tournament page and confirm it's fast and the stats/histograms still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
