### PR TITLE
#100: resource guard — abort runaway runs before they panic the host

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,11 @@ jobs:
         export PYTHONPATH="$(pwd):${PYTHONPATH}"
         python3 tests/tournament_timing_test.py
 
+    - name: Run resource guard test
+      run: |
+        export PYTHONPATH="$(pwd):${PYTHONPATH}"
+        python3 tests/resource_guard_test.py
+
   competition:
     runs-on: macos-latest
 

--- a/competition_runner.py
+++ b/competition_runner.py
@@ -32,6 +32,8 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from resource_guard import ResourceGuard
+
 # ─── Single-instance guard ────────────────────────────────────────────────────
 
 _PIDFILE = Path('competition_runner.pid')
@@ -451,6 +453,22 @@ def run_competition(cfg: dict, real_teams: Dict[str, str],
     competition_id = (f"{now.tm_year}-{now.tm_mon}-{now.tm_mday}_"
                       f"{now.tm_hour:02d}-{now.tm_min:02d}-{now.tm_sec:02d}.{ms:03d}")
     print(f"Competition id: {competition_id} (results under {cfg['results_dir']}/{competition_id}/)")
+
+    # Resource guard (issue #100): a runaway run has watchdog-panicked the host
+    # before. Sample memory pressure + per-child RSS for forensics, and kill the
+    # whole stack if the system enters a sustained swap-thrash spiral.
+    def _resource_abort(reason: str):
+        print(f'\nFATAL: resource guard tripped — {reason}', flush=True)
+        print('Killing the tournament stack to keep the host alive (issue #100).',
+              flush=True)
+        _cleanup()
+        os._exit(2)
+
+    guard = ResourceGuard(
+        Path(cfg['results_dir']) / competition_id / 'resources.log',
+        procs=lambda: list(_child_procs),
+        on_abort=_resource_abort)
+    guard.start()
 
     # Filler teams are computed once with stable passwords so their clients
     # can be started once and loop across all tournament cycles, just like

--- a/resource_guard.py
+++ b/resource_guard.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+resource_guard.py — protect the host from a runaway tournament stack (issue #100).
+
+A competition run (tournament server + filler AI clients) has driven the host
+into swap exhaustion severe enough that macOS watchdog-panicked the kernel
+("no checkins from watchdogd in 94 seconds"). The crash is marginal — the same
+configuration usually completes — so the guard has two jobs:
+
+  1. Forensics: sample system memory pressure, swap usage, and the RSS of every
+     child process every few seconds into <results>/<competition_id>/resources.log,
+     so the next incident identifies the actual memory hog.
+  2. Abort-before-panic: when memory pressure stays critical AND swap usage is
+     past a hard limit, kill the tournament stack instead of letting the OS die.
+
+The abort trigger is deliberately a conjunction: transient critical pressure is
+normal under load (CI runners hit it too), but critical pressure *sustained
+across consecutive samples while gigabytes deep into swap* is the thrash spiral
+that precedes the watchdog panic.
+
+Environment overrides:
+  HEARTS_GUARD=0                    disable entirely
+  HEARTS_GUARD_INTERVAL_S=5         seconds between samples
+  HEARTS_GUARD_SWAP_LIMIT_MB=3072   swap-used threshold for the abort trigger
+  HEARTS_GUARD_CRITICAL_SAMPLES=3   consecutive critical samples required
+"""
+
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+PRESSURE_NORMAL   = 1
+PRESSURE_WARNING  = 2
+PRESSURE_CRITICAL = 4
+
+
+def sample_pressure() -> Optional[int]:
+    """System memory-pressure level: 1 normal, 2 warning, 4 critical.
+
+    macOS exposes this directly; on Linux we approximate from the PSI memory
+    file when present. Returns None when no signal is available (guard then
+    logs '-' and never aborts on pressure).
+    """
+    if sys.platform == 'darwin':
+        try:
+            out = subprocess.run(
+                ['sysctl', '-n', 'kern.memorystatus_vm_pressure_level'],
+                capture_output=True, text=True, timeout=5)
+            return int(out.stdout.strip()) if out.returncode == 0 else None
+        except Exception:
+            return None
+    try:
+        with open('/proc/pressure/memory') as f:
+            m = re.search(r'full avg10=([\d.]+)', f.read())
+        if not m:
+            return None
+        avg10 = float(m.group(1))
+        return (PRESSURE_CRITICAL if avg10 >= 25.0
+                else PRESSURE_WARNING if avg10 >= 5.0 else PRESSURE_NORMAL)
+    except Exception:
+        return None
+
+
+def sample_swap_mb() -> Optional[Tuple[int, int]]:
+    """(used_mb, free_mb) of swap, or None when unavailable."""
+    if sys.platform == 'darwin':
+        try:
+            out = subprocess.run(['sysctl', '-n', 'vm.swapusage'],
+                                 capture_output=True, text=True, timeout=5)
+            m = re.search(r'used = ([\d.]+)M.*free = ([\d.]+)M', out.stdout)
+            return (int(float(m.group(1))), int(float(m.group(2)))) if m else None
+        except Exception:
+            return None
+    try:
+        info = {}
+        with open('/proc/meminfo') as f:
+            for line in f:
+                k, _, v = line.partition(':')
+                info[k] = v
+        total = int(info['SwapTotal'].split()[0]) // 1024
+        free = int(info['SwapFree'].split()[0]) // 1024
+        return (total - free, free)
+    except Exception:
+        return None
+
+
+def sample_rss_mb(pids: List[int]) -> Dict[int, Tuple[int, str]]:
+    """{pid: (rss_mb, command_name)} for the pids that are still alive."""
+    if not pids:
+        return {}
+    try:
+        out = subprocess.run(
+            ['ps', '-o', 'pid=,rss=,comm=', '-p', ','.join(map(str, pids))],
+            capture_output=True, text=True, timeout=5)
+        result = {}
+        for line in out.stdout.splitlines():
+            parts = line.split(None, 2)
+            if len(parts) >= 2:
+                pid, rss_kb = int(parts[0]), int(parts[1])
+                name = os.path.basename(parts[2]) if len(parts) > 2 else '?'
+                result[pid] = (rss_kb // 1024, name)
+        return result
+    except Exception:
+        return {}
+
+
+class ResourceGuard:
+    """Background sampler + abort trigger for a competition run.
+
+    `procs` is called each sample and must return the live child Popen objects
+    (server + filler clients). `on_abort(reason)` is invoked at most once, from
+    the sampler thread, when the abort condition holds; it is expected to kill
+    the stack and not return.
+    """
+
+    def __init__(self, log_path: Path,
+                 procs: Callable[[], List[subprocess.Popen]],
+                 on_abort: Callable[[str], None],
+                 *,
+                 interval_s: Optional[float] = None,
+                 swap_limit_mb: Optional[int] = None,
+                 critical_samples: Optional[int] = None,
+                 pressure_fn: Callable[[], Optional[int]] = sample_pressure,
+                 swap_fn: Callable[[], Optional[Tuple[int, int]]] = sample_swap_mb,
+                 rss_fn: Callable[[List[int]], Dict[int, Tuple[int, str]]] = sample_rss_mb):
+        env = os.environ
+        self.log_path = Path(log_path)
+        self.procs = procs
+        self.on_abort = on_abort
+        self.interval_s = float(env.get('HEARTS_GUARD_INTERVAL_S', '5')) \
+            if interval_s is None else interval_s
+        self.swap_limit_mb = int(env.get('HEARTS_GUARD_SWAP_LIMIT_MB', '3072')) \
+            if swap_limit_mb is None else swap_limit_mb
+        self.critical_samples = int(env.get('HEARTS_GUARD_CRITICAL_SAMPLES', '3')) \
+            if critical_samples is None else critical_samples
+        self.enabled = env.get('HEARTS_GUARD', '1') != '0'
+        self._pressure_fn = pressure_fn
+        self._swap_fn = swap_fn
+        self._rss_fn = rss_fn
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._consecutive_critical = 0
+
+    def start(self):
+        if not self.enabled:
+            print('Resource guard disabled (HEARTS_GUARD=0).')
+            return
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._thread = threading.Thread(target=self._run, daemon=True,
+                                        name='resource-guard')
+        self._thread.start()
+        print(f'Resource guard active: sampling every {self.interval_s:g}s to '
+              f'{self.log_path} (abort: pressure critical x{self.critical_samples} '
+              f'+ swap > {self.swap_limit_mb}MB)')
+
+    def stop(self):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self.interval_s + 2)
+
+    # ── internals ─────────────────────────────────────────────────────────────
+
+    def _sample_once(self) -> Optional[str]:
+        """Take one sample, append it to the log; return an abort reason or None."""
+        pressure = self._pressure_fn()
+        swap = self._swap_fn()
+        pids = [p.pid for p in self.procs() if p.poll() is None]
+        rss = self._rss_fn(pids + [os.getpid()])
+
+        total_mb = sum(mb for mb, _ in rss.values())
+        per_proc = ' '.join(f'{pid}:{name}={mb}M'
+                            for pid, (mb, name) in sorted(rss.items()))
+        swap_used, swap_free = swap if swap else (None, None)
+        line = (f"{time.strftime('%Y-%m-%dT%H:%M:%S')} "
+                f"pressure={pressure if pressure is not None else '-'} "
+                f"swap_used_mb={swap_used if swap_used is not None else '-'} "
+                f"swap_free_mb={swap_free if swap_free is not None else '-'} "
+                f"rss_total_mb={total_mb} | {per_proc}\n")
+        try:
+            with open(self.log_path, 'a') as f:
+                f.write(line)
+        except Exception:
+            pass
+
+        if pressure is not None and pressure >= PRESSURE_CRITICAL:
+            self._consecutive_critical += 1
+        else:
+            self._consecutive_critical = 0
+
+        if (self._consecutive_critical >= self.critical_samples
+                and swap_used is not None and swap_used >= self.swap_limit_mb):
+            return (f'memory pressure critical for {self._consecutive_critical} '
+                    f'consecutive samples with {swap_used}MB of swap in use '
+                    f'(limit {self.swap_limit_mb}MB)')
+        return None
+
+    def _run(self):
+        while not self._stop.is_set():
+            reason = self._sample_once()
+            if reason:
+                try:
+                    with open(self.log_path, 'a') as f:
+                        f.write(f"{time.strftime('%Y-%m-%dT%H:%M:%S')} "
+                                f"ABORT: {reason}\n")
+                except Exception:
+                    pass
+                self.on_abort(reason)
+                return
+            self._stop.wait(self.interval_s)

--- a/tests/resource_guard_test.py
+++ b/tests/resource_guard_test.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Resource guard test — validates the abort trigger and forensic logging of
+resource_guard.py (issue #100) with injected samplers, plus a smoke test of the
+real platform samplers.
+
+Cases:
+  1. Normal pressure          → samples logged, no abort
+  2. Critical + high swap     → abort fires after exactly N consecutive samples
+  3. Critical + low swap      → no abort (conjunction requires both)
+  4. Intermittent critical    → consecutive counter resets, no abort
+  5. HEARTS_GUARD=0           → guard never starts
+  6. Real samplers            → return well-formed values on this platform
+
+Run from repo root:
+    python3 tests/resource_guard_test.py
+
+Exit 0 on pass, 1 on any failure.
+"""
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.getcwd())
+
+from resource_guard import (ResourceGuard, sample_pressure, sample_rss_mb,
+                            sample_swap_mb, PRESSURE_CRITICAL, PRESSURE_NORMAL)
+
+errors = []
+
+
+def check(cond: bool, msg: str):
+    if not cond:
+        errors.append(msg)
+        print(f'  FAIL: {msg}')
+    else:
+        print(f'  ok: {msg}')
+
+
+def make_guard(tmp: Path, pressures, swap, aborts, **kw):
+    """Guard with scripted pressure readings (last value repeats forever)."""
+    seq = list(pressures)
+
+    def pressure_fn():
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    return ResourceGuard(
+        tmp / 'resources.log',
+        procs=lambda: [],
+        on_abort=lambda reason: aborts.append(reason),
+        interval_s=0.01,
+        swap_limit_mb=1000,
+        critical_samples=3,
+        pressure_fn=pressure_fn,
+        swap_fn=lambda: swap,
+        rss_fn=lambda pids: {os.getpid(): (12, 'python3')},
+        **kw)
+
+
+def wait_for(cond_fn, timeout_s=2.0):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if cond_fn():
+            return True
+        time.sleep(0.01)
+    return cond_fn()
+
+
+def main():
+    # 1. Normal pressure: logging works, no abort.
+    print('Case 1: normal pressure')
+    with tempfile.TemporaryDirectory() as d:
+        tmp, aborts = Path(d), []
+        g = make_guard(tmp, [PRESSURE_NORMAL], (2000, 500), aborts)
+        g.start()
+        wait_for(lambda: (tmp / 'resources.log').exists()
+                 and len((tmp / 'resources.log').read_text().splitlines()) >= 3)
+        g.stop()
+        check(not aborts, 'no abort under normal pressure')
+        lines = (tmp / 'resources.log').read_text().splitlines()
+        check(len(lines) >= 3, f'samples logged ({len(lines)} lines)')
+        check('pressure=1' in lines[0] and 'swap_used_mb=2000' in lines[0]
+              and 'rss_total_mb=12' in lines[0],
+              f'log line carries pressure/swap/rss: {lines[0]}')
+
+    # 2. Sustained critical pressure + swap above limit: aborts after 3 samples.
+    print('Case 2: critical pressure + high swap')
+    with tempfile.TemporaryDirectory() as d:
+        tmp, aborts = Path(d), []
+        g = make_guard(tmp, [PRESSURE_CRITICAL], (2000, 100), aborts)
+        g.start()
+        check(wait_for(lambda: aborts), 'abort fired')
+        g.stop()
+        check(len(aborts) == 1, 'abort fired exactly once')
+        content = (tmp / 'resources.log').read_text()
+        check('ABORT:' in content, 'abort reason recorded in log')
+        sample_lines = [l for l in content.splitlines() if 'ABORT' not in l]
+        check(len(sample_lines) == 3,
+              f'abort after exactly 3 consecutive samples (got {len(sample_lines)})')
+
+    # 3. Critical pressure but swap under the limit: never aborts.
+    print('Case 3: critical pressure + low swap')
+    with tempfile.TemporaryDirectory() as d:
+        tmp, aborts = Path(d), []
+        g = make_guard(tmp, [PRESSURE_CRITICAL], (500, 1500), aborts)
+        g.start()
+        wait_for(lambda: (tmp / 'resources.log').exists()
+                 and len((tmp / 'resources.log').read_text().splitlines()) >= 5)
+        g.stop()
+        check(not aborts, 'no abort when swap is below the limit')
+
+    # 4. Critical pressure that clears: the consecutive counter resets.
+    print('Case 4: intermittent critical pressure')
+    with tempfile.TemporaryDirectory() as d:
+        tmp, aborts = Path(d), []
+        pressures = [PRESSURE_CRITICAL, PRESSURE_CRITICAL, PRESSURE_NORMAL,
+                     PRESSURE_CRITICAL, PRESSURE_CRITICAL, PRESSURE_NORMAL]
+        g = make_guard(tmp, pressures, (2000, 100), aborts)
+        g.start()
+        wait_for(lambda: (tmp / 'resources.log').exists()
+                 and len((tmp / 'resources.log').read_text().splitlines()) >= 7)
+        g.stop()
+        check(not aborts, 'no abort when critical streaks stay under the threshold')
+
+    # 5. HEARTS_GUARD=0 disables the guard.
+    print('Case 5: disabled via env')
+    with tempfile.TemporaryDirectory() as d:
+        tmp, aborts = Path(d), []
+        os.environ['HEARTS_GUARD'] = '0'
+        try:
+            g = make_guard(tmp, [PRESSURE_CRITICAL], (2000, 100), aborts)
+            g.start()
+            time.sleep(0.1)
+            g.stop()
+        finally:
+            del os.environ['HEARTS_GUARD']
+        check(not (tmp / 'resources.log').exists(), 'disabled guard writes nothing')
+        check(not aborts, 'disabled guard never aborts')
+
+    # 6. Real samplers return well-formed values on this platform.
+    print('Case 6: real sampler smoke test')
+    p = sample_pressure()
+    check(p is None or p in (1, 2, 4), f'pressure level well-formed ({p})')
+    s = sample_swap_mb()
+    check(s is None or (len(s) == 2 and all(v >= 0 for v in s)),
+          f'swap sample well-formed ({s})')
+    r = sample_rss_mb([os.getpid()])
+    check(os.getpid() in r and r[os.getpid()][0] > 0,
+          f'own RSS sampled ({r.get(os.getpid())})')
+
+    if errors:
+        print(f'\nFAIL ({len(errors)} error(s))')
+        sys.exit(1)
+    print('\nPASS')
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #100.

## Diagnosis (confirmed)
The Jun 9 crash was a **kernel watchdog panic** — `watchdogd` starved for 94s under severe memory pressure (`LOW swap space`, 3 swapfiles, high `kernel_task` CPU = page-out storm). The panicked task (`StatusKitAgent`) is incidental. It correlates tightly with a competition run on this 8 GB M2:

| time (Jun 9) | event |
|---|---|
| 18:45:29 | competition `2026-6-9_18-45-29.251` starts (600Q + 500F, 6 teams) |
| 18:46–18:47 | 298/600 qualifying games complete at normal throughput |
| 18:47 | last game JSON written — progress stops (thrash begins) |
| 18:50:28 | watchdog panic |

`last reboot` shows unclean reboots on **May 13, Jun 2, and Jun 10** — at least the third occurrence. The same config completed fine on Jun 5, so the failure is marginal (depends on the host's memory headroom at launch), and no per-process memory data exists from the crash window to name the culprit.

## Fix
New `resource_guard.py`, started by `competition_runner.py` for every competition:

1. **Forensics** — every 5s, log memory-pressure level, swap usage, and the RSS of each child (server + every filler client) to `<results>/<competition_id>/resources.log`. If this ever recurs, the log names the memory hog and that becomes a targeted fix.
2. **Abort-before-panic** — when pressure is **critical for 3 consecutive samples AND swap used > 3 GB**, kill the tournament stack and exit 2 instead of letting macOS watchdog-panic. The conjunction prevents false triggers from transient pressure spikes (normal under load; CI runners sit at warning routinely — this very dev machine idles at level 2).

Tunables: `HEARTS_GUARD=0` (disable), `HEARTS_GUARD_INTERVAL_S`, `HEARTS_GUARD_SWAP_LIMIT_MB`, `HEARTS_GUARD_CRITICAL_SAMPLES`. Works on macOS (sysctl) with a Linux fallback (PSI + /proc/meminfo); degrades to log-only when no pressure signal exists.

## Verification
- `tests/resource_guard_test.py` (added to the integration workflow): trigger fires after exactly N sustained-critical samples with high swap; no trigger on low swap, intermittent criticals, or `HEARTS_GUARD=0`; real samplers return well-formed values.
- End-to-end smoke run (4 filler teams, full qualifying + finals cycle): guard sampled all 6 processes alongside a completing tournament with zero interference:
```
2026-06-10T14:05:51 pressure=2 swap_used_mb=306 swap_free_mb=717 rss_total_mb=141 | 15552:Python=14M 16327:Python=30M 16328:Python=29M 16330:Python=29M 16331:Python=29M 16333:tournament_server=10M
```

## Test plan
- [x] Unit test: abort trigger logic (sustained/intermittent/conjunction/disable)
- [x] Smoke: real competition cycle completes with guard active, resources.log written
- [ ] CI green (including the existing competition job, which now runs with the guard on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
