### PR TITLE
Fix server abort on duplicate pass cards from a client

### DIFF
--- a/server/game/remote_player.h
+++ b/server/game/remote_player.h
@@ -60,6 +60,18 @@ public:
                                     mPlayerTagSession.c_str(), cards[i].getAbbreviation().c_str());
                                 valid = false;
                             }
+                            // Reject duplicate cards: passing the same card twice would
+                            // otherwise abort the server when the round subtracts it from
+                            // the hand twice (card_collection.h operator-).
+                            for (int j = 0; j < i && valid; ++j)
+                            {
+                                if (cards[i] == cards[j])
+                                {
+                                    LOG("Client %s tried to pass duplicate card: %s",
+                                        mPlayerTagSession.c_str(), cards[i].getAbbreviation().c_str());
+                                    valid = false;
+                                }
+                            }
                         }
                         if (valid)
                             return cards;

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -15,12 +15,33 @@ import os
 if len(sys.argv) < 2:
     sys.argv.append("./local.config.env")
 
+from typing import List
+
 from clients.python.api.networking.ManagedConnection import ManagedConnection
 from clients.python.api.networking.SessionHelpers import RunGame, RunMultipleGames
 from clients.python.api.Player import Player
 from clients.python.players.random_player import RandomPlayer
+from clients.python.api.types.Card import Card
+from clients.python.api.types.PassDirection import PassDirection
+from clients.python.api.types.PlayerTagSession import PlayerTagSession
 from clients.python.util.Constants import GameType
 from clients.python.util.Env import SERVER_IP, SERVER_PORT
+
+
+class DuplicatePassPlayer(RandomPlayer):
+    """Misbehaving client: passes the same card three times.
+
+    A duplicate-card pass once aborted the server — it accepted the cards (each
+    is genuinely in hand) and then crashed subtracting the same card from the
+    hand twice (card_collection.h operator-). The server must instead reject the
+    pass and auto-pass, so the game still completes. Defined here (not under
+    players/) so it is excluded from smoke discovery.
+    """
+    player_tag = "duplicate_pass_player"
+
+    def get_cards_to_pass(self, pass_dir: PassDirection, receiving_player: PlayerTagSession) -> List[Card]:
+        card = self.hand[0]
+        return [card, card, card]
 
 # Players excluded from automated smoke testing
 _SKIP_PLAYER_FILES = {
@@ -103,6 +124,20 @@ def test_each_player():
             check_game(game, f"smoke-{player_cls.player_tag}")
 
 
+def test_malicious_duplicate_pass():
+    """Regression: a client passing duplicate cards must not crash the server.
+
+    Before the fix the server aborted on the duplicate-card subtraction; the
+    game would never complete. A completed game (winner declared) proves the
+    server stayed up and auto-passed for the misbehaving client.
+    """
+    print("Test 4: Malicious client passes duplicate cards (server must survive)")
+    roster = [DuplicatePassPlayer, RandomPlayer, RandomPlayer, RandomPlayer]
+    with ManagedConnection(timeout_s=TIMEOUT_S) as conn:
+        game = RunGame(conn, GameType.ANY, roster, timeout_s=TIMEOUT_S)
+    check_game(game, "malicious-duplicate-pass")
+
+
 if __name__ == "__main__":
     print("Hearts Engine Integration Tests")
     print("================================")
@@ -112,6 +147,7 @@ if __name__ == "__main__":
     test_single_game()
     test_two_concurrent_games()
     test_each_player()
+    test_malicious_duplicate_pass()
 
     print("\nAll integration tests PASSED")
     sys.exit(0)


### PR DESCRIPTION
## Problem

A client that passes the same card three times (e.g. `["AC","AC","AC"]`) crashed the lobby server:

```
[ASSERT_FAIL]: Tried to remove nonexistent card AC from deck (size 13)
Assertion failed: (itr != cards.end()), function operator-, file card_collection.h, line 162.
```

`RemotePlayer::getCardsToPass` validated that each pass card was in the player's hand but never checked the three were **distinct**, and the `vector<string>` `CardCollection` constructor used to parse client input skips `verifyUnique()`. The duplicate reached `Round::passCards`, which aborts in `CardCollection::operator-` when it removes the same card from the hand twice — taking down the whole process. Any client can trigger this.

## Fix

Reject duplicate pass cards in `getCardsToPass` so the server falls back to `autoPassCards()` — the same graceful path already used for any other invalid pass input.

## Testing

- Reproduced the crash against a live server, confirmed the fix keeps the server up (duplicate passes now log `tried to pass duplicate card` then `Auto-passed`).
- Added a regression test in `tests/integration_test.py`: a client passing duplicate cards, asserting the game still completes. Runs in the existing `integration` CI job.
- `bazel test //tests:all` passes (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
