### PR TITLE
#106: wide tables scroll within their card at every width

### DIFF
--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -31,6 +31,10 @@ h2 {
   border-radius: 10px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   padding: 16px;
+  /* Wide tables (game lists, per-round breakdowns) scroll sideways within the
+     card at every width instead of spilling past its rounded edge and getting
+     clipped by the page. Matches the mobile behavior, now applied globally. */
+  overflow-x: auto;
 }
 
 table.data {
@@ -432,8 +436,7 @@ button.btn.btn--active:hover {
 
   .card-surface {
     padding: 12px;
-    /* Let wide tables scroll sideways instead of breaking the layout. */
-    overflow-x: auto;
+    /* overflow-x: auto is now on the base rule (applies at every width). */
   }
 
   table.data {


### PR DESCRIPTION
Closes #106.

## Problem
The games-list and per-round breakdown tables can be wider than their `.card-surface` container. The card was `overflow-x: visible`, so the table spilled past the card's rounded right edge and was then clipped by the page wrapper (`App.css` `overflow-x: clip`). The result was the visual bug in the issue: stray borders past the card edge and a `Rounds` column you couldn't reach.

## Fix
Promote the **mobile-only** `overflow-x: auto` on `.card-surface` to the **base** rule so it applies at every width. Wide tables now scroll horizontally inside the card — a clean clip at the rounded edge — instead of overflowing the layout. This matches the behavior the issue references ("like in mobile"). It's a 5-line CSS change; the redundant mobile override is removed.

Narrow content is unaffected: `overflow-x: auto` only shows a scrollbar when content actually overflows.

## Verification (in-browser)
- **1280px** — games table scrolls within its card to reveal the `4th`/`Rounds` columns; the page itself has no horizontal scroll; card right edge clips cleanly.
- **420px** — per-round game table scrolls horizontally within its card (matches the mobile screenshot in the issue).
- Checked every `.card-surface` on both pages: none gained an unwanted vertical scrollbar from the `overflow-y` → `auto` side effect (no card has vertically-overflowing absolute content).
- `npm run build` clean.

| before | after |
|---|---|
| table spills past card, `Rounds` clipped | table scrolls inside card, clean edge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
